### PR TITLE
feat: add property descriptions to OAI

### DIFF
--- a/spec/json/twilio_accounts_v1.json
+++ b/spec/json/twilio_accounts_v1.json
@@ -4,19 +4,35 @@
       "accounts.v1.auth_token_promotion": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that the secondary Auth Token was created for",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "auth_token": {
-            "$ref": "#/components/schemas/string"
+            "description": "The promoted Auth Token",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 formatted date and time in UTC when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 formatted date and time in UTC when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URI for this resource, relative to `https://accounts.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -28,22 +44,43 @@
       "accounts.v1.credential.credential_aws": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URI for this resource, relative to `https://accounts.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -51,22 +88,43 @@
       "accounts.v1.credential.credential_public_key": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Credential that the PublicKey resource belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URI for this resource, relative to `https://accounts.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -74,50 +132,38 @@
       "accounts.v1.secondary_auth_token": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that the secondary Auth Token was created for",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 formatted date and time in UTC when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 formatted date and time in UTC when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "secondary_auth_token": {
-            "$ref": "#/components/schemas/string"
+            "description": "The generated secondary Auth Token",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URI for this resource, relative to `https://accounts.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_api_v2010.json
+++ b/spec/json/twilio_api_v2010.json
@@ -1,54 +1,75 @@
 {
   "components": {
     "schemas": {
-      "account_status": {
-        "enum": [
-          "active",
-          "suspended",
-          "closed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "account_type": {
-        "enum": [
-          "Trial",
-          "Full"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "api.v2010.account": {
         "properties": {
           "auth_token": {
-            "$ref": "#/components/schemas/string"
+            "description": "The authorization token for this account",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this account was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this account was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human readable description of this account",
+            "nullable": true,
+            "type": "string"
           },
           "owner_account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique 34 character id representing the parent of this account",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/account_status"
+            "description": "The status of this account",
+            "enum": [
+              "active",
+              "suspended",
+              "closed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Account Instance Subresources",
+            "nullable": true,
+            "type": "object"
           },
           "type": {
-            "$ref": "#/components/schemas/account_type"
+            "description": "The type of this account",
+            "enum": [
+              "Trial",
+              "Full"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI for this resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -56,49 +77,88 @@
       "api.v2010.account.address": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that is responsible for the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "city": {
-            "$ref": "#/components/schemas/string"
+            "description": "The city in which the address is located",
+            "nullable": true,
+            "type": "string"
           },
           "customer_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name associated with the address",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "emergency_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether emergency calling has been enabled on this number",
+            "nullable": true,
+            "type": "boolean"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code of the address",
+            "nullable": true,
+            "type": "string"
           },
           "postal_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The postal code of the address",
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The state or region of the address",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "street": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number and street address of the address",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "validated": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the address has been validated to comply with local regulation",
+            "nullable": true,
+            "type": "boolean"
           },
           "verified": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the address has been verified to comply with regulation",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -106,82 +166,210 @@
       "api.v2010.account.address.dependent_phone_number": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "address_requirements": {
-            "$ref": "#/components/schemas/dependent_phone_number_address_requirement"
+            "description": "Whether the phone number requires an Address registered with Twilio",
+            "enum": [
+              "none",
+              "any",
+              "local",
+              "foreign"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to start a new TwiML session",
+            "nullable": true,
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/object"
+            "description": "Indicate if a phone can receive calls or messages",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "emergency_address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The emergency address configuration to use for emergency calling",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "emergency_status": {
-            "$ref": "#/components/schemas/dependent_phone_number_emergency_status"
+            "description": "Whether the phone number is enabled for emergency calling",
+            "enum": [
+              "Active",
+              "Inactive"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles SMS messages sent to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when an error occurs while retrieving or executing the TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with sms_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives an incoming SMS message",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "voice_caller_id_lookup": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to lookup the caller's name",
+            "nullable": true,
+            "type": "boolean"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs in TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with the voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -189,64 +377,160 @@
       "api.v2010.account.application": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to start a new TwiML session",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "message_status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send message status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when an error occurs while retrieving or executing the TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with sms_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives an incoming SMS message",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_caller_id_lookup": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to lookup the caller's name",
+            "nullable": true,
+            "type": "boolean"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when a TwiML error occurs",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with the voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -254,34 +538,71 @@
       "api.v2010.account.authorized_connect_app": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "connect_app_company_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The company name set for the Connect App",
+            "nullable": true,
+            "type": "string"
           },
           "connect_app_description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A detailed description of the app",
+            "nullable": true,
+            "type": "string"
           },
           "connect_app_friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the Connect App",
+            "nullable": true,
+            "type": "string"
           },
           "connect_app_homepage_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The public URL for the Connect App",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "connect_app_sid": {
-            "$ref": "#/components/schemas/sid_CN"
+            "description": "The SID that we assigned to the Connect App",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "permissions": {
-            "$ref": "#/components/schemas/authorized_connect_app_permission_list"
+            "description": "Permissions authorized to the app",
+            "items": {
+              "enum": [
+                "get-all",
+                "post-all"
+              ],
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -289,19 +610,30 @@
       "api.v2010.account.available_phone_number_country": {
         "properties": {
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether all phone numbers available in the country are new to the Twilio platform.",
+            "nullable": true,
+            "type": "boolean"
           },
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "country_code": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO-3166-1 country code of the country.",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URI of the Country resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -309,43 +641,83 @@
       "api.v2010.account.available_phone_number_country.available_phone_number_local": {
         "properties": {
           "address_requirements": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of Address resource the phone number requires",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Whether a phone number can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "A formatted version of the phone number",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "lata": {
-            "$ref": "#/components/schemas/string"
+            "description": "The LATA of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "latitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The latitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "locality": {
-            "$ref": "#/components/schemas/string"
+            "description": "The locality or city of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "longitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The longitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "postal_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The postal or ZIP code of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "rate_center": {
-            "$ref": "#/components/schemas/string"
+            "description": "The rate center of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The two-letter state or province abbreviation of this phone number's location",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -353,43 +725,83 @@
       "api.v2010.account.available_phone_number_country.available_phone_number_machine_to_machine": {
         "properties": {
           "address_requirements": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of Address resource the phone number requires",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Whether a phone number can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "A formatted version of the phone number",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "lata": {
-            "$ref": "#/components/schemas/string"
+            "description": "The LATA of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "latitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The latitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "locality": {
-            "$ref": "#/components/schemas/string"
+            "description": "The locality or city of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "longitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The longitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "postal_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The postal or ZIP code of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "rate_center": {
-            "$ref": "#/components/schemas/string"
+            "description": "The rate center of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The two-letter state or province abbreviation of this phone number's location",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -397,43 +809,83 @@
       "api.v2010.account.available_phone_number_country.available_phone_number_mobile": {
         "properties": {
           "address_requirements": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of Address resource the phone number requires",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Whether a phone number can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "A formatted version of the phone number",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "lata": {
-            "$ref": "#/components/schemas/string"
+            "description": "The LATA of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "latitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The latitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "locality": {
-            "$ref": "#/components/schemas/string"
+            "description": "The locality or city of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "longitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The longitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "postal_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The postal or ZIP code of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "rate_center": {
-            "$ref": "#/components/schemas/string"
+            "description": "The rate center of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The two-letter state or province abbreviation of this phone number's location",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -441,43 +893,83 @@
       "api.v2010.account.available_phone_number_country.available_phone_number_national": {
         "properties": {
           "address_requirements": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of Address resource the phone number requires",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Whether a phone number can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "A formatted version of the phone number",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "lata": {
-            "$ref": "#/components/schemas/string"
+            "description": "The LATA of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "latitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The latitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "locality": {
-            "$ref": "#/components/schemas/string"
+            "description": "The locality or city of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "longitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The longitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "postal_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The postal or ZIP code of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "rate_center": {
-            "$ref": "#/components/schemas/string"
+            "description": "The rate center of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The two-letter state or province abbreviation of this phone number's location",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -485,43 +977,83 @@
       "api.v2010.account.available_phone_number_country.available_phone_number_shared_cost": {
         "properties": {
           "address_requirements": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of Address resource the phone number requires",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Whether a phone number can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "A formatted version of the phone number",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "lata": {
-            "$ref": "#/components/schemas/string"
+            "description": "The LATA of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "latitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The latitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "locality": {
-            "$ref": "#/components/schemas/string"
+            "description": "The locality or city of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "longitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The longitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "postal_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The postal or ZIP code of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "rate_center": {
-            "$ref": "#/components/schemas/string"
+            "description": "The rate center of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The two-letter state or province abbreviation of this phone number's location",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -529,43 +1061,83 @@
       "api.v2010.account.available_phone_number_country.available_phone_number_toll_free": {
         "properties": {
           "address_requirements": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of Address resource the phone number requires",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Whether a phone number can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "A formatted version of the phone number",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "lata": {
-            "$ref": "#/components/schemas/string"
+            "description": "The LATA of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "latitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The latitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "locality": {
-            "$ref": "#/components/schemas/string"
+            "description": "The locality or city of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "longitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The longitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "postal_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The postal or ZIP code of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "rate_center": {
-            "$ref": "#/components/schemas/string"
+            "description": "The rate center of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The two-letter state or province abbreviation of this phone number's location",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -573,43 +1145,83 @@
       "api.v2010.account.available_phone_number_country.available_phone_number_voip": {
         "properties": {
           "address_requirements": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of Address resource the phone number requires",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Whether a phone number can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "A formatted version of the phone number",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "lata": {
-            "$ref": "#/components/schemas/string"
+            "description": "The LATA of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "latitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The latitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "locality": {
-            "$ref": "#/components/schemas/string"
+            "description": "The locality or city of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "longitude": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The longitude of this phone number's location",
+            "nullable": true,
+            "type": "number"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "postal_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The postal or ZIP code of this phone number's location",
+            "nullable": true,
+            "type": "string"
           },
           "rate_center": {
-            "$ref": "#/components/schemas/string"
+            "description": "The rate center of this phone number",
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The two-letter state or province abbreviation of this phone number's location",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -617,13 +1229,22 @@
       "api.v2010.account.balance": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "Account Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "balance": {
-            "$ref": "#/components/schemas/string"
+            "description": "Account balance",
+            "nullable": true,
+            "type": "string"
           },
           "currency": {
-            "$ref": "#/components/schemas/string"
+            "description": "Currency units",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -631,85 +1252,172 @@
       "api.v2010.account.call": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "annotation": {
-            "$ref": "#/components/schemas/string"
+            "description": "The annotation provided for the call",
+            "nullable": true,
+            "type": "string"
           },
           "answered_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "Either `human` or `machine` if this call was initiated with answering machine detection. Empty otherwise.",
+            "nullable": true,
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API Version used to create the call",
+            "nullable": true,
+            "type": "string"
           },
           "caller_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The caller's name if this call was an incoming call to a phone number with caller ID Lookup enabled. Otherwise, empty.",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "direction": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string describing the direction of the call. `inbound` for inbound calls, `outbound-api` for calls initiated via the REST API or `outbound-dial` for calls initiated by a `Dial` verb.",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/string"
+            "description": "The length of the call in seconds.",
+            "nullable": true,
+            "type": "string"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The end time of the call. Null if the call did not complete successfully.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "forwarded_from": {
-            "$ref": "#/components/schemas/string"
+            "description": "The forwarding phone number if this call was an incoming call forwarded from another number (depends on carrier supporting forwarding). Otherwise, empty.",
+            "nullable": true,
+            "type": "string"
           },
           "from": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number, SIP address or Client identifier that made this call. Phone numbers are in E.164 format (e.g., +16175551212). SIP addresses are formatted as `name@company.com`. Client identifiers are formatted `client:name`.",
+            "nullable": true,
+            "type": "string"
           },
           "from_formatted": {
-            "$ref": "#/components/schemas/string"
+            "description": "The calling phone number, SIP address, or Client identifier formatted for display.",
+            "nullable": true,
+            "type": "string"
           },
           "group_sid": {
-            "$ref": "#/components/schemas/sid_GP"
+            "description": "The Group SID associated with this call. If no Group is associated with the call, the field is empty.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^GP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "parent_call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID that identifies the call that created this leg.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "phone_number_sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "If the call was inbound, this is the SID of the IncomingPhoneNumber resource that received the call. If the call was outbound, it is the SID of the OutgoingCallerId resource from which the call was placed.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/string"
+            "description": "The charge for this call, in the currency associated with the account. Populated after the call is completed. May not be immediately available.",
+            "nullable": true,
+            "type": "string"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `Price` is measured.",
+            "nullable": true,
+            "type": "string"
           },
           "queue_time": {
-            "$ref": "#/components/schemas/string"
+            "description": "The wait time in milliseconds before the call is placed.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The unique string that identifies this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The start time of the call. Null if the call has not yet been dialed.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/call_status"
+            "description": "The status of this call.",
+            "enum": [
+              "queued",
+              "ringing",
+              "in-progress",
+              "completed",
+              "busy",
+              "failed",
+              "no-answer",
+              "canceled"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related subresources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "to": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number, SIP address or Client identifier that received this call. Phone numbers are in E.164 format (e.g., +16175551212). SIP addresses are formatted as `name@company.com`. Client identifiers are formatted `client:name`.",
+            "nullable": true,
+            "type": "string"
           },
           "to_formatted": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number, SIP address or Client identifier that received this call. Formatted for display.",
+            "nullable": true,
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The (optional) unique identifier of the trunk resource that was used for this call.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of this resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -717,10 +1425,14 @@
       "api.v2010.account.call.call_event": {
         "properties": {
           "request": {
-            "$ref": "#/components/schemas/object"
+            "description": "Call Request.",
+            "nullable": true,
+            "type": "object"
           },
           "response": {
-            "$ref": "#/components/schemas/object"
+            "description": "Call Response with Events.",
+            "nullable": true,
+            "type": "object"
           }
         },
         "type": "object"
@@ -728,22 +1440,55 @@
       "api.v2010.account.call.call_feedback": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique sid that identifies this account",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "issues": {
-            "$ref": "#/components/schemas/call_feedback_issues_list"
+            "description": "Issues experienced during the call",
+            "items": {
+              "enum": [
+                "audio-latency",
+                "digits-not-captured",
+                "dropped-call",
+                "imperfect-audio",
+                "incorrect-caller-id",
+                "one-way-audio",
+                "post-dial-delay",
+                "unsolicited-call"
+              ],
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "quality_score": {
-            "$ref": "#/components/schemas/integer"
+            "description": "1 to 5 quality score",
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "A string that uniquely identifies this feedback resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -751,46 +1496,104 @@
       "api.v2010.account.call.call_feedback_summary": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique sid that identifies this account",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "call_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of calls",
+            "nullable": true,
+            "type": "integer"
           },
           "call_feedback_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of calls with a feedback entry",
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The latest feedback entry date in the summary",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "include_subaccounts": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the feedback summary includes subaccounts",
+            "nullable": true,
+            "type": "boolean"
           },
           "issues": {
-            "$ref": "#/components/schemas/feedback_issue_list"
+            "description": "Issues experienced during the call",
+            "items": {
+              "properties": {
+                "count": {
+                  "type": "number"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "percentage_of_total_calls": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "quality_score_average": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The average QualityScore of the feedback entries",
+            "nullable": true,
+            "type": "number"
           },
           "quality_score_median": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The median QualityScore of the feedback entries",
+            "nullable": true,
+            "type": "number"
           },
           "quality_score_standard_deviation": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The standard deviation of the quality scores",
+            "nullable": true,
+            "type": "number"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FS"
+            "description": "A string that uniquely identifies this feedback entry",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The earliest feedback entry date in the summary",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/call_feedback_summary_status"
+            "description": "The status of the feedback summary",
+            "enum": [
+              "queued",
+              "in-progress",
+              "completed",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -798,46 +1601,97 @@
       "api.v2010.account.call.call_notification": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the Call Notification resource",
+            "nullable": true,
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "A unique error code corresponding to the notification",
+            "nullable": true,
+            "type": "string"
           },
           "log": {
-            "$ref": "#/components/schemas/string"
+            "description": "An integer log level",
+            "nullable": true,
+            "type": "string"
           },
           "message_date": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date the notification was generated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "message_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text of the notification",
+            "nullable": true,
+            "type": "string"
           },
           "more_info": {
-            "$ref": "#/components/schemas/url"
+            "description": "A URL for more information about the error code",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "request_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "HTTP method used with the request url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "request_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "URL of the resource that generated the notification",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -845,55 +1699,112 @@
       "api.v2010.account.call.call_notification-instance": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the Call Notification resource",
+            "nullable": true,
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "A unique error code corresponding to the notification",
+            "nullable": true,
+            "type": "string"
           },
           "log": {
-            "$ref": "#/components/schemas/string"
+            "description": "An integer log level",
+            "nullable": true,
+            "type": "string"
           },
           "message_date": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date the notification was generated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "message_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text of the notification",
+            "nullable": true,
+            "type": "string"
           },
           "more_info": {
-            "$ref": "#/components/schemas/url"
+            "description": "A URL for more information about the error code",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "request_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "HTTP method used with the request url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "request_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "URL of the resource that generated the notification",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "request_variables": {
-            "$ref": "#/components/schemas/string"
+            "description": "Twilio-generated HTTP variables sent to the server",
+            "nullable": true,
+            "type": "string"
           },
           "response_body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The HTTP body returned by your server",
+            "nullable": true,
+            "type": "string"
           },
           "response_headers": {
-            "$ref": "#/components/schemas/string"
+            "description": "The HTTP headers returned by your server",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -901,58 +1812,127 @@
       "api.v2010.account.call.call_recording": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to make the recording",
+            "nullable": true,
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channels": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of channels in the final recording file",
+            "nullable": true,
+            "type": "integer"
           },
           "conference_sid": {
-            "$ref": "#/components/schemas/sid_CF"
+            "description": "The Conference SID that identifies the conference associated with the recording",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/string"
+            "description": "The length of the recording in seconds",
+            "nullable": true,
+            "type": "string"
           },
           "encryption_details": {
-            "$ref": "#/components/schemas/object"
+            "description": "How to decrypt the recording.",
+            "nullable": true,
+            "type": "object"
           },
           "error_code": {
-            "$ref": "#/components/schemas/integer"
+            "description": "More information about why the recording is missing, if status is `absent`.",
+            "nullable": true,
+            "type": "integer"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The one-time cost of creating the recording.",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency used in the price property.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "source": {
-            "$ref": "#/components/schemas/call_recording_source"
+            "description": "How the recording was created",
+            "enum": [
+              "DialVerb",
+              "Conference",
+              "OutboundAPI",
+              "Trunking",
+              "RecordVerb",
+              "StartCallRecordingAPI",
+              "StartConferenceRecordingAPI"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The start time of the recording, given in RFC 2822 format",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/call_recording_status"
+            "description": "The status of the recording",
+            "enum": [
+              "in-progress",
+              "paused",
+              "stopped",
+              "processing",
+              "completed",
+              "absent"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "track": {
-            "$ref": "#/components/schemas/string"
+            "description": "The recorded track. Can be: `inbound`, `outbound`, or `both`.",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -960,22 +1940,46 @@
       "api.v2010.account.call.payments": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Payments resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PK"
+            "description": "The SID of the Payments resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -983,40 +1987,88 @@
       "api.v2010.account.conference": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create this conference",
+            "nullable": true,
+            "type": "string"
           },
           "call_sid_ending_conference": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The call SID that caused the conference to end",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string that you assigned to describe this conference room",
+            "nullable": true,
+            "type": "string"
           },
           "reason_conference_ended": {
-            "$ref": "#/components/schemas/conference_reason_conference_ended"
+            "description": "The reason why a conference ended.",
+            "enum": [
+              "conference-ended-via-api",
+              "participant-with-end-conference-on-exit-left",
+              "participant-with-end-conference-on-exit-kicked",
+              "last-participant-kicked",
+              "last-participant-left"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "region": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string that represents the Twilio Region where the conference was mixed",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CF"
+            "description": "The unique string that identifies this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/conference_status"
+            "description": "The status of this conference",
+            "enum": [
+              "init",
+              "in-progress",
+              "completed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of this resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1024,55 +2076,122 @@
       "api.v2010.account.conference.conference_recording": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the recording",
+            "nullable": true,
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channels": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of channels in the final recording file as an integer",
+            "nullable": true,
+            "type": "integer"
           },
           "conference_sid": {
-            "$ref": "#/components/schemas/sid_CF"
+            "description": "The Conference SID that identifies the conference associated with the recording",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/string"
+            "description": "The length of the recording in seconds",
+            "nullable": true,
+            "type": "string"
           },
           "encryption_details": {
-            "$ref": "#/components/schemas/object"
+            "description": "How to decrypt the recording.",
+            "nullable": true,
+            "type": "object"
           },
           "error_code": {
-            "$ref": "#/components/schemas/integer"
+            "description": "More information about why the recording is missing, if status is `absent`.",
+            "nullable": true,
+            "type": "integer"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The one-time cost of creating the recording.",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency used in the price property.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "source": {
-            "$ref": "#/components/schemas/conference_recording_source"
+            "description": "How the recording was created",
+            "enum": [
+              "DialVerb",
+              "Conference",
+              "OutboundAPI",
+              "Trunking",
+              "RecordVerb",
+              "StartCallRecordingAPI",
+              "StartConferenceRecordingAPI"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The start time of the recording, given in RFC 2822 format",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/conference_recording_status"
+            "description": "The status of the recording",
+            "enum": [
+              "in-progress",
+              "paused",
+              "stopped",
+              "processing",
+              "completed",
+              "absent"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1080,46 +2199,97 @@
       "api.v2010.account.conference.participant": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "call_sid_to_coach": {
-            "$ref": "#/components/schemas/sid_CF"
+            "description": "The SID of the participant who is being `coached`",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "coaching": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Indicates if the participant changed to coach",
+            "nullable": true,
+            "type": "boolean"
           },
           "conference_sid": {
-            "$ref": "#/components/schemas/sid_CF"
+            "description": "The SID of the conference the participant is in",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "end_conference_on_exit": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the conference ends when the participant leaves",
+            "nullable": true,
+            "type": "boolean"
           },
           "hold": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the participant is on hold",
+            "nullable": true,
+            "type": "boolean"
           },
           "label": {
-            "$ref": "#/components/schemas/string"
+            "description": "The label of this participant",
+            "nullable": true,
+            "type": "string"
           },
           "muted": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the participant is muted",
+            "nullable": true,
+            "type": "boolean"
           },
           "start_conference_on_enter": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the conference starts when the participant joins the conference",
+            "nullable": true,
+            "type": "boolean"
           },
           "status": {
-            "$ref": "#/components/schemas/participant_status"
+            "description": "The status of the participant's call in a session",
+            "enum": [
+              "queued",
+              "connecting",
+              "ringing",
+              "connected",
+              "complete",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1127,37 +2297,84 @@
       "api.v2010.account.connect_app": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "authorize_redirect_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to redirect the user to after authorization",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "company_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The company name set for the Connect App",
+            "nullable": true,
+            "type": "string"
           },
           "deauthorize_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call deauthorize_callback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "deauthorize_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call to de-authorize the Connect App",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "The description of the Connect App",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "homepage_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL users can obtain more information",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "permissions": {
-            "$ref": "#/components/schemas/connect_app_permission_list"
+            "description": "The set of permissions that your ConnectApp requests",
+            "items": {
+              "enum": [
+                "get-all",
+                "post-all"
+              ],
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1165,103 +2382,270 @@
       "api.v2010.account.incoming_phone_number": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "address_requirements": {
-            "$ref": "#/components/schemas/incoming_phone_number_address_requirement"
+            "description": "Whether the phone number requires an Address registered with Twilio.",
+            "enum": [
+              "none",
+              "any",
+              "local",
+              "foreign"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The SID of the Address resource associated with the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to start a new TwiML session",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "bundle_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The SID of the Bundle resource associated with number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Indicate if a phone can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "emergency_address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The emergency address configuration to use for emergency calling",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "emergency_status": {
-            "$ref": "#/components/schemas/incoming_phone_number_emergency_status"
+            "description": "Whether the phone number is enabled for emergency calling",
+            "enum": [
+              "Active",
+              "Inactive"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "identity_sid": {
-            "$ref": "#/components/schemas/sid_RI"
+            "description": "The SID of the Identity resource associated with number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RI[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "origin": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number's origin. Can be twilio or hosted.",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles SMS messages sent to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when an error occurs while retrieving or executing the TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with sms_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives an incoming SMS message",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "voice_caller_id_lookup": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to lookup the caller's name",
+            "nullable": true,
+            "type": "boolean"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs in TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with the voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_receive_mode": {
-            "$ref": "#/components/schemas/incoming_phone_number_voice_receive_mode"
+            "enum": [
+              "voice",
+              "fax"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1269,37 +2653,71 @@
       "api.v2010.account.incoming_phone_number.incoming_phone_number_assigned_add_on": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "configuration": {
-            "$ref": "#/components/schemas/object"
+            "description": "A JSON string that represents the current configuration",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A short description of the Add-on functionality",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "resource_sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The SID of the Phone Number that installed this Add-on",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_XE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1307,31 +2725,62 @@
       "api.v2010.account.incoming_phone_number.incoming_phone_number_assigned_add_on.incoming_phone_number_assigned_add_on_extension": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assigned_add_on_sid": {
-            "$ref": "#/components/schemas/sid_XE"
+            "description": "The SID that uniquely identifies the assigned Add-on installation",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Extension will be invoked",
+            "nullable": true,
+            "type": "boolean"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "product_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string that you assigned to describe the Product this Extension is used within",
+            "nullable": true,
+            "type": "string"
           },
           "resource_sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The SID of the Phone Number to which the Add-on is assigned",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_XF"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1339,103 +2788,270 @@
       "api.v2010.account.incoming_phone_number.incoming_phone_number_local": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "address_requirements": {
-            "$ref": "#/components/schemas/incoming_phone_number_local_address_requirement"
+            "description": "Whether the phone number requires an Address registered with Twilio.",
+            "enum": [
+              "none",
+              "any",
+              "local",
+              "foreign"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The SID of the Address resource associated with the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to start a new TwiML session",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "bundle_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The SID of the Bundle resource associated with number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Indicate if a phone can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "emergency_address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The emergency address configuration to use for emergency calling",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "emergency_status": {
-            "$ref": "#/components/schemas/incoming_phone_number_local_emergency_status"
+            "description": "Whether the phone number is enabled for emergency calling",
+            "enum": [
+              "Active",
+              "Inactive"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "identity_sid": {
-            "$ref": "#/components/schemas/sid_RI"
+            "description": "The SID of the Identity resource associated with number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RI[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "origin": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number's origin. Can be twilio or hosted.",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the Application resource to handle SMS messages",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when an error occurs while retrieving or executing the TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with sms_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives an incoming SMS message",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "voice_caller_id_lookup": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to lookup the caller's name",
+            "nullable": true,
+            "type": "boolean"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs in TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with the voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_receive_mode": {
-            "$ref": "#/components/schemas/incoming_phone_number_local_voice_receive_mode"
+            "enum": [
+              "voice",
+              "fax"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when this phone number receives a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1443,103 +3059,270 @@
       "api.v2010.account.incoming_phone_number.incoming_phone_number_mobile": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "address_requirements": {
-            "$ref": "#/components/schemas/incoming_phone_number_mobile_address_requirement"
+            "description": "Whether the phone number requires an Address registered with Twilio.",
+            "enum": [
+              "none",
+              "any",
+              "local",
+              "foreign"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The SID of the Address resource associated with the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to start a new TwiML session",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "bundle_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The SID of the Bundle resource associated with number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Indicate if a phone can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "emergency_address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The emergency address configuration to use for emergency calling",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "emergency_status": {
-            "$ref": "#/components/schemas/incoming_phone_number_mobile_emergency_status"
+            "description": "Whether the phone number is enabled for emergency calling",
+            "enum": [
+              "Active",
+              "Inactive"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "identity_sid": {
-            "$ref": "#/components/schemas/sid_RI"
+            "description": "The SID of the Identity resource associated with number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RI[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "origin": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number's origin. Can be twilio or hosted.",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles SMS messages sent to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when an error occurs while retrieving or executing the TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with sms_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives an incoming SMS message",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "voice_caller_id_lookup": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to lookup the caller's name",
+            "nullable": true,
+            "type": "boolean"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs in TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with the voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_receive_mode": {
-            "$ref": "#/components/schemas/incoming_phone_number_mobile_voice_receive_mode"
+            "enum": [
+              "voice",
+              "fax"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1547,103 +3330,270 @@
       "api.v2010.account.incoming_phone_number.incoming_phone_number_toll_free": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "address_requirements": {
-            "$ref": "#/components/schemas/incoming_phone_number_toll_free_address_requirement"
+            "description": "Whether the phone number requires an Address registered with Twilio.",
+            "enum": [
+              "none",
+              "any",
+              "local",
+              "foreign"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The SID of the Address resource associated with the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to start a new TwiML session",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "bundle_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The SID of the Bundle resource associated with number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "Indicate if a phone can receive calls or messages",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "emergency_address_sid": {
-            "$ref": "#/components/schemas/sid_AD"
+            "description": "The emergency address configuration to use for emergency calling",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "emergency_status": {
-            "$ref": "#/components/schemas/incoming_phone_number_toll_free_emergency_status"
+            "description": "Whether the phone number is enabled for emergency calling",
+            "enum": [
+              "Active",
+              "Inactive"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "identity_sid": {
-            "$ref": "#/components/schemas/sid_RI"
+            "description": "The SID of the Identity resource associated with number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RI[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "origin": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number's origin. Can be twilio or hosted.",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles SMS messages sent to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when an error occurs while retrieving or executing the TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with sms_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives an incoming SMS message",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "voice_caller_id_lookup": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to lookup the caller's name",
+            "nullable": true,
+            "type": "boolean"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs in TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with the voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_receive_mode": {
-            "$ref": "#/components/schemas/incoming_phone_number_toll_free_voice_receive_mode"
+            "enum": [
+              "voice",
+              "fax"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1651,16 +3601,29 @@
       "api.v2010.account.key": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_SK"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SK[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1668,64 +3631,136 @@
       "api.v2010.account.message": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to process the message",
+            "nullable": true,
+            "type": "string"
           },
           "body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The message text",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_sent": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT when the message was sent",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "direction": {
-            "$ref": "#/components/schemas/message_direction"
+            "description": "The direction of the message",
+            "enum": [
+              "inbound",
+              "outbound-api",
+              "outbound-call",
+              "outbound-reply"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The error code associated with the message",
+            "nullable": true,
+            "type": "integer"
           },
           "error_message": {
-            "$ref": "#/components/schemas/string"
+            "description": "The description of the error_code",
+            "nullable": true,
+            "type": "string"
           },
           "from": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number that initiated the message",
+            "nullable": true,
+            "type": "string"
           },
           "messaging_service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The SID of the Messaging Service used with the message.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "num_media": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of media files associated with the message",
+            "nullable": true,
+            "type": "string"
           },
           "num_segments": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of messages used to deliver the message body",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount billed for the message",
+            "nullable": true,
+            "type": "string"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which price is measured",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MM"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^(SM|MM)[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/message_status"
+            "description": "The status of the message",
+            "enum": [
+              "queued",
+              "sending",
+              "sent",
+              "failed",
+              "delivered",
+              "undelivered",
+              "receiving",
+              "received",
+              "accepted",
+              "scheduled",
+              "read",
+              "partially_delivered"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "to": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number that received the message",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1733,25 +3768,51 @@
       "api.v2010.account.message.media": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "content_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The default mime-type of the media",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "parent_sid": {
-            "$ref": "#/components/schemas/sid_MM"
+            "description": "The SID of the resource that created the media",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^(SM|MM)[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ME"
+            "description": "The unique string that identifies this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ME[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of this resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1759,22 +3820,46 @@
       "api.v2010.account.message.message_feedback": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "message_sid": {
-            "$ref": "#/components/schemas/sid_MM"
+            "description": "The SID of the Message resource for which the feedback was provided",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^(SM|MM)[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "outcome": {
-            "$ref": "#/components/schemas/message_feedback_outcome"
+            "description": "Whether the feedback has arrived",
+            "enum": [
+              "confirmed",
+              "unconfirmed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1782,19 +3867,34 @@
       "api.v2010.account.new_key": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "secret": {
-            "$ref": "#/components/schemas/base64"
+            "description": "The secret your application uses to sign Access Tokens and to authenticate to the REST API.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_SK"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SK[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1802,19 +3902,34 @@
       "api.v2010.account.new_signing_key": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "secret": {
-            "$ref": "#/components/schemas/base64"
+            "description": "The secret your application uses to sign Access Tokens and to authenticate to the REST API.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_SK"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SK[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1822,46 +3937,97 @@
       "api.v2010.account.notification": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to generate the notification",
+            "nullable": true,
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "A unique error code corresponding to the notification",
+            "nullable": true,
+            "type": "string"
           },
           "log": {
-            "$ref": "#/components/schemas/string"
+            "description": "An integer log level",
+            "nullable": true,
+            "type": "string"
           },
           "message_date": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date the notification was generated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "message_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text of the notification",
+            "nullable": true,
+            "type": "string"
           },
           "more_info": {
-            "$ref": "#/components/schemas/url"
+            "description": "A URL for more information about the error code",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "request_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "HTTP method used with the request url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "request_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "URL of the resource that generated the notification",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1869,55 +4035,112 @@
       "api.v2010.account.notification-instance": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to generate the notification",
+            "nullable": true,
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "A unique error code corresponding to the notification",
+            "nullable": true,
+            "type": "string"
           },
           "log": {
-            "$ref": "#/components/schemas/string"
+            "description": "An integer log level",
+            "nullable": true,
+            "type": "string"
           },
           "message_date": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date the notification was generated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "message_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text of the notification",
+            "nullable": true,
+            "type": "string"
           },
           "more_info": {
-            "$ref": "#/components/schemas/url"
+            "description": "A URL for more information about the error code",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "request_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "HTTP method used with the request url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "request_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "URL of the resource that generated the notification",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "request_variables": {
-            "$ref": "#/components/schemas/string"
+            "description": "Twilio-generated HTTP variables sent to the server",
+            "nullable": true,
+            "type": "string"
           },
           "response_body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The HTTP body returned by your server",
+            "nullable": true,
+            "type": "string"
           },
           "response_headers": {
-            "$ref": "#/components/schemas/string"
+            "description": "The HTTP headers returned by your server",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1925,25 +4148,48 @@
       "api.v2010.account.outgoing_caller_id": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1951,31 +4197,58 @@
       "api.v2010.account.queue": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "average_wait_time": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Average wait time of members in the queue",
+            "nullable": true,
+            "type": "integer"
           },
           "current_size": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of calls currently in the queue.",
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string that you assigned to describe this resource",
+            "nullable": true,
+            "type": "string"
           },
           "max_size": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The max number of calls allowed in the queue",
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_QU"
+            "description": "The unique string that identifies this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^QU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of this resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -1983,22 +4256,42 @@
       "api.v2010.account.queue.member": {
         "properties": {
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_enqueued": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date the member was enqueued",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "position": {
-            "$ref": "#/components/schemas/integer"
+            "description": "This member's current position in the queue.",
+            "nullable": true,
+            "type": "integer"
           },
           "queue_sid": {
-            "$ref": "#/components/schemas/sid_QU"
+            "description": "The SID of the Queue the member is in",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^QU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "wait_time": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of seconds the member has been in the queue.",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
@@ -2006,58 +4299,127 @@
       "api.v2010.account.recording": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used during the recording.",
+            "nullable": true,
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channels": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of channels in the final recording file as an integer.",
+            "nullable": true,
+            "type": "integer"
           },
           "conference_sid": {
-            "$ref": "#/components/schemas/sid_CF"
+            "description": "The unique ID for the conference associated with the recording.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/string"
+            "description": "The length of the recording in seconds.",
+            "nullable": true,
+            "type": "string"
           },
           "encryption_details": {
-            "$ref": "#/components/schemas/object"
+            "description": "How to decrypt the recording.",
+            "nullable": true,
+            "type": "object"
           },
           "error_code": {
-            "$ref": "#/components/schemas/integer"
+            "description": "More information about why the recording is missing, if status is `absent`.",
+            "nullable": true,
+            "type": "integer"
           },
           "price": {
-            "$ref": "#/components/schemas/string"
+            "description": "The one-time cost of creating the recording.",
+            "nullable": true,
+            "type": "string"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The currency used in the price property.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "source": {
-            "$ref": "#/components/schemas/recording_source"
+            "description": "How the recording was created",
+            "enum": [
+              "DialVerb",
+              "Conference",
+              "OutboundAPI",
+              "Trunking",
+              "RecordVerb",
+              "StartCallRecordingAPI",
+              "StartConferenceRecordingAPI"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The start time of the recording, given in RFC 2822 format",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/recording_status"
+            "description": "The status of the recording.",
+            "enum": [
+              "in-progress",
+              "paused",
+              "stopped",
+              "processing",
+              "completed",
+              "absent"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2065,34 +4427,82 @@
       "api.v2010.account.recording.recording_add_on_result": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "add_on_configuration_sid": {
-            "$ref": "#/components/schemas/sid_XE"
+            "description": "The SID of the Add-on configuration",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "add_on_sid": {
-            "$ref": "#/components/schemas/sid_XB"
+            "description": "The SID of the Add-on to which the result belongs",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_completed": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date and time in GMT that the result was completed",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "reference_sid": {
-            "$ref": "#/components/schemas/sid_RE"
+            "description": "The SID of the recording to which the AddOnResult resource belongs",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_XR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/recording_add_on_result_status"
+            "description": "The status of the result",
+            "enum": [
+              "canceled",
+              "completed",
+              "deleted",
+              "failed",
+              "in-progress",
+              "init",
+              "processing",
+              "queued"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           }
         },
         "type": "object"
@@ -2100,37 +4510,79 @@
       "api.v2010.account.recording.recording_add_on_result.recording_add_on_result_payload": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "add_on_configuration_sid": {
-            "$ref": "#/components/schemas/sid_XE"
+            "description": "The SID of the Add-on configuration",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "add_on_result_sid": {
-            "$ref": "#/components/schemas/sid_XR"
+            "description": "The SID of the AddOnResult to which the payload belongs",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "add_on_sid": {
-            "$ref": "#/components/schemas/sid_XB"
+            "description": "The SID of the Add-on to which the result belongs",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "content_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The MIME type of the payload",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "label": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that describes the payload",
+            "nullable": true,
+            "type": "string"
           },
           "reference_sid": {
-            "$ref": "#/components/schemas/sid_RE"
+            "description": "The SID of the recording to which the AddOnResult resource that contains the payload belongs",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_XH"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^XH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           }
         },
         "type": "object"
@@ -2138,43 +4590,86 @@
       "api.v2010.account.recording.recording_transcription": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the transcription",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/string"
+            "description": "The duration of the transcribed audio in seconds.",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The charge for the transcription",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which price is measured",
+            "nullable": true,
+            "type": "string"
           },
           "recording_sid": {
-            "$ref": "#/components/schemas/sid_RE"
+            "description": "The SID that identifies the transcription's recording",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_TR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/recording_transcription_status"
+            "description": "The status of the transcription",
+            "enum": [
+              "in-progress",
+              "completed",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "transcription_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text content of the transcription.",
+            "nullable": true,
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The transcription type",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2182,40 +4677,91 @@
       "api.v2010.account.short_code": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to start a new TwiML session",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string that you assigned to describe this resource",
+            "nullable": true,
+            "type": "string"
           },
           "short_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The short code. e.g., 894546.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_SC"
+            "description": "The unique string that identifies this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "HTTP method we use to call the sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "URL Twilio will request if an error occurs in executing TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "HTTP method to use when requesting the sms url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "URL we call when receiving an incoming SMS message to this short code",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of this resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2223,16 +4769,25 @@
       "api.v2010.account.signing_key": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_SK"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SK[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -2244,25 +4799,48 @@
       "api.v2010.account.sip.sip_credential_list": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique sid that identifies this account",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "Human readable descriptive text",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CL"
+            "description": "A string that uniquely identifies this credential",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The list of credentials associated with this credential list.",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI for this resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2270,25 +4848,51 @@
       "api.v2010.account.sip.sip_credential_list.sip_credential": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique id of the Account that is responsible for this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "credential_list_sid": {
-            "$ref": "#/components/schemas/sid_CL"
+            "description": "The unique id that identifies the credential list that includes this credential",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date that this resource was created, given as GMT in RFC 2822 format.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date that this resource was last updated, given as GMT in RFC 2822 format.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI for this resource, relative to https://api.twilio.com",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "username": {
-            "$ref": "#/components/schemas/string"
+            "description": "The username for this credential.",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2296,67 +4900,151 @@
       "api.v2010.account.sip.sip_domain": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to process the call",
+            "nullable": true,
+            "type": "string"
           },
           "auth_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The types of authentication mapped to the domain",
+            "nullable": true,
+            "type": "string"
           },
           "byoc_trunk_sid": {
-            "$ref": "#/components/schemas/sid_BY"
+            "description": "The SID of the BYOC Trunk resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "domain_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique address on Twilio to route SIP traffic",
+            "nullable": true,
+            "type": "string"
           },
           "emergency_caller_sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "Whether an emergency caller sid is configured for the domain.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "emergency_calling_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether emergency calling is enabled for the domain.",
+            "nullable": true,
+            "type": "boolean"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "secure": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether secure SIP is enabled for the domain",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_SD"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sip_registration": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether SIP registration is allowed",
+            "nullable": true,
+            "type": "boolean"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list mapping resources associated with the SIP Domain resource",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs while executing TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call voice_status_callback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_status_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call with status updates",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when receiving a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2372,19 +5060,37 @@
       "api.v2010.account.sip.sip_domain.sip_auth.sip_auth_calls.sip_auth_calls_credential_list_mapping": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CL[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -2392,19 +5098,37 @@
       "api.v2010.account.sip.sip_domain.sip_auth.sip_auth_calls.sip_auth_calls_ip_access_control_list_mapping": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AL[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -2416,19 +5140,37 @@
       "api.v2010.account.sip.sip_domain.sip_auth.sip_auth_registrations.sip_auth_registrations_credential_list_mapping": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CL[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -2436,25 +5178,48 @@
       "api.v2010.account.sip.sip_domain.sip_credential_list_mapping": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique id of the Account that is responsible for this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date that this resource was created, given as GMT in RFC 2822 format.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date that this resource was last updated, given as GMT in RFC 2822 format.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human readable descriptive text for this resource, up to 64 characters long.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CL"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The credentials associated with this resource.",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI for this resource, relative to https://api.twilio.com",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2462,25 +5227,48 @@
       "api.v2010.account.sip.sip_domain.sip_ip_access_control_list_mapping": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique id of the Account that is responsible for this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date that this resource was created, given as GMT in RFC 2822 format.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date that this resource was last updated, given as GMT in RFC 2822 format.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human readable descriptive text for this resource, up to 64 characters long.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AL"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The list of IP addresses associated with this domain.",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI for this resource, relative to https://api.twilio.com",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2488,25 +5276,48 @@
       "api.v2010.account.sip.sip_ip_access_control_list": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique sid that identifies this account",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date this resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human readable description of this resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AL"
+            "description": "A string that uniquely identifies this resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The IP addresses associated with this resource.",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI for this resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2514,31 +5325,61 @@
       "api.v2010.account.sip.sip_ip_access_control_list.sip_ip_address": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique id of the Account that is responsible for this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cidr_prefix_length": {
-            "$ref": "#/components/schemas/integer"
+            "description": "An integer representing the length of the CIDR prefix to use with this IP address when accepting traffic. By default the entire IP address is used.",
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date that this resource was created, given as GMT in RFC 2822 format.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The date that this resource was last updated, given as GMT in RFC 2822 format.",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human readable descriptive text for this resource, up to 64 characters long.",
+            "nullable": true,
+            "type": "string"
           },
           "ip_access_control_list_sid": {
-            "$ref": "#/components/schemas/sid_AL"
+            "description": "The unique id of the IpAccessControlList resource that includes this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "ip_address": {
-            "$ref": "#/components/schemas/string"
+            "description": "An IP address in dotted decimal notation from which you want to accept traffic. Any SIP requests from this IP address will be allowed by Twilio. IPv4 only supported today.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IP"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI for this resource, relative to https://api.twilio.com",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2546,25 +5387,61 @@
       "api.v2010.account.token": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "ice_servers": {
-            "$ref": "#/components/schemas/ice_server_list"
+            "description": "An array representing the ephemeral credentials",
+            "items": {
+              "properties": {
+                "credential": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "urls": {
+                  "type": "string"
+                },
+                "username": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "password": {
-            "$ref": "#/components/schemas/string"
+            "description": "The temporary password used for authenticating",
+            "nullable": true,
+            "type": "string"
           },
           "ttl": {
-            "$ref": "#/components/schemas/string"
+            "description": "The duration in seconds the credentials are valid",
+            "nullable": true,
+            "type": "string"
           },
           "username": {
-            "$ref": "#/components/schemas/string"
+            "description": "The temporary username that uniquely identifies a Token",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2572,43 +5449,86 @@
       "api.v2010.account.transcription": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the transcription",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/string"
+            "description": "The duration of the transcribed audio in seconds.",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The charge for the transcription",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which price is measured",
+            "nullable": true,
+            "type": "string"
           },
           "recording_sid": {
-            "$ref": "#/components/schemas/sid_RE"
+            "description": "The SID that identifies the transcription's recording",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_TR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/transcription_status"
+            "description": "The status of the transcription",
+            "enum": [
+              "in-progress",
+              "completed",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "transcription_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text content of the transcription.",
+            "nullable": true,
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The transcription type",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2620,49 +5540,325 @@
       "api.v2010.account.usage.usage_record": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2670,49 +5866,325 @@
       "api.v2010.account.usage.usage_record.usage_record_all_time": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_all_time_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2720,49 +6192,325 @@
       "api.v2010.account.usage.usage_record.usage_record_daily": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_daily_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2770,49 +6518,325 @@
       "api.v2010.account.usage.usage_record.usage_record_last_month": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_last_month_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2820,49 +6844,325 @@
       "api.v2010.account.usage.usage_record.usage_record_monthly": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_monthly_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2870,49 +7170,325 @@
       "api.v2010.account.usage.usage_record.usage_record_this_month": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_this_month_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2920,49 +7496,325 @@
       "api.v2010.account.usage.usage_record.usage_record_today": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_today_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -2970,49 +7822,325 @@
       "api.v2010.account.usage.usage_record.usage_record_yearly": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_yearly_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -3020,49 +8148,325 @@
       "api.v2010.account.usage.usage_record.usage_record_yesterday": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account accrued the usage",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "as_of": {
-            "$ref": "#/components/schemas/string"
+            "description": "Usage records up to date as of this timestamp",
+            "nullable": true,
+            "type": "string"
           },
           "category": {
-            "$ref": "#/components/schemas/usage_record_yesterday_category"
+            "description": "The category of usage",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "count": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number of usage events",
+            "nullable": true,
+            "type": "string"
           },
           "count_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which count is measured",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A plain-language description of the usage category",
+            "nullable": true,
+            "type": "string"
           },
           "end_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The last date for which usage is included in the UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The total price of the usage",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which `price` is measured",
+            "nullable": true,
+            "type": "string"
           },
           "start_date": {
-            "$ref": "#/components/schemas/date_iso8601"
+            "description": "The first date for which usage is included in this UsageRecord",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "subresource_uris": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of related resources identified by their relative URIs",
+            "nullable": true,
+            "type": "object"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of usage",
+            "nullable": true,
+            "type": "string"
           },
           "usage_unit": {
-            "$ref": "#/components/schemas/string"
+            "description": "The units in which usage is measured",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -3070,52 +8474,354 @@
       "api.v2010.account.usage.usage_trigger": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that this trigger monitors",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to create the resource",
+            "nullable": true,
+            "type": "string"
           },
           "callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call callback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "he URL we call when the trigger fires",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "current_value": {
-            "$ref": "#/components/schemas/string"
+            "description": "The current value of the field the trigger is watching",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_fired": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the trigger was last fired",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_rfc2822"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time-rfc-2822",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the trigger",
+            "nullable": true,
+            "type": "string"
           },
           "recurring": {
-            "$ref": "#/components/schemas/usage_trigger_recurring"
+            "description": "The frequency of a recurring UsageTrigger",
+            "enum": [
+              "daily",
+              "monthly",
+              "yearly",
+              "alltime"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "trigger_by": {
-            "$ref": "#/components/schemas/usage_trigger_trigger_field"
+            "description": "The field in the UsageRecord resource that fires the trigger",
+            "enum": [
+              "count",
+              "usage",
+              "price"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trigger_value": {
-            "$ref": "#/components/schemas/string"
+            "description": "The value at which the trigger will fire",
+            "nullable": true,
+            "type": "string"
           },
           "uri": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URI of the resource, relative to `https://api.twilio.com`",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "usage_category": {
-            "$ref": "#/components/schemas/usage_trigger_usage_category"
+            "description": "The usage category the trigger watches",
+            "enum": [
+              "agent-conference",
+              "answering-machine-detection",
+              "authy-authentications",
+              "authy-calls-outbound",
+              "authy-monthly-fees",
+              "authy-phone-intelligence",
+              "authy-phone-verifications",
+              "authy-sms-outbound",
+              "call-progess-events",
+              "calleridlookups",
+              "calls",
+              "calls-client",
+              "calls-globalconference",
+              "calls-inbound",
+              "calls-inbound-local",
+              "calls-inbound-mobile",
+              "calls-inbound-tollfree",
+              "calls-outbound",
+              "calls-pay-verb-transactions",
+              "calls-recordings",
+              "calls-sip",
+              "calls-sip-inbound",
+              "calls-sip-outbound",
+              "carrier-lookups",
+              "conversations",
+              "conversations-api-requests",
+              "conversations-conversation-events",
+              "conversations-endpoint-connectivity",
+              "conversations-events",
+              "conversations-participant-events",
+              "conversations-participants",
+              "cps",
+              "fraud-lookups",
+              "group-rooms",
+              "group-rooms-data-track",
+              "group-rooms-encrypted-media-recorded",
+              "group-rooms-media-downloaded",
+              "group-rooms-media-recorded",
+              "group-rooms-media-routed",
+              "group-rooms-media-stored",
+              "group-rooms-participant-minutes",
+              "group-rooms-recorded-minutes",
+              "imp-v1-usage",
+              "lookups",
+              "marketplace",
+              "marketplace-algorithmia-named-entity-recognition",
+              "marketplace-cadence-transcription",
+              "marketplace-cadence-translation",
+              "marketplace-capio-speech-to-text",
+              "marketplace-convriza-ababa",
+              "marketplace-deepgram-phrase-detector",
+              "marketplace-digital-segment-business-info",
+              "marketplace-facebook-offline-conversions",
+              "marketplace-google-speech-to-text",
+              "marketplace-ibm-watson-message-insights",
+              "marketplace-ibm-watson-message-sentiment",
+              "marketplace-ibm-watson-recording-analysis",
+              "marketplace-ibm-watson-tone-analyzer",
+              "marketplace-icehook-systems-scout",
+              "marketplace-infogroup-dataaxle-bizinfo",
+              "marketplace-keen-io-contact-center-analytics",
+              "marketplace-marchex-cleancall",
+              "marketplace-marchex-sentiment-analysis-for-sms",
+              "marketplace-marketplace-nextcaller-social-id",
+              "marketplace-mobile-commons-opt-out-classifier",
+              "marketplace-nexiwave-voicemail-to-text",
+              "marketplace-nextcaller-advanced-caller-identification",
+              "marketplace-nomorobo-spam-score",
+              "marketplace-payfone-tcpa-compliance",
+              "marketplace-remeeting-automatic-speech-recognition",
+              "marketplace-tcpa-defense-solutions-blacklist-feed",
+              "marketplace-telo-opencnam",
+              "marketplace-truecnam-true-spam",
+              "marketplace-twilio-caller-name-lookup-us",
+              "marketplace-twilio-carrier-information-lookup",
+              "marketplace-voicebase-pci",
+              "marketplace-voicebase-transcription",
+              "marketplace-voicebase-transcription-custom-vocabulary",
+              "marketplace-whitepages-pro-caller-identification",
+              "marketplace-whitepages-pro-phone-intelligence",
+              "marketplace-whitepages-pro-phone-reputation",
+              "marketplace-wolfarm-spoken-results",
+              "marketplace-wolfram-short-answer",
+              "marketplace-ytica-contact-center-reporting-analytics",
+              "mediastorage",
+              "mms",
+              "mms-inbound",
+              "mms-inbound-longcode",
+              "mms-inbound-shortcode",
+              "mms-messages-carrierfees",
+              "mms-outbound",
+              "mms-outbound-longcode",
+              "mms-outbound-shortcode",
+              "monitor-reads",
+              "monitor-storage",
+              "monitor-writes",
+              "notify",
+              "notify-actions-attempts",
+              "notify-channels",
+              "number-format-lookups",
+              "pchat",
+              "pchat-users",
+              "peer-to-peer-rooms-participant-minutes",
+              "pfax",
+              "pfax-minutes",
+              "pfax-minutes-inbound",
+              "pfax-minutes-outbound",
+              "pfax-pages",
+              "phonenumbers",
+              "phonenumbers-cps",
+              "phonenumbers-emergency",
+              "phonenumbers-local",
+              "phonenumbers-mobile",
+              "phonenumbers-setups",
+              "phonenumbers-tollfree",
+              "premiumsupport",
+              "proxy",
+              "proxy-active-sessions",
+              "pstnconnectivity",
+              "pv",
+              "pv-composition-media-downloaded",
+              "pv-composition-media-encrypted",
+              "pv-composition-media-stored",
+              "pv-composition-minutes",
+              "pv-recording-compositions",
+              "pv-room-participants",
+              "pv-room-participants-au1",
+              "pv-room-participants-br1",
+              "pv-room-participants-ie1",
+              "pv-room-participants-jp1",
+              "pv-room-participants-sg1",
+              "pv-room-participants-us1",
+              "pv-room-participants-us2",
+              "pv-rooms",
+              "pv-sip-endpoint-registrations",
+              "recordings",
+              "recordingstorage",
+              "rooms-group-bandwidth",
+              "rooms-group-minutes",
+              "rooms-peer-to-peer-minutes",
+              "shortcodes",
+              "shortcodes-customerowned",
+              "shortcodes-mms-enablement",
+              "shortcodes-mps",
+              "shortcodes-random",
+              "shortcodes-uk",
+              "shortcodes-vanity",
+              "small-group-rooms",
+              "small-group-rooms-data-track",
+              "small-group-rooms-participant-minutes",
+              "sms",
+              "sms-inbound",
+              "sms-inbound-longcode",
+              "sms-inbound-shortcode",
+              "sms-messages-carrierfees",
+              "sms-messages-features",
+              "sms-messages-features-senderid",
+              "sms-outbound",
+              "sms-outbound-content-inspection",
+              "sms-outbound-longcode",
+              "sms-outbound-shortcode",
+              "speech-recognition",
+              "studio-engagements",
+              "sync",
+              "sync-actions",
+              "sync-endpoint-hours",
+              "sync-endpoint-hours-above-daily-cap",
+              "taskrouter-tasks",
+              "totalprice",
+              "transcriptions",
+              "trunking-cps",
+              "trunking-emergency-calls",
+              "trunking-origination",
+              "trunking-origination-local",
+              "trunking-origination-mobile",
+              "trunking-origination-tollfree",
+              "trunking-recordings",
+              "trunking-secure",
+              "trunking-termination",
+              "turnmegabytes",
+              "turnmegabytes-australia",
+              "turnmegabytes-brasil",
+              "turnmegabytes-germany",
+              "turnmegabytes-india",
+              "turnmegabytes-ireland",
+              "turnmegabytes-japan",
+              "turnmegabytes-singapore",
+              "turnmegabytes-useast",
+              "turnmegabytes-uswest",
+              "twilio-interconnect",
+              "verify-push",
+              "video-recordings",
+              "voice-insights",
+              "voice-insights-client-insights-on-demand-minute",
+              "voice-insights-ptsn-insights-on-demand-minute",
+              "voice-insights-sip-interface-insights-on-demand-minute",
+              "voice-insights-sip-trunking-insights-on-demand-minute",
+              "wireless",
+              "wireless-orders",
+              "wireless-orders-artwork",
+              "wireless-orders-bulk",
+              "wireless-orders-esim",
+              "wireless-orders-starter",
+              "wireless-usage",
+              "wireless-usage-commands",
+              "wireless-usage-commands-africa",
+              "wireless-usage-commands-asia",
+              "wireless-usage-commands-centralandsouthamerica",
+              "wireless-usage-commands-europe",
+              "wireless-usage-commands-home",
+              "wireless-usage-commands-northamerica",
+              "wireless-usage-commands-oceania",
+              "wireless-usage-commands-roaming",
+              "wireless-usage-data",
+              "wireless-usage-data-africa",
+              "wireless-usage-data-asia",
+              "wireless-usage-data-centralandsouthamerica",
+              "wireless-usage-data-custom-additionalmb",
+              "wireless-usage-data-custom-first5mb",
+              "wireless-usage-data-domestic-roaming",
+              "wireless-usage-data-europe",
+              "wireless-usage-data-individual-additionalgb",
+              "wireless-usage-data-individual-firstgb",
+              "wireless-usage-data-international-roaming-canada",
+              "wireless-usage-data-international-roaming-india",
+              "wireless-usage-data-international-roaming-mexico",
+              "wireless-usage-data-northamerica",
+              "wireless-usage-data-oceania",
+              "wireless-usage-data-pooled",
+              "wireless-usage-data-pooled-downlink",
+              "wireless-usage-data-pooled-uplink",
+              "wireless-usage-mrc",
+              "wireless-usage-mrc-custom",
+              "wireless-usage-mrc-individual",
+              "wireless-usage-mrc-pooled",
+              "wireless-usage-mrc-suspended",
+              "wireless-usage-sms",
+              "wireless-usage-voice"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "usage_record_uri": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URI of the UsageRecord resource this trigger watches",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -3123,3213 +8829,38 @@
       "api.v2010.account.validation_request": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "description": "The SID of the Call the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number to verify in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "validation_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The 6 digit validation code that someone must enter to validate the Caller ID  when `phone_number` is called",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "authorized_connect_app_permission_list": {
-        "items": {
-          "enum": [
-            "get-all",
-            "post-all"
-          ],
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "base64": {
-        "nullable": true,
-        "type": "string"
-      },
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "call_feedback_issues_list": {
-        "items": {
-          "enum": [
-            "audio-latency",
-            "digits-not-captured",
-            "dropped-call",
-            "imperfect-audio",
-            "incorrect-caller-id",
-            "one-way-audio",
-            "post-dial-delay",
-            "unsolicited-call"
-          ],
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "call_feedback_summary_status": {
-        "enum": [
-          "queued",
-          "in-progress",
-          "completed",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "call_recording_source": {
-        "enum": [
-          "DialVerb",
-          "Conference",
-          "OutboundAPI",
-          "Trunking",
-          "RecordVerb",
-          "StartCallRecordingAPI",
-          "StartConferenceRecordingAPI"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "call_recording_status": {
-        "enum": [
-          "in-progress",
-          "paused",
-          "stopped",
-          "processing",
-          "completed",
-          "absent"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "call_status": {
-        "enum": [
-          "queued",
-          "ringing",
-          "in-progress",
-          "completed",
-          "busy",
-          "failed",
-          "no-answer",
-          "canceled"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "conference_reason_conference_ended": {
-        "enum": [
-          "conference-ended-via-api",
-          "participant-with-end-conference-on-exit-left",
-          "participant-with-end-conference-on-exit-kicked",
-          "last-participant-kicked",
-          "last-participant-left"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "conference_recording_source": {
-        "enum": [
-          "DialVerb",
-          "Conference",
-          "OutboundAPI",
-          "Trunking",
-          "RecordVerb",
-          "StartCallRecordingAPI",
-          "StartConferenceRecordingAPI"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "conference_recording_status": {
-        "enum": [
-          "in-progress",
-          "paused",
-          "stopped",
-          "processing",
-          "completed",
-          "absent"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "conference_status": {
-        "enum": [
-          "init",
-          "in-progress",
-          "completed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "connect_app_permission_list": {
-        "items": {
-          "enum": [
-            "get-all",
-            "post-all"
-          ],
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "currency": {
-        "nullable": true,
-        "type": "string"
-      },
-      "date_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_rfc2822": {
-        "format": "date-time-rfc-2822",
-        "nullable": true,
-        "type": "string"
-      },
-      "decimal": {
-        "nullable": true,
-        "type": "number"
-      },
-      "dependent_phone_number_address_requirement": {
-        "enum": [
-          "none",
-          "any",
-          "local",
-          "foreign"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "dependent_phone_number_emergency_status": {
-        "enum": [
-          "Active",
-          "Inactive"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "feedback_issue_list": {
-        "items": {
-          "properties": {
-            "count": {
-              "type": "number"
-            },
-            "description": {
-              "type": "string"
-            },
-            "percentage_of_total_calls": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "ice_server_list": {
-        "items": {
-          "properties": {
-            "credential": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "urls": {
-              "type": "string"
-            },
-            "username": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "incoming_phone_number_address_requirement": {
-        "enum": [
-          "none",
-          "any",
-          "local",
-          "foreign"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_emergency_status": {
-        "enum": [
-          "Active",
-          "Inactive"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_local_address_requirement": {
-        "enum": [
-          "none",
-          "any",
-          "local",
-          "foreign"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_local_emergency_status": {
-        "enum": [
-          "Active",
-          "Inactive"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_local_voice_receive_mode": {
-        "enum": [
-          "voice",
-          "fax"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_mobile_address_requirement": {
-        "enum": [
-          "none",
-          "any",
-          "local",
-          "foreign"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_mobile_emergency_status": {
-        "enum": [
-          "Active",
-          "Inactive"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_mobile_voice_receive_mode": {
-        "enum": [
-          "voice",
-          "fax"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_toll_free_address_requirement": {
-        "enum": [
-          "none",
-          "any",
-          "local",
-          "foreign"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_toll_free_emergency_status": {
-        "enum": [
-          "Active",
-          "Inactive"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_toll_free_voice_receive_mode": {
-        "enum": [
-          "voice",
-          "fax"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "incoming_phone_number_voice_receive_mode": {
-        "enum": [
-          "voice",
-          "fax"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "iso_country_code": {
-        "nullable": true,
-        "type": "string"
-      },
-      "message_direction": {
-        "enum": [
-          "inbound",
-          "outbound-api",
-          "outbound-call",
-          "outbound-reply"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "message_feedback_outcome": {
-        "enum": [
-          "confirmed",
-          "unconfirmed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "message_status": {
-        "enum": [
-          "queued",
-          "sending",
-          "sent",
-          "failed",
-          "delivered",
-          "undelivered",
-          "receiving",
-          "received",
-          "accepted",
-          "scheduled",
-          "read",
-          "partially_delivered"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "participant_status": {
-        "enum": [
-          "queued",
-          "connecting",
-          "ringing",
-          "connected",
-          "complete",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "phone_number": {
-        "nullable": true,
-        "type": "string"
-      },
-      "phone_number_capabilities": {
-        "nullable": true,
-        "properties": {
-          "fax": {
-            "type": "boolean"
-          },
-          "mms": {
-            "type": "boolean"
-          },
-          "sms": {
-            "type": "boolean"
-          },
-          "voice": {
-            "type": "boolean"
-          }
-        },
-        "type": "object"
-      },
-      "recording_add_on_result_status": {
-        "enum": [
-          "canceled",
-          "completed",
-          "deleted",
-          "failed",
-          "in-progress",
-          "init",
-          "processing",
-          "queued"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "recording_source": {
-        "enum": [
-          "DialVerb",
-          "Conference",
-          "OutboundAPI",
-          "Trunking",
-          "RecordVerb",
-          "StartCallRecordingAPI",
-          "StartConferenceRecordingAPI"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "recording_status": {
-        "enum": [
-          "in-progress",
-          "paused",
-          "stopped",
-          "processing",
-          "completed",
-          "absent"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "recording_transcription_status": {
-        "enum": [
-          "in-progress",
-          "completed",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AD": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AD[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AP": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AP[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BU": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BU[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BY": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BY[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CF": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CF[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_GP": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^GP[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IP": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IP[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ME": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ME[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MG": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MG[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^(SM|MM)[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_NO": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^NO[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_PK": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^PK[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_PN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^PN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_QU": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^QU[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RI": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RI[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_SC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^SC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_SD": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^SD[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_SK": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^SK[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_TK": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^TK[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_TR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^TR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_XB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^XB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_XE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^XE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_XF": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^XF[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_XH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^XH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_XR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^XR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "transcription_status": {
-        "enum": [
-          "in-progress",
-          "completed",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "uri": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_all_time_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_daily_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_last_month_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_monthly_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_this_month_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_today_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_yearly_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_record_yesterday_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_trigger_recurring": {
-        "enum": [
-          "daily",
-          "monthly",
-          "yearly",
-          "alltime"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_trigger_trigger_field": {
-        "enum": [
-          "count",
-          "usage",
-          "price"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "usage_trigger_usage_category": {
-        "enum": [
-          "agent-conference",
-          "answering-machine-detection",
-          "authy-authentications",
-          "authy-calls-outbound",
-          "authy-monthly-fees",
-          "authy-phone-intelligence",
-          "authy-phone-verifications",
-          "authy-sms-outbound",
-          "call-progess-events",
-          "calleridlookups",
-          "calls",
-          "calls-client",
-          "calls-globalconference",
-          "calls-inbound",
-          "calls-inbound-local",
-          "calls-inbound-mobile",
-          "calls-inbound-tollfree",
-          "calls-outbound",
-          "calls-pay-verb-transactions",
-          "calls-recordings",
-          "calls-sip",
-          "calls-sip-inbound",
-          "calls-sip-outbound",
-          "carrier-lookups",
-          "conversations",
-          "conversations-api-requests",
-          "conversations-conversation-events",
-          "conversations-endpoint-connectivity",
-          "conversations-events",
-          "conversations-participant-events",
-          "conversations-participants",
-          "cps",
-          "fraud-lookups",
-          "group-rooms",
-          "group-rooms-data-track",
-          "group-rooms-encrypted-media-recorded",
-          "group-rooms-media-downloaded",
-          "group-rooms-media-recorded",
-          "group-rooms-media-routed",
-          "group-rooms-media-stored",
-          "group-rooms-participant-minutes",
-          "group-rooms-recorded-minutes",
-          "imp-v1-usage",
-          "lookups",
-          "marketplace",
-          "marketplace-algorithmia-named-entity-recognition",
-          "marketplace-cadence-transcription",
-          "marketplace-cadence-translation",
-          "marketplace-capio-speech-to-text",
-          "marketplace-convriza-ababa",
-          "marketplace-deepgram-phrase-detector",
-          "marketplace-digital-segment-business-info",
-          "marketplace-facebook-offline-conversions",
-          "marketplace-google-speech-to-text",
-          "marketplace-ibm-watson-message-insights",
-          "marketplace-ibm-watson-message-sentiment",
-          "marketplace-ibm-watson-recording-analysis",
-          "marketplace-ibm-watson-tone-analyzer",
-          "marketplace-icehook-systems-scout",
-          "marketplace-infogroup-dataaxle-bizinfo",
-          "marketplace-keen-io-contact-center-analytics",
-          "marketplace-marchex-cleancall",
-          "marketplace-marchex-sentiment-analysis-for-sms",
-          "marketplace-marketplace-nextcaller-social-id",
-          "marketplace-mobile-commons-opt-out-classifier",
-          "marketplace-nexiwave-voicemail-to-text",
-          "marketplace-nextcaller-advanced-caller-identification",
-          "marketplace-nomorobo-spam-score",
-          "marketplace-payfone-tcpa-compliance",
-          "marketplace-remeeting-automatic-speech-recognition",
-          "marketplace-tcpa-defense-solutions-blacklist-feed",
-          "marketplace-telo-opencnam",
-          "marketplace-truecnam-true-spam",
-          "marketplace-twilio-caller-name-lookup-us",
-          "marketplace-twilio-carrier-information-lookup",
-          "marketplace-voicebase-pci",
-          "marketplace-voicebase-transcription",
-          "marketplace-voicebase-transcription-custom-vocabulary",
-          "marketplace-whitepages-pro-caller-identification",
-          "marketplace-whitepages-pro-phone-intelligence",
-          "marketplace-whitepages-pro-phone-reputation",
-          "marketplace-wolfarm-spoken-results",
-          "marketplace-wolfram-short-answer",
-          "marketplace-ytica-contact-center-reporting-analytics",
-          "mediastorage",
-          "mms",
-          "mms-inbound",
-          "mms-inbound-longcode",
-          "mms-inbound-shortcode",
-          "mms-messages-carrierfees",
-          "mms-outbound",
-          "mms-outbound-longcode",
-          "mms-outbound-shortcode",
-          "monitor-reads",
-          "monitor-storage",
-          "monitor-writes",
-          "notify",
-          "notify-actions-attempts",
-          "notify-channels",
-          "number-format-lookups",
-          "pchat",
-          "pchat-users",
-          "peer-to-peer-rooms-participant-minutes",
-          "pfax",
-          "pfax-minutes",
-          "pfax-minutes-inbound",
-          "pfax-minutes-outbound",
-          "pfax-pages",
-          "phonenumbers",
-          "phonenumbers-cps",
-          "phonenumbers-emergency",
-          "phonenumbers-local",
-          "phonenumbers-mobile",
-          "phonenumbers-setups",
-          "phonenumbers-tollfree",
-          "premiumsupport",
-          "proxy",
-          "proxy-active-sessions",
-          "pstnconnectivity",
-          "pv",
-          "pv-composition-media-downloaded",
-          "pv-composition-media-encrypted",
-          "pv-composition-media-stored",
-          "pv-composition-minutes",
-          "pv-recording-compositions",
-          "pv-room-participants",
-          "pv-room-participants-au1",
-          "pv-room-participants-br1",
-          "pv-room-participants-ie1",
-          "pv-room-participants-jp1",
-          "pv-room-participants-sg1",
-          "pv-room-participants-us1",
-          "pv-room-participants-us2",
-          "pv-rooms",
-          "pv-sip-endpoint-registrations",
-          "recordings",
-          "recordingstorage",
-          "rooms-group-bandwidth",
-          "rooms-group-minutes",
-          "rooms-peer-to-peer-minutes",
-          "shortcodes",
-          "shortcodes-customerowned",
-          "shortcodes-mms-enablement",
-          "shortcodes-mps",
-          "shortcodes-random",
-          "shortcodes-uk",
-          "shortcodes-vanity",
-          "small-group-rooms",
-          "small-group-rooms-data-track",
-          "small-group-rooms-participant-minutes",
-          "sms",
-          "sms-inbound",
-          "sms-inbound-longcode",
-          "sms-inbound-shortcode",
-          "sms-messages-carrierfees",
-          "sms-messages-features",
-          "sms-messages-features-senderid",
-          "sms-outbound",
-          "sms-outbound-content-inspection",
-          "sms-outbound-longcode",
-          "sms-outbound-shortcode",
-          "speech-recognition",
-          "studio-engagements",
-          "sync",
-          "sync-actions",
-          "sync-endpoint-hours",
-          "sync-endpoint-hours-above-daily-cap",
-          "taskrouter-tasks",
-          "totalprice",
-          "transcriptions",
-          "trunking-cps",
-          "trunking-emergency-calls",
-          "trunking-origination",
-          "trunking-origination-local",
-          "trunking-origination-mobile",
-          "trunking-origination-tollfree",
-          "trunking-recordings",
-          "trunking-secure",
-          "trunking-termination",
-          "turnmegabytes",
-          "turnmegabytes-australia",
-          "turnmegabytes-brasil",
-          "turnmegabytes-germany",
-          "turnmegabytes-india",
-          "turnmegabytes-ireland",
-          "turnmegabytes-japan",
-          "turnmegabytes-singapore",
-          "turnmegabytes-useast",
-          "turnmegabytes-uswest",
-          "twilio-interconnect",
-          "verify-push",
-          "video-recordings",
-          "voice-insights",
-          "voice-insights-client-insights-on-demand-minute",
-          "voice-insights-ptsn-insights-on-demand-minute",
-          "voice-insights-sip-interface-insights-on-demand-minute",
-          "voice-insights-sip-trunking-insights-on-demand-minute",
-          "wireless",
-          "wireless-orders",
-          "wireless-orders-artwork",
-          "wireless-orders-bulk",
-          "wireless-orders-esim",
-          "wireless-orders-starter",
-          "wireless-usage",
-          "wireless-usage-commands",
-          "wireless-usage-commands-africa",
-          "wireless-usage-commands-asia",
-          "wireless-usage-commands-centralandsouthamerica",
-          "wireless-usage-commands-europe",
-          "wireless-usage-commands-home",
-          "wireless-usage-commands-northamerica",
-          "wireless-usage-commands-oceania",
-          "wireless-usage-commands-roaming",
-          "wireless-usage-data",
-          "wireless-usage-data-africa",
-          "wireless-usage-data-asia",
-          "wireless-usage-data-centralandsouthamerica",
-          "wireless-usage-data-custom-additionalmb",
-          "wireless-usage-data-custom-first5mb",
-          "wireless-usage-data-domestic-roaming",
-          "wireless-usage-data-europe",
-          "wireless-usage-data-individual-additionalgb",
-          "wireless-usage-data-individual-firstgb",
-          "wireless-usage-data-international-roaming-canada",
-          "wireless-usage-data-international-roaming-india",
-          "wireless-usage-data-international-roaming-mexico",
-          "wireless-usage-data-northamerica",
-          "wireless-usage-data-oceania",
-          "wireless-usage-data-pooled",
-          "wireless-usage-data-pooled-downlink",
-          "wireless-usage-data-pooled-uplink",
-          "wireless-usage-mrc",
-          "wireless-usage-mrc-custom",
-          "wireless-usage-mrc-individual",
-          "wireless-usage-mrc-pooled",
-          "wireless-usage-mrc-suspended",
-          "wireless-usage-sms",
-          "wireless-usage-voice"
-        ],
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_autopilot_v1.json
+++ b/spec/json/twilio_autopilot_v1.json
@@ -4,46 +4,87 @@
       "autopilot.v1.assistant": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "callback_events": {
-            "$ref": "#/components/schemas/string"
+            "description": "Reserved",
+            "nullable": true,
+            "type": "string"
           },
           "callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "Reserved",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "development_stage": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string describing the state of the assistant.",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "latest_model_build_sid": {
-            "$ref": "#/components/schemas/sid_UG"
+            "description": "Reserved",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of the URLs of the Assistant's related resources",
+            "nullable": true,
+            "type": "object"
           },
           "log_queries": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether queries should be logged and kept after training",
+            "nullable": true,
+            "type": "boolean"
           },
           "needs_model_build": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether model needs to be rebuilt",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Assistant resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -51,16 +92,31 @@
       "autopilot.v1.assistant.defaults": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "The JSON string that describes the default task links",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Defaults resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -68,19 +124,39 @@
       "autopilot.v1.assistant.dialogue": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "The JSON string that describes the dialogue session object",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UK"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Dialogue resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -88,31 +164,61 @@
       "autopilot.v1.assistant.field_type": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of the URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UB"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the FieldType resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -120,34 +226,72 @@
       "autopilot.v1.assistant.field_type.field_value": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the FieldType associated with the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "field_type_sid": {
-            "$ref": "#/components/schemas/sid_UB"
+            "description": "The SID of the Field Type associated with the Field Value",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "language": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO language-country tag that identifies the language of the value",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UC"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "synonym_of": {
-            "$ref": "#/components/schemas/sid_UC"
+            "description": "The word for which the field value is a synonym of",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the FieldValue resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "value": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Field Value data",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -155,34 +299,73 @@
       "autopilot.v1.assistant.model_build": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "build_duration": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The time in seconds it took to build the model",
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/integer"
+            "description": "More information about why the model build failed, if `status` is `failed`",
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UG"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/model_build_status"
+            "description": "The status of the model build process",
+            "enum": [
+              "enqueued",
+              "building",
+              "completed",
+              "failed",
+              "canceled"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the ModelBuild resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -190,46 +373,95 @@
       "autopilot.v1.assistant.query": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "dialogue_sid": {
-            "$ref": "#/components/schemas/sid_UK"
+            "description": "The SID of the [Dialogue](https://www.twilio.com/docs/autopilot/api/dialogue).",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "language": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO language-country string that specifies the language used by the Query",
+            "nullable": true,
+            "type": "string"
           },
           "model_build_sid": {
-            "$ref": "#/components/schemas/sid_UG"
+            "description": "The SID of the [Model Build](https://www.twilio.com/docs/autopilot/api/model-build) queried",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "query": {
-            "$ref": "#/components/schemas/string"
+            "description": "The end-user's natural language input",
+            "nullable": true,
+            "type": "string"
           },
           "results": {
-            "$ref": "#/components/schemas/object"
+            "description": "The natural language analysis results that include the Task recognized and a list of identified Fields",
+            "nullable": true,
+            "type": "object"
           },
           "sample_sid": {
-            "$ref": "#/components/schemas/sid_UF"
+            "description": "The SID of an optional reference to the Sample created from the query",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UH"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "source_channel": {
-            "$ref": "#/components/schemas/string"
+            "description": "The communication channel from where the end-user input came",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/string"
+            "description": "The status of the Query",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Query resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -237,16 +469,31 @@
       "autopilot.v1.assistant.style_sheet": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "The JSON string that describes the style sheet object",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the StyleSheet resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -254,34 +501,67 @@
       "autopilot.v1.assistant.task": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "actions_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL from which the Assistant can fetch actions",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of the URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UD"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Task resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -289,31 +569,64 @@
       "autopilot.v1.assistant.task.field": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the Task associated with the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "field_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Field Type of the field",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_sid": {
-            "$ref": "#/components/schemas/sid_UD"
+            "description": "The SID of the [Task](https://www.twilio.com/docs/autopilot/api/task) resource associated with this Field",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Field resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -321,34 +634,69 @@
       "autopilot.v1.assistant.task.sample": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the Task associated with the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "language": {
-            "$ref": "#/components/schemas/string"
+            "description": "An ISO language-country string that specifies the language used for the sample",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UF"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "source_channel": {
-            "$ref": "#/components/schemas/string"
+            "description": "The communication channel from which the sample was captured",
+            "nullable": true,
+            "type": "string"
           },
           "tagged_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text example of how end users might express the task",
+            "nullable": true,
+            "type": "string"
           },
           "task_sid": {
-            "$ref": "#/components/schemas/sid_UD"
+            "description": "The SID of the Task associated with the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Sample resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -356,19 +704,39 @@
       "autopilot.v1.assistant.task.task_actions": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the Task associated with the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "The JSON string that specifies the actions that instruct the Assistant on how to perform the task",
+            "nullable": true,
+            "type": "object"
           },
           "task_sid": {
-            "$ref": "#/components/schemas/sid_UD"
+            "description": "The SID of the Task associated with the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the TaskActions resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -376,22 +744,44 @@
       "autopilot.v1.assistant.task.task_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the Task associated with the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "fields_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Fields associated with the Task",
+            "nullable": true,
+            "type": "integer"
           },
           "samples_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Samples associated with the Task",
+            "nullable": true,
+            "type": "integer"
           },
           "task_sid": {
-            "$ref": "#/components/schemas/sid_UD"
+            "description": "The SID of the Task for which the statistics were collected",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the TaskStatistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -399,34 +789,67 @@
       "autopilot.v1.assistant.webhook": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assistant_sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The SID of the Assistant that is the parent of the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "events": {
-            "$ref": "#/components/schemas/string"
+            "description": "The list of space-separated events that this Webhook is subscribed to.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UM"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Webhook resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/string"
+            "description": "The method used when calling the webhook's URL.",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL associated with this Webhook.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -434,161 +857,79 @@
       "autopilot.v1.restore_assistant": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "callback_events": {
-            "$ref": "#/components/schemas/string"
+            "description": "Reserved",
+            "nullable": true,
+            "type": "string"
           },
           "callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "Reserved",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "development_stage": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string describing the state of the assistant.",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "latest_model_build_sid": {
-            "$ref": "#/components/schemas/sid_UG"
+            "description": "Reserved",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "log_queries": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether queries should be logged and kept after training",
+            "nullable": true,
+            "type": "boolean"
           },
           "needs_model_build": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether model needs to be rebuilt",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_UA"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^UA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "model_build_status": {
-        "enum": [
-          "enqueued",
-          "building",
-          "completed",
-          "failed",
-          "canceled"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UD": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UD[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UF": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UF[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UG": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UG[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UK": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UK[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_UM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^UM[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_bulkexports_v1.json
+++ b/spec/json/twilio_bulkexports_v1.json
@@ -1,20 +1,23 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
       "bulkexports.v1.export": {
         "properties": {
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs.",
+            "nullable": true,
+            "type": "object"
           },
           "resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -22,19 +25,29 @@
       "bulkexports.v1.export.day": {
         "properties": {
           "create_date": {
-            "$ref": "#/components/schemas/string"
+            "description": "The date when resource is created",
+            "nullable": true,
+            "type": "string"
           },
           "day": {
-            "$ref": "#/components/schemas/string"
+            "description": "The date of the data in the file",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly name specified when creating the job",
+            "nullable": true,
+            "type": "string"
           },
           "resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "nullable": true,
+            "type": "string"
           },
           "size": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Size of the file in bytes",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
@@ -42,7 +55,9 @@
       "bulkexports.v1.export.day-instance": {
         "properties": {
           "redirect_to": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -50,31 +65,52 @@
       "bulkexports.v1.export.export_custom_job": {
         "properties": {
           "details": {
-            "$ref": "#/components/schemas/object"
+            "description": "The details of a job state which is an object that contains a status string, a day count integer, and list of days in the job",
+            "nullable": true,
+            "type": "object"
           },
           "email": {
-            "$ref": "#/components/schemas/string"
+            "description": "The optional email to send the completion notification to",
+            "nullable": true,
+            "type": "string"
           },
           "end_day": {
-            "$ref": "#/components/schemas/string"
+            "description": "The end day for the custom export specified as a string in the format of yyyy-MM-dd. This will be the last day exported. For instance, to export a single day, choose the same day for start and end day. To export the first 4 days of July, you would set the start date to 2020-07-01 and the end date to 2020-07-04. The end date must be the UTC day before yesterday.",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly name specified when creating the job",
+            "nullable": true,
+            "type": "string"
           },
           "job_sid": {
-            "$ref": "#/components/schemas/sid_JS"
+            "description": "The unique job_sid returned when the custom export was created. This can be used to look up the status of the job.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^JS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "nullable": true,
+            "type": "string"
           },
           "start_day": {
-            "$ref": "#/components/schemas/string"
+            "description": "The start day for the custom export specified as a string in the format of yyyy-MM-dd",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/string"
+            "description": "This is the method used to call the webhook",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The optional webhook url called on completion",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -82,34 +118,57 @@
       "bulkexports.v1.export.job": {
         "properties": {
           "details": {
-            "$ref": "#/components/schemas/object"
+            "description": "This is a list of the completed, pending, or errored dates within the export time range, with one entry for each status with more than one day in that status",
+            "nullable": true,
+            "type": "object"
           },
           "email": {
-            "$ref": "#/components/schemas/string"
+            "description": "The optional email to send the completion notification to",
+            "nullable": true,
+            "type": "string"
           },
           "end_day": {
-            "$ref": "#/components/schemas/string"
+            "description": "The end time for the export specified when creating the job",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly name specified when creating the job",
+            "nullable": true,
+            "type": "string"
           },
           "job_sid": {
-            "$ref": "#/components/schemas/sid_JS"
+            "description": "The job_sid returned when the export was created",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^JS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "nullable": true,
+            "type": "string"
           },
           "start_day": {
-            "$ref": "#/components/schemas/string"
+            "description": "The start time for the export specified when creating the job",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/string"
+            "description": "This is the method used to call the webhook",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The optional webhook url called on completion",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -117,50 +176,34 @@
       "bulkexports.v1.export_configuration": {
         "properties": {
           "enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether files are automatically generated",
+            "nullable": true,
+            "type": "boolean"
           },
           "resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/string"
+            "description": "Whether to GET or POST to the webhook url",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "URL targeted at export",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid_JS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^JS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_chat_v1.json
+++ b/spec/json/twilio_chat_v1.json
@@ -1,43 +1,61 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "channel_channel_type": {
-        "enum": [
-          "public",
-          "private"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "chat.v1.credential": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sandbox": {
-            "$ref": "#/components/schemas/string"
+            "description": "[APN only] Whether to send the credential to sandbox APNs",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/credential_push_service"
+            "description": "The type of push-notification service the credential is for",
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Credential resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -45,67 +63,130 @@
       "chat.v1.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "consumption_report_interval": {
-            "$ref": "#/components/schemas/integer"
+            "description": "DEPRECATED",
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "default_channel_creator_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The channel role assigned to a channel creator when they join a new channel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_channel_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The channel role assigned to users when they are added to a channel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_service_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The service role assigned to users when they are added to the service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "limits": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that describes the limits of the service instance",
+            "nullable": true,
+            "type": "object"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The absolute URLs of the Service's Channels, Roles, and Users",
+            "nullable": true,
+            "type": "object"
           },
           "notifications": {
-            "$ref": "#/components/schemas/object"
+            "description": "The notification configuration for the Service instance",
+            "nullable": true,
+            "type": "object"
           },
           "post_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URL for post-event webhooks",
+            "nullable": true,
+            "type": "string"
           },
           "pre_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The webhook URL for pre-event webhooks",
+            "nullable": true,
+            "type": "string"
           },
           "reachability_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Reachability Indicator feature is enabled for this Service instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "read_status_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Message Consumption Horizon feature is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "typing_indicator_timeout": {
-            "$ref": "#/components/schemas/integer"
+            "description": "How long in seconds to wait before assuming the user is no longer typing",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Service resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_filters": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The list of WebHook events that are enabled for this Service instance",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/string"
+            "description": "The HTTP method  to use for both PRE and POST webhooks",
+            "nullable": true,
+            "type": "string"
           },
           "webhooks": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains information about the webhooks configured for this service",
+            "nullable": true,
+            "type": "object"
           }
         },
         "type": "object"
@@ -113,46 +194,90 @@
       "chat.v1.service.channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the User that created the channel",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URLs to access the Members, Messages , Invites and, if it exists, the last Message for the Channel",
+            "nullable": true,
+            "type": "object"
           },
           "members_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of Members in the Channel",
+            "nullable": true,
+            "type": "integer"
           },
           "messages_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of Messages in the Channel",
+            "nullable": true,
+            "type": "integer"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/channel_channel_type"
+            "description": "The visibility of the channel. Can be: `public` or `private`",
+            "enum": [
+              "public",
+              "private"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Channel resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -160,34 +285,72 @@
       "chat.v1.service.channel.invite": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel the new resource belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the User that created the invite",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of the Role assigned to the member",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Invite resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -195,37 +358,78 @@
       "chat.v1.service.channel.member": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Channel for the member",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "last_consumed_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The index of the last Message that the Member has read within the Channel",
+            "nullable": true,
+            "type": "integer"
           },
           "last_consumption_timestamp": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 based timestamp string that represents the date-time of the last Message read event for the Member within the Channel",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of the Role assigned to the member",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Member resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -233,43 +437,87 @@
       "chat.v1.service.channel.message": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The content of the message",
+            "nullable": true,
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Channel the Message resource belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "from": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the message's author",
+            "nullable": true,
+            "type": "string"
           },
           "index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The index of the message within the Channel",
+            "nullable": true,
+            "type": "integer"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IM"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "to": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel that the message was sent to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Message resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "was_edited": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the message has been edited since  it was created",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -277,31 +525,68 @@
       "chat.v1.service.role": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "permissions": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "An array of the permissions the role has been granted",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/role_role_type"
+            "description": "The type of role",
+            "enum": [
+              "channel",
+              "deployment"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Role resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -309,46 +594,89 @@
       "chat.v1.service.user": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "is_notifiable": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the User has a potentially valid Push Notification registration for the Service instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "is_online": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the User is actively connected to the Service instance and online",
+            "nullable": true,
+            "type": "boolean"
           },
           "joined_channels_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of Channels this User is a Member of",
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The absolute URLs of the Channel and Binding resources related to the user",
+            "nullable": true,
+            "type": "object"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of the assigned to the user",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the User resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -356,153 +684,64 @@
       "chat.v1.service.user.user_channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel the resource belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "last_consumed_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The index of the last Message in the Channel the Member has read",
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URLs to access the Members, Messages , Invites and, if it exists, the last Message for the Channel",
+            "nullable": true,
+            "type": "object"
           },
           "member_sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "The SID of the User as a Member in the Channel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/user_channel_channel_status"
+            "description": "The status of the User on the Channel",
+            "enum": [
+              "joined",
+              "invited",
+              "not_participating"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unread_messages_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of unread Messages in the Channel for the User",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
-      },
-      "credential_push_service": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "role_role_type": {
-        "enum": [
-          "channel",
-          "deployment"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IM[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_US": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^US[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "user_channel_channel_status": {
-        "enum": [
-          "joined",
-          "invited",
-          "not_participating"
-        ],
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_chat_v2.json
+++ b/spec/json/twilio_chat_v2.json
@@ -1,52 +1,61 @@
 {
   "components": {
     "schemas": {
-      "binding_binding_type": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "channel_channel_type": {
-        "enum": [
-          "public",
-          "private"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "chat.v2.credential": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sandbox": {
-            "$ref": "#/components/schemas/string"
+            "description": "[APN only] Whether to send the credential to sandbox APNs",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/credential_push_service"
+            "description": "The type of push-notification service the credential is for",
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Credential resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -54,73 +63,140 @@
       "chat.v2.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "consumption_report_interval": {
-            "$ref": "#/components/schemas/integer"
+            "description": "DEPRECATED",
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "default_channel_creator_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The channel role assigned to a channel creator when they join a new channel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_channel_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The channel role assigned to users when they are added to a channel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_service_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The service role assigned to users when they are added to the service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "limits": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that describes the limits of the service instance",
+            "nullable": true,
+            "type": "object"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The absolute URLs of the Service's Channels, Roles, and Users",
+            "nullable": true,
+            "type": "object"
           },
           "media": {
-            "$ref": "#/components/schemas/object"
+            "description": "The properties of the media that the service supports",
+            "nullable": true,
+            "type": "object"
           },
           "notifications": {
-            "$ref": "#/components/schemas/object"
+            "description": "The notification configuration for the Service instance",
+            "nullable": true,
+            "type": "object"
           },
           "post_webhook_retry_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of times calls to the `post_webhook_url` will be retried",
+            "nullable": true,
+            "type": "integer"
           },
           "post_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URL for post-event webhooks",
+            "nullable": true,
+            "type": "string"
           },
           "pre_webhook_retry_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Count of times webhook will be retried in case of timeout or 429/503/504 HTTP responses",
+            "nullable": true,
+            "type": "integer"
           },
           "pre_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The webhook URL for pre-event webhooks",
+            "nullable": true,
+            "type": "string"
           },
           "reachability_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Reachability Indicator feature is enabled for this Service instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "read_status_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Message Consumption Horizon feature is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "typing_indicator_timeout": {
-            "$ref": "#/components/schemas/integer"
+            "description": "How long in seconds to wait before assuming the user is no longer typing",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Service resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_filters": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The list of webhook events that are enabled for this Service instance",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/string"
+            "description": "The HTTP method  to use for both PRE and POST webhooks",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -128,40 +204,87 @@
       "chat.v2.service.binding": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "binding_type": {
-            "$ref": "#/components/schemas/binding_binding_type"
+            "description": "The push technology to use for the binding",
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Credential for the binding",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "endpoint": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique endpoint identifier for the Binding",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The absolute URLs of the Binding's User",
+            "nullable": true,
+            "type": "object"
           },
           "message_types": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The Programmable Chat message types the binding is subscribed to",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the Binding resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Binding resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -169,46 +292,90 @@
       "chat.v2.service.channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the User that created the channel",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URLs to access the Members, Messages , Invites and, if it exists, the last Message for the Channel",
+            "nullable": true,
+            "type": "object"
           },
           "members_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of Members in the Channel",
+            "nullable": true,
+            "type": "integer"
           },
           "messages_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of Messages that have been passed in the Channel",
+            "nullable": true,
+            "type": "integer"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/channel_channel_type"
+            "description": "The visibility of the channel. Can be: `public` or `private`",
+            "enum": [
+              "public",
+              "private"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Channel resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -216,31 +383,64 @@
       "chat.v2.service.channel.channel_webhook": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel the Channel Webhook resource belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "configuration": {
-            "$ref": "#/components/schemas/object"
+            "description": "The JSON string that describes the configuration object for the channel webhook",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the Channel Webhook resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WH"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of webhook",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Channel Webhook resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -248,34 +448,72 @@
       "chat.v2.service.channel.invite": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel the new resource belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the User that created the invite",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of the Role assigned to the member",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Invite resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -283,40 +521,83 @@
       "chat.v2.service.channel.member": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel for the member",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "last_consumed_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The index of the last Message that the Member has read within the Channel",
+            "nullable": true,
+            "type": "integer"
           },
           "last_consumption_timestamp": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 based timestamp string that represents the datetime of the last Message read event for the Member within the Channel",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of the Role assigned to the member",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Member resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -324,52 +605,102 @@
       "chat.v2.service.channel.message": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The content of the message",
+            "nullable": true,
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel the Message resource belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "from": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Identity of the message's author",
+            "nullable": true,
+            "type": "string"
           },
           "index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The index of the message within the Channel",
+            "nullable": true,
+            "type": "integer"
           },
           "last_updated_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Identity of the User who last updated the Message",
+            "nullable": true,
+            "type": "string"
           },
           "media": {
-            "$ref": "#/components/schemas/object"
+            "description": "A Media object that describes the Message's media if attached; otherwise, null",
+            "nullable": true,
+            "type": "object"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IM"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "to": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel that the message was sent to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Message type",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Message resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "was_edited": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the message has been edited since  it was created",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -377,31 +708,68 @@
       "chat.v2.service.role": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "permissions": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "An array of the permissions the role has been granted",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/role_role_type"
+            "description": "The type of role",
+            "enum": [
+              "channel",
+              "deployment"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Role resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -409,46 +777,89 @@
       "chat.v2.service.user": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "is_notifiable": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the User has a potentially valid Push Notification registration for the Service instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "is_online": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the User is actively connected to the Service instance and online",
+            "nullable": true,
+            "type": "boolean"
           },
           "joined_channels_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of Channels the User is a Member of",
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The absolute URLs of the Channel and Binding resources related to the user",
+            "nullable": true,
+            "type": "object"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of the Role assigned to the user",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the User resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -456,40 +867,90 @@
       "chat.v2.service.user.user_binding": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "binding_type": {
-            "$ref": "#/components/schemas/user_binding_binding_type"
+            "description": "The push technology to use for the binding",
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Credential for the binding",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "endpoint": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique endpoint identifier for the User Binding",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "message_types": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The Programmable Chat message types the binding is subscribed to",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the User Binding resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "user_sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "description": "The SID of the User with the binding",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -497,193 +958,87 @@
       "chat.v2.service.user.user_channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The SID of the Channel the resource belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "last_consumed_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The index of the last Message in the Channel the Member has read",
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URLs to access the Members, Messages , Invites and, if it exists, the last Message for the Channel",
+            "nullable": true,
+            "type": "object"
           },
           "member_sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "The SID of the User as a Member in the Channel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "notification_level": {
-            "$ref": "#/components/schemas/user_channel_notification_level"
+            "description": "The push notification level of the User for the Channel",
+            "enum": [
+              "default",
+              "muted"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/user_channel_channel_status"
+            "description": "The status of the User on the Channel",
+            "enum": [
+              "joined",
+              "invited",
+              "not_participating"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unread_messages_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of unread Messages in the Channel for the User",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "user_sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "description": "The SID of the User the User Channel belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "credential_push_service": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "role_role_type": {
-        "enum": [
-          "channel",
-          "deployment"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IM[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_US": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^US[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "user_binding_binding_type": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "user_channel_channel_status": {
-        "enum": [
-          "joined",
-          "invited",
-          "not_participating"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "user_channel_notification_level": {
-        "enum": [
-          "default",
-          "muted"
-        ],
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_conversations_v1.json
+++ b/spec/json/twilio_conversations_v1.json
@@ -1,68 +1,52 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "configuration_webhook_method": {
-        "enum": [
-          "GET",
-          "POST"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "configuration_webhook_target": {
-        "enum": [
-          "webhook",
-          "flex"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "conversation_message_receipt_delivery_status": {
-        "enum": [
-          "read",
-          "failed",
-          "delivered",
-          "undelivered",
-          "sent"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "conversation_state": {
-        "enum": [
-          "inactive",
-          "active",
-          "closed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "conversations.v1.configuration": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account responsible for this configuration.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the default Conversation Service that every new conversation is associated with.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_closed_timer": {
-            "$ref": "#/components/schemas/string"
+            "description": "Default ISO8601 duration when conversation will be switched to `closed` state.",
+            "nullable": true,
+            "type": "string"
           },
           "default_inactive_timer": {
-            "$ref": "#/components/schemas/string"
+            "description": "Default ISO8601 duration when conversation will be switched to `inactive` state.",
+            "nullable": true,
+            "type": "string"
           },
           "default_messaging_service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The SID of the default Messaging Service that every new conversation is associated with.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URLs to access the webhook and default service configurations.",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this global configuration.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -70,25 +54,54 @@
       "conversations.v1.configuration.configuration_webhook": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this conversation.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "filters": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The list of webhook event triggers that are enabled for this Service.",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "method": {
-            "$ref": "#/components/schemas/configuration_webhook_method"
+            "description": "The HTTP method to be used when sending a webhook request.",
+            "enum": [
+              "GET",
+              "POST"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "post_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The absolute url the post-event webhook request should be sent to.",
+            "nullable": true,
+            "type": "string"
           },
           "pre_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The absolute url the pre-event webhook request should be sent to.",
+            "nullable": true,
+            "type": "string"
           },
           "target": {
-            "$ref": "#/components/schemas/configuration_webhook_target"
+            "description": "The routing target of the webhook.",
+            "enum": [
+              "webhook",
+              "flex"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this webhook.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -96,43 +109,89 @@
       "conversations.v1.conversation": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this conversation.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "An optional string metadata field you can use to store any data you wish.",
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The unique ID of the Conversation Service this conversation belongs to.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The human-readable name of this conversation.",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URLs to access the participants, messages and webhooks of this conversation.",
+            "nullable": true,
+            "type": "object"
           },
           "messaging_service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The unique ID of the Messaging Service this conversation belongs to.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "state": {
-            "$ref": "#/components/schemas/conversation_state"
+            "description": "Current state of this conversation.",
+            "enum": [
+              "inactive",
+              "active",
+              "closed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "timers": {
-            "$ref": "#/components/schemas/object"
+            "description": "Timer date values for this conversation.",
+            "nullable": true,
+            "type": "object"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this conversation.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -140,46 +199,92 @@
       "conversations.v1.conversation.conversation_message": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this message.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string metadata field you can use to store any data you wish.",
+            "nullable": true,
+            "type": "string"
           },
           "author": {
-            "$ref": "#/components/schemas/string"
+            "description": "The channel specific identifier of the message's author.",
+            "nullable": true,
+            "type": "string"
           },
           "body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The content of the message.",
+            "nullable": true,
+            "type": "string"
           },
           "conversation_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Conversation for this message.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "delivery": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the summary of delivery statuses for the message to non-chat participants.",
+            "nullable": true,
+            "type": "object"
           },
           "index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The index of the message within the Conversation.",
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URL to access the receipts of this message.",
+            "nullable": true,
+            "type": "object"
           },
           "media": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "An array of objects that describe the Message's media if attached, otherwise, null.",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "The unique ID of messages's author participant.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IM"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute API URL for this message.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -187,37 +292,87 @@
       "conversations.v1.conversation.conversation_message.conversation_message_receipt": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this participant.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_message_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "A messaging channel-specific identifier for the message delivered to participant",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "conversation_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Conversation for this message.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The message [delivery error code](https://www.twilio.com/docs/sms/api/message-resource#delivery-related-errors) for a `failed` status",
+            "nullable": true,
+            "type": "integer"
           },
           "message_sid": {
-            "$ref": "#/components/schemas/sid_IM"
+            "description": "The SID of the message the delivery receipt belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "The unique ID of the participant the delivery receipt belongs to.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_DY"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/conversation_message_receipt_delivery_status"
+            "description": "The message delivery status",
+            "enum": [
+              "read",
+              "failed",
+              "delivered",
+              "undelivered",
+              "sent"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this delivery receipt.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -225,40 +380,79 @@
       "conversations.v1.conversation.conversation_participant": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this participant.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "An optional string metadata field you can use to store any data you wish.",
+            "nullable": true,
+            "type": "string"
           },
           "conversation_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Conversation for this participant.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "A unique string identifier for the conversation participant as Conversation User.",
+            "nullable": true,
+            "type": "string"
           },
           "last_read_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Index of last \u201cread\u201d message in the Conversation for the Participant.",
+            "nullable": true,
+            "type": "integer"
           },
           "last_read_timestamp": {
-            "$ref": "#/components/schemas/string"
+            "description": "Timestamp of last \u201cread\u201d message in the Conversation for the Participant.",
+            "nullable": true,
+            "type": "string"
           },
           "messaging_binding": {
-            "$ref": "#/components/schemas/object"
+            "description": "Information about how this participant exchanges messages with the conversation.",
+            "nullable": true,
+            "type": "object"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of a conversation-level Role to assign to the participant",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this participant.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -266,28 +460,56 @@
       "conversations.v1.conversation.conversation_scoped_webhook": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this conversation.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "configuration": {
-            "$ref": "#/components/schemas/object"
+            "description": "The configuration of this webhook.",
+            "nullable": true,
+            "type": "object"
           },
           "conversation_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Conversation for this webhook.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WH"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "target": {
-            "$ref": "#/components/schemas/string"
+            "description": "The target of this webhook.",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this webhook.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -295,28 +517,58 @@
       "conversations.v1.credential": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this credential.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The human-readable name of this credential.",
+            "nullable": true,
+            "type": "string"
           },
           "sandbox": {
-            "$ref": "#/components/schemas/string"
+            "description": "[APN only] Whether to send the credential to sandbox APNs.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/credential_push_type"
+            "description": "The type of push-notification service the credential is for.",
+            "enum": [
+              "apn",
+              "gcm",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this credential.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -324,31 +576,68 @@
       "conversations.v1.role": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "permissions": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "An array of the permissions the role has been granted",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/role_role_type"
+            "description": "The type of role",
+            "enum": [
+              "conversation",
+              "service"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this user role.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -356,25 +645,48 @@
       "conversations.v1.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this service.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The human-readable name of this service.",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URLs to access the conversations, users, roles, bindings and configuration of this service.",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this service.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -382,37 +694,82 @@
       "conversations.v1.service.service_binding": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this binding.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "binding_type": {
-            "$ref": "#/components/schemas/service_binding_binding_type"
+            "description": "The push technology to use for the binding.",
+            "enum": [
+              "apn",
+              "gcm",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Credential for the binding.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "endpoint": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique endpoint identifier for the Binding.",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of Conversation User associated with this binding.",
+            "nullable": true,
+            "type": "string"
           },
           "message_types": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The Conversation message types the binding is subscribed to.",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BS"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this binding.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -420,25 +777,52 @@
       "conversations.v1.service.service_configuration": {
         "properties": {
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_chat_service_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The service role assigned to users when they are added to the service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_conversation_creator_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The role assigned to a conversation creator user when they join a new conversation",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_conversation_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The role assigned to users when they are added to a conversation",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URL to access the push notifications configuration of this service.",
+            "nullable": true,
+            "type": "object"
           },
           "reachability_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Reachability Indicator feature is enabled for this Conversations Service",
+            "nullable": true,
+            "type": "boolean"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this service configuration.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -446,25 +830,46 @@
       "conversations.v1.service.service_configuration.service_notification": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this configuration.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "added_to_conversation": {
-            "$ref": "#/components/schemas/object"
+            "description": "The Push Notification configuration for being added to a Conversation.",
+            "nullable": true,
+            "type": "object"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the Configuration applies to.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "log_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Weather the notification logging is enabled.",
+            "nullable": true,
+            "type": "boolean"
           },
           "new_message": {
-            "$ref": "#/components/schemas/object"
+            "description": "The Push Notification configuration for New Messages.",
+            "nullable": true,
+            "type": "object"
           },
           "removed_from_conversation": {
-            "$ref": "#/components/schemas/object"
+            "description": "The Push Notification configuration for being removed from a Conversation.",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this configuration.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -472,43 +877,89 @@
       "conversations.v1.service.service_conversation": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this conversation.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "An optional string metadata field you can use to store any data you wish.",
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The unique ID of the Conversation Service this conversation belongs to.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The human-readable name of this conversation.",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URLs to access the participants, messages and webhooks of this conversation.",
+            "nullable": true,
+            "type": "object"
           },
           "messaging_service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The unique ID of the Messaging Service this conversation belongs to.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "state": {
-            "$ref": "#/components/schemas/service_conversation_state"
+            "description": "Current state of this conversation.",
+            "enum": [
+              "inactive",
+              "active",
+              "closed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "timers": {
-            "$ref": "#/components/schemas/object"
+            "description": "Timer date values for this conversation.",
+            "nullable": true,
+            "type": "object"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this conversation.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -516,49 +967,100 @@
       "conversations.v1.service.service_conversation.service_conversation_message": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this message.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string metadata field you can use to store any data you wish.",
+            "nullable": true,
+            "type": "string"
           },
           "author": {
-            "$ref": "#/components/schemas/string"
+            "description": "The channel specific identifier of the message's author.",
+            "nullable": true,
+            "type": "string"
           },
           "body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The content of the message.",
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "conversation_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Conversation for this message.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "delivery": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the summary of delivery statuses for the message to non-chat participants.",
+            "nullable": true,
+            "type": "object"
           },
           "index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The index of the message within the Conversation.",
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Absolute URL to access the receipts of this message.",
+            "nullable": true,
+            "type": "object"
           },
           "media": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "An array of objects that describe the Message's media if attached, otherwise, null.",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "The unique ID of messages's author participant.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IM"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this message.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -566,40 +1068,95 @@
       "conversations.v1.service.service_conversation.service_conversation_message.service_conversation_message_receipt": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this participant.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_message_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "A messaging channel-specific identifier for the message delivered to participant",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "conversation_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Conversation for this message.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The message [delivery error code](https://www.twilio.com/docs/sms/api/message-resource#delivery-related-errors) for a `failed` status",
+            "nullable": true,
+            "type": "integer"
           },
           "message_sid": {
-            "$ref": "#/components/schemas/sid_IM"
+            "description": "The SID of the message the delivery receipt belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "The unique ID of the participant the delivery receipt belongs to.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_DY"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/service_conversation_message_receipt_delivery_status"
+            "description": "The message delivery status",
+            "enum": [
+              "read",
+              "failed",
+              "delivered",
+              "undelivered",
+              "sent"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this delivery receipt.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -607,43 +1164,87 @@
       "conversations.v1.service.service_conversation.service_conversation_participant": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this participant.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "An optional string metadata field you can use to store any data you wish.",
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "conversation_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Conversation for this participant.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "A unique string identifier for the conversation participant as Conversation User.",
+            "nullable": true,
+            "type": "string"
           },
           "last_read_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Index of last \u201cread\u201d message in the Conversation for the Participant.",
+            "nullable": true,
+            "type": "integer"
           },
           "last_read_timestamp": {
-            "$ref": "#/components/schemas/string"
+            "description": "Timestamp of last \u201cread\u201d message in the Conversation for the Participant.",
+            "nullable": true,
+            "type": "string"
           },
           "messaging_binding": {
-            "$ref": "#/components/schemas/object"
+            "description": "Information about how this participant exchanges messages with the conversation.",
+            "nullable": true,
+            "type": "object"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of a conversation-level Role to assign to the participant",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this participant.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -651,31 +1252,64 @@
       "conversations.v1.service.service_conversation.service_conversation_scoped_webhook": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The unique ID of the Account responsible for this conversation.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "configuration": {
-            "$ref": "#/components/schemas/object"
+            "description": "The configuration of this webhook.",
+            "nullable": true,
+            "type": "object"
           },
           "conversation_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique ID of the Conversation for this webhook.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that this resource was last updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WH"
+            "description": "A 34 character string that uniquely identifies this resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "target": {
-            "$ref": "#/components/schemas/string"
+            "description": "The target of this webhook.",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this webhook.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -683,31 +1317,68 @@
       "conversations.v1.service.service_role": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "permissions": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "An array of the permissions the role has been granted",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/service_role_role_type"
+            "description": "The type of role",
+            "enum": [
+              "conversation",
+              "service"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this user role.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -715,40 +1386,79 @@
       "conversations.v1.service.service_user": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON Object string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "is_notifiable": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the User has a potentially valid Push Notification registration for this Conversations Service",
+            "nullable": true,
+            "type": "boolean"
           },
           "is_online": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the User is actively connected to this Conversations Service and online",
+            "nullable": true,
+            "type": "boolean"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of a service-level Role assigned to the user",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this user.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -756,228 +1466,82 @@
       "conversations.v1.user": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON Object string that stores application-specific data",
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Conversation Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "is_notifiable": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the User has a potentially valid Push Notification registration for this Conversations Service",
+            "nullable": true,
+            "type": "boolean"
           },
           "is_online": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the User is actively connected to this Conversations Service and online",
+            "nullable": true,
+            "type": "boolean"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "description": "The SID of a service-level Role assigned to the user",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "An absolute URL for this user.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "credential_push_type": {
-        "enum": [
-          "apn",
-          "gcm",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "role_role_type": {
-        "enum": [
-          "conversation",
-          "service"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "service_binding_binding_type": {
-        "enum": [
-          "apn",
-          "gcm",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "service_conversation_message_receipt_delivery_status": {
-        "enum": [
-          "read",
-          "failed",
-          "delivered",
-          "undelivered",
-          "sent"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "service_conversation_state": {
-        "enum": [
-          "inactive",
-          "active",
-          "closed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "service_role_role_type": {
-        "enum": [
-          "conversation",
-          "service"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_DY": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^DY[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IM[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MG": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MG[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_US": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^US[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_events_v1.json
+++ b/spec/json/twilio_events_v1.json
@@ -1,33 +1,44 @@
 {
   "components": {
     "schemas": {
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
       "events.v1.event_type": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Event Type was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Event Type was updated.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "Event Type description.",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "schema_id": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Schema identifier for this Event Type.",
+            "nullable": true,
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Event Type identifier.",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -35,19 +46,31 @@
       "events.v1.schema": {
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/string"
+            "description": "Schema Identifier.",
+            "nullable": true,
+            "type": "string"
           },
           "last_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that the last schema version was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "last_version": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Last schema version.",
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs.",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -55,19 +78,31 @@
       "events.v1.schema.version": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date the schema version was created.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "id": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique identifier of the schema.",
+            "nullable": true,
+            "type": "string"
           },
           "raw": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "schema_version": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The version of this schema.",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -75,31 +110,65 @@
       "events.v1.sink": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Sink was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Sink was updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "Sink Description",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs.",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_DG"
+            "description": "A string that uniquely identifies this Sink.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sink_configuration": {
-            "$ref": "#/components/schemas/object"
+            "description": "JSON Sink configuration.",
+            "nullable": true,
+            "type": "object"
           },
           "sink_type": {
-            "$ref": "#/components/schemas/sink_sink_type"
+            "description": "Sink type.",
+            "enum": [
+              "kinesis",
+              "webhook"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/sink_status"
+            "description": "The Status of this Sink",
+            "enum": [
+              "initialized",
+              "validating",
+              "active",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -107,7 +176,9 @@
       "events.v1.sink.sink_test": {
         "properties": {
           "result": {
-            "$ref": "#/components/schemas/string"
+            "description": "Feedback indicating whether the test event was generated.",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -115,7 +186,9 @@
       "events.v1.sink.sink_validate": {
         "properties": {
           "result": {
-            "$ref": "#/components/schemas/string"
+            "description": "Feedback indicating whether the given Sink was validated.",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -123,28 +196,56 @@
       "events.v1.subscription": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "Account SID.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Subscription was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Subscription was updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "Subscription description",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs.",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_DF"
+            "description": "A string that uniquely identifies this Subscription.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sink_sid": {
-            "$ref": "#/components/schemas/sid_DG"
+            "description": "Sink SID.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -152,82 +253,39 @@
       "events.v1.subscription.subscribed_event": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "Account SID.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "subscription_sid": {
-            "$ref": "#/components/schemas/sid_DF"
+            "description": "Subscription SID.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "Type of event being subscribed to.",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "version": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The schema version that the subscription should use.",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_DF": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^DF[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_DG": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^DG[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sink_sink_type": {
-        "enum": [
-          "kinesis",
-          "webhook"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sink_status": {
-        "enum": [
-          "initialized",
-          "validating",
-          "active",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_fax_v1.json
+++ b/spec/json/twilio_fax_v1.json
@@ -1,74 +1,130 @@
 {
   "components": {
     "schemas": {
-      "currency": {
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "decimal": {
-        "nullable": true,
-        "type": "number"
-      },
       "fax.v1.fax": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to transmit the fax",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 formatted date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 formatted date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "direction": {
-            "$ref": "#/components/schemas/fax_direction"
+            "description": "The direction of the fax",
+            "enum": [
+              "inbound",
+              "outbound"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The time it took to transmit the fax",
+            "nullable": true,
+            "type": "integer"
           },
           "from": {
-            "$ref": "#/components/schemas/string"
+            "description": "The number the fax was sent from",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the fax's related resources",
+            "nullable": true,
+            "type": "object"
           },
           "media_sid": {
-            "$ref": "#/components/schemas/sid_ME"
+            "description": "The SID of the FaxMedia resource that is associated with the Fax",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ME[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "media_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Twilio-hosted URL that can be used to download fax media",
+            "nullable": true,
+            "type": "string"
           },
           "num_pages": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of pages contained in the fax document",
+            "nullable": true,
+            "type": "integer"
           },
           "price": {
-            "$ref": "#/components/schemas/decimal"
+            "description": "The fax transmission price",
+            "nullable": true,
+            "type": "number"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The ISO 4217 currency used for billing",
+            "nullable": true,
+            "type": "string"
           },
           "quality": {
-            "$ref": "#/components/schemas/fax_quality"
+            "description": "The quality of the fax",
+            "enum": [
+              "standard",
+              "fine",
+              "superfine"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FX"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FX[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/fax_status"
+            "description": "The status of the fax",
+            "enum": [
+              "queued",
+              "processing",
+              "sending",
+              "delivered",
+              "receiving",
+              "received",
+              "no-answer",
+              "busy",
+              "failed",
+              "canceled"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "to": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number that received the fax",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the fax resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -76,99 +132,54 @@
       "fax.v1.fax.fax_media": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "content_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The content type of the stored fax media",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "fax_sid": {
-            "$ref": "#/components/schemas/sid_FX"
+            "description": "The SID of the fax the FaxMedia resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FX[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ME"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ME[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the FaxMedia resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "fax_direction": {
-        "enum": [
-          "inbound",
-          "outbound"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "fax_quality": {
-        "enum": [
-          "standard",
-          "fine",
-          "superfine"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "fax_status": {
-        "enum": [
-          "queued",
-          "processing",
-          "sending",
-          "delivered",
-          "receiving",
-          "received",
-          "no-answer",
-          "busy",
-          "failed",
-          "canceled"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FX": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FX[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ME": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ME[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_flex_v1.json
+++ b/spec/json/twilio_flex_v1.json
@@ -1,49 +1,65 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "configuration_status": {
-        "enum": [
-          "ok",
-          "inprogress",
-          "notstarted"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
       "flex.v1.channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource and owns this Workflow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Flex chat channel was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Flex chat channel was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "flex_flow_sid": {
-            "$ref": "#/components/schemas/sid_FO"
+            "description": "The SID of the Flex Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_sid": {
-            "$ref": "#/components/schemas/sid_WT"
+            "description": "The SID of the TaskRouter Task",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Flex chat channel resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "user_sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "description": "The SID of the chat user",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -51,121 +67,250 @@
       "flex.v1.configuration": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains application-specific data",
+            "nullable": true,
+            "type": "object"
           },
           "call_recording_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether call recording is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "call_recording_webhook_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The call recording webhook URL",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_instance_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the chat service this user belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "crm_attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the CRM attributes",
+            "nullable": true,
+            "type": "object"
           },
           "crm_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The CRM Callback URL",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "crm_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether CRM is present for Flex",
+            "nullable": true,
+            "type": "boolean"
           },
           "crm_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The CRM Fallback URL",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "crm_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The CRM Type",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Configuration resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Configuration resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "flex_service_instance_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Flex service instance",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "integrations": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "A list of objects that contain the configurations for the Integrations supported in this configuration",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "markdown": {
-            "$ref": "#/components/schemas/object"
+            "description": "Configurable parameters for Markdown",
+            "nullable": true,
+            "type": "object"
           },
           "messaging_service_instance_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The SID of the Messaging service instance",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "notifications": {
-            "$ref": "#/components/schemas/object"
+            "description": "Configurable parameters for Notifications",
+            "nullable": true,
+            "type": "object"
           },
           "outbound_call_flows": {
-            "$ref": "#/components/schemas/object"
+            "description": "The list of outbound call flows",
+            "nullable": true,
+            "type": "object"
           },
           "plugin_service_attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "The plugin service attributes",
+            "nullable": true,
+            "type": "object"
           },
           "plugin_service_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the plugin service enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "public_attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "The list of public attributes",
+            "nullable": true,
+            "type": "object"
           },
           "queue_stats_configuration": {
-            "$ref": "#/components/schemas/object"
+            "description": "Configurable parameters for Queues Statistics",
+            "nullable": true,
+            "type": "object"
           },
           "runtime_domain": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL where the Flex instance is hosted",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "serverless_service_sids": {
-            "$ref": "#/components/schemas/sid_ZS_list"
+            "description": "The list of serverless service SIDs",
+            "items": {
+              "maxLength": 34,
+              "minLength": 34,
+              "pattern": "^ZS[0-9a-fA-F]{32}$",
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Flex Service version",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/configuration_status"
+            "description": "The status of the Flex onboarding",
+            "enum": [
+              "ok",
+              "inprogress",
+              "notstarted"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "taskrouter_offline_activity_sid": {
-            "$ref": "#/components/schemas/sid_WA"
+            "description": "The TaskRouter SID of the offline activity",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "taskrouter_skills": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The Skill description for TaskRouter workers",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "taskrouter_target_taskqueue_sid": {
-            "$ref": "#/components/schemas/sid_WQ"
+            "description": "The SID of the TaskRouter Target TaskQueue",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WQ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "taskrouter_target_workflow_sid": {
-            "$ref": "#/components/schemas/sid_WW"
+            "description": "The SID of the TaskRouter target Workflow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "taskrouter_taskqueues": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The list of TaskRouter TaskQueues",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "taskrouter_worker_attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "The TaskRouter Worker attributes",
+            "nullable": true,
+            "type": "object"
           },
           "taskrouter_worker_channels": {
-            "$ref": "#/components/schemas/object"
+            "description": "The TaskRouter default channel capacities and availability for workers",
+            "nullable": true,
+            "type": "object"
           },
           "taskrouter_workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the TaskRouter Workspace",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "ui_attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "The object that describes Flex UI characteristics and settings",
+            "nullable": true,
+            "type": "object"
           },
           "ui_dependencies": {
-            "$ref": "#/components/schemas/object"
+            "description": "The object that defines the NPM packages and versions to be used in Hosted Flex",
+            "nullable": true,
+            "type": "object"
           },
           "ui_language": {
-            "$ref": "#/components/schemas/string"
+            "description": "The primary language of the Flex UI",
+            "nullable": true,
+            "type": "string"
           },
           "ui_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Pinned UI version",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Configuration resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -173,46 +318,99 @@
       "flex.v1.flex_flow": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_type": {
-            "$ref": "#/components/schemas/flex_flow_channel_type"
+            "description": "The channel type",
+            "enum": [
+              "web",
+              "sms",
+              "facebook",
+              "whatsapp",
+              "line",
+              "custom"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "chat_service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the chat service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "contact_identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The channel contact's Identity",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Flex Flow is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "integration": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains specific parameters for the integration",
+            "nullable": true,
+            "type": "object"
           },
           "integration_type": {
-            "$ref": "#/components/schemas/flex_flow_integration_type"
+            "description": "The integration type",
+            "enum": [
+              "studio",
+              "external",
+              "task"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "janitor_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Remove active Proxy sessions if the corresponding Task is deleted.",
+            "nullable": true,
+            "type": "boolean"
           },
           "long_lived": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Re-use this chat channel for future interactions with a contact",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Flex Flow resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -220,153 +418,49 @@
       "flex.v1.web_channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource and owns this Workflow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "flex_flow_sid": {
-            "$ref": "#/components/schemas/sid_FO"
+            "description": "The SID of the Flex Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "description": "The unique string that identifies the WebChannel resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the WebChannel resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "flex_flow_channel_type": {
-        "enum": [
-          "web",
-          "sms",
-          "facebook",
-          "whatsapp",
-          "line",
-          "custom"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "flex_flow_integration_type": {
-        "enum": [
-          "studio",
-          "external",
-          "task"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FO": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FO[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MG": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MG[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_US": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^US[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WQ": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WQ[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WW": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WW[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ZS_list": {
-        "items": {
-          "maxLength": 34,
-          "minLength": 34,
-          "pattern": "^ZS[0-9a-fA-F]{32}$",
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_insights_v1.json
+++ b/spec/json/twilio_insights_v1.json
@@ -1,59 +1,23 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "event_level": {
-        "enum": [
-          "UNKNOWN",
-          "DEBUG",
-          "INFO",
-          "WARNING",
-          "ERROR"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "event_twilio_edge": {
-        "enum": [
-          "unknown_edge",
-          "carrier_edge",
-          "sip_edge",
-          "sdk_edge",
-          "client_edge"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "insights.v1.call": {
         "properties": {
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -61,37 +25,68 @@
       "insights.v1.call.event": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "carrier_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "client_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "edge": {
-            "$ref": "#/components/schemas/event_twilio_edge"
+            "enum": [
+              "unknown_edge",
+              "carrier_edge",
+              "sip_edge",
+              "sdk_edge",
+              "client_edge"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "group": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "level": {
-            "$ref": "#/components/schemas/event_level"
+            "enum": [
+              "UNKNOWN",
+              "DEBUG",
+              "INFO",
+              "WARNING",
+              "ERROR"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "sdk_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "sip_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "timestamp": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -99,31 +94,59 @@
       "insights.v1.call.metric": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "carrier_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "client_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "direction": {
-            "$ref": "#/components/schemas/metric_stream_direction"
+            "enum": [
+              "unknown",
+              "inbound",
+              "outbound",
+              "both"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "edge": {
-            "$ref": "#/components/schemas/metric_twilio_edge"
+            "enum": [
+              "unknown_edge",
+              "carrier_edge",
+              "sip_edge",
+              "sdk_edge",
+              "client_edge"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sdk_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "sip_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "timestamp": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -131,67 +154,121 @@
       "insights.v1.call.summary": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "call_sid": {
-            "$ref": "#/components/schemas/sid_CA"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "call_state": {
-            "$ref": "#/components/schemas/summary_call_state"
+            "enum": [
+              "ringing",
+              "completed",
+              "busy",
+              "fail",
+              "noanswer",
+              "canceled",
+              "answered",
+              "undialed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "call_type": {
-            "$ref": "#/components/schemas/summary_call_type"
+            "enum": [
+              "carrier",
+              "sip",
+              "trunking",
+              "client"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "carrier_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "client_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "connect_duration": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "created_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "from": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "processing_state": {
-            "$ref": "#/components/schemas/summary_processing_state"
+            "enum": [
+              "complete",
+              "partial"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "properties": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "sdk_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "sip_edge": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "tags": {
-            "$ref": "#/components/schemas/string_list"
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "to": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "trust": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -199,82 +276,180 @@
       "insights.v1.video_room_summary": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "codecs": {
-            "$ref": "#/components/schemas/video_room_summary_codec_list"
+            "items": {
+              "enum": [
+                "VP8",
+                "H264",
+                "VP9"
+              ],
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "concurrent_participants": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "create_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "created_method": {
-            "$ref": "#/components/schemas/video_room_summary_created_method"
+            "enum": [
+              "sdk",
+              "ad_hoc",
+              "api"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "duration_sec": {
-            "$ref": "#/components/schemas/long"
+            "nullable": true,
+            "type": "integer"
           },
           "edge_location": {
-            "$ref": "#/components/schemas/video_room_summary_edge_location"
+            "enum": [
+              "ashburn",
+              "dublin",
+              "frankfurt",
+              "singapore",
+              "sydney",
+              "sao_paulo",
+              "roaming",
+              "umatilla",
+              "tokyo"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "end_reason": {
-            "$ref": "#/components/schemas/video_room_summary_end_reason"
+            "enum": [
+              "room_ended_via_api",
+              "timeout"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "max_concurrent_participants": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "max_participants": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "media_region": {
-            "$ref": "#/components/schemas/video_room_summary_twilio_realm"
+            "enum": [
+              "us1",
+              "us2",
+              "au1",
+              "br1",
+              "ie1",
+              "jp1",
+              "sg1",
+              "in1",
+              "de1",
+              "gll"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "processing_state": {
-            "$ref": "#/components/schemas/video_room_summary_processing_state"
+            "enum": [
+              "complete",
+              "in_progress"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "recording_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "room_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "room_status": {
-            "$ref": "#/components/schemas/video_room_summary_room_status"
+            "enum": [
+              "in_progress",
+              "completed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "room_type": {
-            "$ref": "#/components/schemas/video_room_summary_room_type"
+            "enum": [
+              "go",
+              "peer_to_peer",
+              "group",
+              "group_small"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "total_participant_duration_sec": {
-            "$ref": "#/components/schemas/long"
+            "nullable": true,
+            "type": "integer"
           },
           "total_recording_duration_sec": {
-            "$ref": "#/components/schemas/long"
+            "nullable": true,
+            "type": "integer"
           },
           "unique_participant_identities": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "unique_participants": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -282,308 +457,122 @@
       "insights.v1.video_room_summary.video_participant_summary": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "codecs": {
-            "$ref": "#/components/schemas/video_participant_summary_codec_list"
+            "items": {
+              "enum": [
+                "VP8",
+                "H264",
+                "VP9"
+              ],
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "duration_sec": {
-            "$ref": "#/components/schemas/long"
+            "nullable": true,
+            "type": "integer"
           },
           "edge_location": {
-            "$ref": "#/components/schemas/video_participant_summary_edge_location"
+            "enum": [
+              "ashburn",
+              "dublin",
+              "frankfurt",
+              "singapore",
+              "sydney",
+              "sao_paulo",
+              "roaming",
+              "umatilla",
+              "tokyo"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "end_reason": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "error_code_url": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "join_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "leave_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "media_region": {
-            "$ref": "#/components/schemas/video_participant_summary_twilio_realm"
+            "enum": [
+              "us1",
+              "us2",
+              "au1",
+              "br1",
+              "ie1",
+              "jp1",
+              "sg1",
+              "in1",
+              "de1",
+              "gll"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "participant_identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_PA"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "properties": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "publisher_info": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/video_participant_summary_room_status"
+            "enum": [
+              "in_progress",
+              "completed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "long": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "metric_stream_direction": {
-        "enum": [
-          "unknown",
-          "inbound",
-          "outbound",
-          "both"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "metric_twilio_edge": {
-        "enum": [
-          "unknown_edge",
-          "carrier_edge",
-          "sip_edge",
-          "sdk_edge",
-          "client_edge"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_PA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^PA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RM[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "summary_call_state": {
-        "enum": [
-          "ringing",
-          "completed",
-          "busy",
-          "fail",
-          "noanswer",
-          "canceled",
-          "answered",
-          "undialed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "summary_call_type": {
-        "enum": [
-          "carrier",
-          "sip",
-          "trunking",
-          "client"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "summary_processing_state": {
-        "enum": [
-          "complete",
-          "partial"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "video_participant_summary_codec_list": {
-        "items": {
-          "enum": [
-            "VP8",
-            "H264",
-            "VP9"
-          ],
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "video_participant_summary_edge_location": {
-        "enum": [
-          "ashburn",
-          "dublin",
-          "frankfurt",
-          "singapore",
-          "sydney",
-          "sao_paulo",
-          "roaming",
-          "umatilla",
-          "tokyo"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_participant_summary_room_status": {
-        "enum": [
-          "in_progress",
-          "completed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_participant_summary_twilio_realm": {
-        "enum": [
-          "us1",
-          "us2",
-          "au1",
-          "br1",
-          "ie1",
-          "jp1",
-          "sg1",
-          "in1",
-          "de1",
-          "gll"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_room_summary_codec_list": {
-        "items": {
-          "enum": [
-            "VP8",
-            "H264",
-            "VP9"
-          ],
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "video_room_summary_created_method": {
-        "enum": [
-          "sdk",
-          "ad_hoc",
-          "api"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_room_summary_edge_location": {
-        "enum": [
-          "ashburn",
-          "dublin",
-          "frankfurt",
-          "singapore",
-          "sydney",
-          "sao_paulo",
-          "roaming",
-          "umatilla",
-          "tokyo"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_room_summary_end_reason": {
-        "enum": [
-          "room_ended_via_api",
-          "timeout"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_room_summary_processing_state": {
-        "enum": [
-          "complete",
-          "in_progress"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_room_summary_room_status": {
-        "enum": [
-          "in_progress",
-          "completed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_room_summary_room_type": {
-        "enum": [
-          "go",
-          "peer_to_peer",
-          "group",
-          "group_small"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "video_room_summary_twilio_realm": {
-        "enum": [
-          "us1",
-          "us2",
-          "au1",
-          "br1",
-          "ie1",
-          "jp1",
-          "sg1",
-          "in1",
-          "de1",
-          "gll"
-        ],
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_ip_messaging_v1.json
+++ b/spec/json/twilio_ip_messaging_v1.json
@@ -1,61 +1,53 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "channel_channel_type": {
-        "enum": [
-          "public",
-          "private"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "credential_push_service": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
       "ip_messaging.v1.credential": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "sandbox": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/credential_push_service"
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -63,67 +55,109 @@
       "ip_messaging.v1.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "consumption_report_interval": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "default_channel_creator_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_channel_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_service_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "limits": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "notifications": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "post_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "pre_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "reachability_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "read_status_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "typing_indicator_timeout": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_filters": {
-            "$ref": "#/components/schemas/string_list"
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "webhooks": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           }
         },
         "type": "object"
@@ -131,46 +165,76 @@
       "ip_messaging.v1.service.channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "members_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "messages_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/channel_channel_type"
+            "enum": [
+              "public",
+              "private"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -178,34 +242,62 @@
       "ip_messaging.v1.service.channel.invite": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IN"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -213,37 +305,67 @@
       "ip_messaging.v1.service.channel.member": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "last_consumed_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "last_consumption_timestamp": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -251,43 +373,74 @@
       "ip_messaging.v1.service.channel.message": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "body": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "from": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "index": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IM"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "to": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "was_edited": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -295,31 +448,59 @@
       "ip_messaging.v1.service.role": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "permissions": {
-            "$ref": "#/components/schemas/string_list"
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/role_role_type"
+            "enum": [
+              "channel",
+              "deployment"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -327,46 +508,75 @@
       "ip_messaging.v1.service.user": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "is_notifiable": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "is_online": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "joined_channels_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -374,135 +584,56 @@
       "ip_messaging.v1.service.user.user_channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "last_consumed_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "member_sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/user_channel_channel_status"
+            "enum": [
+              "joined",
+              "invited",
+              "not_participating"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unread_messages_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "role_role_type": {
-        "enum": [
-          "channel",
-          "deployment"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IM[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_US": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^US[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "user_channel_channel_status": {
-        "enum": [
-          "joined",
-          "invited",
-          "not_participating"
-        ],
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_ip_messaging_v2.json
+++ b/spec/json/twilio_ip_messaging_v2.json
@@ -1,70 +1,53 @@
 {
   "components": {
     "schemas": {
-      "binding_binding_type": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "channel_channel_type": {
-        "enum": [
-          "public",
-          "private"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "credential_push_service": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
       "ip_messaging.v2.credential": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "sandbox": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/credential_push_service"
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -72,73 +55,117 @@
       "ip_messaging.v2.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "consumption_report_interval": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "default_channel_creator_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_channel_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "default_service_role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "limits": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "media": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "notifications": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "post_webhook_retry_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "post_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "pre_webhook_retry_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "pre_webhook_url": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "reachability_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "read_status_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "typing_indicator_timeout": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_filters": {
-            "$ref": "#/components/schemas/string_list"
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -146,40 +173,75 @@
       "ip_messaging.v2.service.binding": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "binding_type": {
-            "$ref": "#/components/schemas/binding_binding_type"
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "endpoint": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "message_types": {
-            "$ref": "#/components/schemas/string_list"
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -187,46 +249,76 @@
       "ip_messaging.v2.service.channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "members_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "messages_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/channel_channel_type"
+            "enum": [
+              "public",
+              "private"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -234,31 +326,55 @@
       "ip_messaging.v2.service.channel.channel_webhook": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "configuration": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -266,34 +382,62 @@
       "ip_messaging.v2.service.channel.invite": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IN"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -301,40 +445,71 @@
       "ip_messaging.v2.service.channel.member": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "last_consumed_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "last_consumption_timestamp": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -342,52 +517,86 @@
       "ip_messaging.v2.service.channel.message": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "body": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "from": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "index": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "last_updated_by": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "media": {
-            "$ref": "#/components/schemas/object"
+            "nullable": true,
+            "type": "object"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IM"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "to": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "was_edited": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -395,31 +604,59 @@
       "ip_messaging.v2.service.role": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "permissions": {
-            "$ref": "#/components/schemas/string_list"
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/role_role_type"
+            "enum": [
+              "channel",
+              "deployment"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -427,46 +664,75 @@
       "ip_messaging.v2.service.user": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "is_notifiable": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "is_online": {
-            "$ref": "#/components/schemas/boolean"
+            "nullable": true,
+            "type": "boolean"
           },
           "joined_channels_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "role_sid": {
-            "$ref": "#/components/schemas/sid_RL"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -474,40 +740,78 @@
       "ip_messaging.v2.service.user.user_binding": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "binding_type": {
-            "$ref": "#/components/schemas/user_binding_binding_type"
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "endpoint": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "message_types": {
-            "$ref": "#/components/schemas/string_list"
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "user_sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -515,175 +819,76 @@
       "ip_messaging.v2.service.user.user_channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_sid": {
-            "$ref": "#/components/schemas/sid_CH"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "last_consumed_message_index": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "member_sid": {
-            "$ref": "#/components/schemas/sid_MB"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "notification_level": {
-            "$ref": "#/components/schemas/user_channel_notification_level"
+            "enum": [
+              "default",
+              "muted"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/user_channel_channel_status"
+            "enum": [
+              "joined",
+              "invited",
+              "not_participating"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unread_messages_count": {
-            "$ref": "#/components/schemas/integer"
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "user_sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "role_role_type": {
-        "enum": [
-          "channel",
-          "deployment"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IM[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_US": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^US[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "user_binding_binding_type": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "user_channel_channel_status": {
-        "enum": [
-          "joined",
-          "invited",
-          "not_participating"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "user_channel_notification_level": {
-        "enum": [
-          "default",
-          "muted"
-        ],
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_lookups_v1.json
+++ b/spec/json/twilio_lookups_v1.json
@@ -4,45 +4,43 @@
       "lookups.v1.phone_number": {
         "properties": {
           "add_ons": {
-            "$ref": "#/components/schemas/object"
+            "description": "A JSON string with the results of the Add-ons you specified",
+            "nullable": true,
+            "type": "object"
           },
           "caller_name": {
-            "$ref": "#/components/schemas/object"
+            "description": "The name of the phone number's owner",
+            "nullable": true,
+            "type": "object"
           },
           "carrier": {
-            "$ref": "#/components/schemas/object"
+            "description": "The telecom company that provides the phone number",
+            "nullable": true,
+            "type": "object"
           },
           "country_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO country code for the phone number",
+            "nullable": true,
+            "type": "string"
           },
           "national_format": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number, in national format",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "phone_number": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_messaging_v1.json
+++ b/spec/json/twilio_messaging_v1.json
@@ -1,71 +1,77 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "brand_registrations_status": {
-        "enum": [
-          "IN_PROGRESS",
-          "VERIFIED",
-          "FAILED"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
       "messaging.v1.brand_registrations": {
         "properties": {
           "a2p_profile_bundle_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "A2P Messaging Profile Bundle BundleSid",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "customer_profile_bundle_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "A2P Messaging Profile Bundle BundleSid",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "failure_reason": {
-            "$ref": "#/components/schemas/string"
+            "description": "A reason why brand registration has failed",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BN"
+            "description": "A2P BrandRegistration Sid",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/brand_registrations_status"
+            "description": "Brand Registration status",
+            "enum": [
+              "IN_PROGRESS",
+              "VERIFIED",
+              "FAILED"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "tcr_id": {
-            "$ref": "#/components/schemas/string"
+            "description": "Campaign Registry (TCR) Brand ID",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Brand Registration",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -73,7 +79,10 @@
       "messaging.v1.deactivation": {
         "properties": {
           "redirect_to": {
-            "$ref": "#/components/schemas/url"
+            "description": "Redirect url to the list of deactivated numbers.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -81,64 +90,137 @@
       "messaging.v1.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "area_code_geomatch": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to enable Area Code Geomatch on the Service Instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "fallback_to_long_code": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to enable Fallback to Long Code for messages sent through the Service instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call using fallback_method if an error occurs while retrieving or executing the TwiML from the Inbound Request URL",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call inbound_request_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "inbound_request_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call using inbound_method when a message is received by any phone number or short code in the Service",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The absolute URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "mms_converter": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to enable the MMS Converter for messages sent through the Service instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "scan_message_content": {
-            "$ref": "#/components/schemas/service_scan_message_content"
+            "description": "Reserved",
+            "enum": [
+              "inherit",
+              "enable",
+              "disable"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "smart_encoding": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to enable Encoding for messages sent through the Service instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call to pass status updates about message delivery",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sticky_sender": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to enable Sticky Sender on the Service instance",
+            "nullable": true,
+            "type": "boolean"
           },
           "synchronous_validation": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Reserved",
+            "nullable": true,
+            "type": "boolean"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Service resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "validity_period": {
-            "$ref": "#/components/schemas/integer"
+            "description": "How long, in seconds, messages sent from the Service are valid",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
@@ -146,28 +228,59 @@
       "messaging.v1.service.alpha_sender": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "alpha_sender": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Alphanumeric Sender ID string",
+            "nullable": true,
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "An array of values that describe whether the number can receive calls or messages",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AI"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AI[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the AlphaSender resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -175,31 +288,64 @@
       "messaging.v1.service.phone_number": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "An array of values that describe whether the number can receive calls or messages",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "country_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The 2-character ISO Country Code of the number",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the PhoneNumber resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -207,116 +353,67 @@
       "messaging.v1.service.short_code": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "An array of values that describe whether the number can receive calls or messages",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "country_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The 2-character ISO Country Code of the number",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "short_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The E.164 format of the short code",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_SC"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the ShortCode resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "phone_number": {
-        "nullable": true,
-        "type": "string"
-      },
-      "service_scan_message_content": {
-        "enum": [
-          "inherit",
-          "enable",
-          "disable"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AI": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AI[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BU": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BU[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MG": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MG[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_PN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^PN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_SC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^SC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_monitor_v1.json
+++ b/spec/json/twilio_monitor_v1.json
@@ -1,69 +1,107 @@
 {
   "components": {
     "schemas": {
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "monitor.v1.alert": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "alert_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text of the alert",
+            "nullable": true,
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used when the alert was generated",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_generated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date and time when the alert was generated specified in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The error code for the condition that generated the alert",
+            "nullable": true,
+            "type": "string"
           },
           "log_level": {
-            "$ref": "#/components/schemas/string"
+            "description": "The log level",
+            "nullable": true,
+            "type": "string"
           },
           "more_info": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URL of the page in our Error Dictionary with more information about the error condition",
+            "nullable": true,
+            "type": "string"
           },
           "request_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The method used by the request that generated the alert",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "request_url": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URL of the request that generated the alert",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "resource_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the resource for which the alert was generated",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the service or resource that generated the alert",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Alert resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -71,61 +109,124 @@
       "monitor.v1.alert-instance": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "alert_text": {
-            "$ref": "#/components/schemas/string"
+            "description": "The text of the alert",
+            "nullable": true,
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used when the alert was generated",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_generated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date and time when the alert was generated specified in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "error_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The error code for the condition that generated the alert",
+            "nullable": true,
+            "type": "string"
           },
           "log_level": {
-            "$ref": "#/components/schemas/string"
+            "description": "The log level",
+            "nullable": true,
+            "type": "string"
           },
           "more_info": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URL of the page in our Error Dictionary with more information about the error condition",
+            "nullable": true,
+            "type": "string"
           },
           "request_headers": {
-            "$ref": "#/components/schemas/string"
+            "description": "The request headers of the request that generated the alert",
+            "nullable": true,
+            "type": "string"
           },
           "request_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The method used by the request that generated the alert",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "request_url": {
-            "$ref": "#/components/schemas/uri"
+            "description": "The URL of the request that generated the alert",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "request_variables": {
-            "$ref": "#/components/schemas/string"
+            "description": "The variables passed in the request that generated the alert",
+            "nullable": true,
+            "type": "string"
           },
           "resource_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the resource for which the alert was generated",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "response_body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The response body of the request that generated the alert",
+            "nullable": true,
+            "type": "string"
           },
           "response_headers": {
-            "$ref": "#/components/schemas/string"
+            "description": "The response headers of the request that generated the alert",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the service or resource that generated the alert",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Alert resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -133,106 +234,91 @@
       "monitor.v1.event": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "actor_sid": {
-            "$ref": "#/components/schemas/sid_US"
+            "description": "The SID of the actor that caused the event, if available",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^US[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "actor_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of actor that caused the event",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A description of the event",
+            "nullable": true,
+            "type": "string"
           },
           "event_data": {
-            "$ref": "#/components/schemas/object"
+            "description": "A JSON string that represents an object with additional data about the event",
+            "nullable": true,
+            "type": "object"
           },
           "event_date": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the event was recorded",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "event_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The event's type",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The absolute URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "resource_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the resource that was affected",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of resource that was affected",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "source": {
-            "$ref": "#/components/schemas/string"
+            "description": "The originating system or interface that caused the event",
+            "nullable": true,
+            "type": "string"
           },
           "source_ip_address": {
-            "$ref": "#/components/schemas/string"
+            "description": "The IP address of the source",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource that was affected",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_NO": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^NO[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_US": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^US[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_notify_v1.json
+++ b/spec/json/twilio_notify_v1.json
@@ -1,61 +1,61 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "credential_push_service": {
-        "enum": [
-          "gcm",
-          "apn",
-          "fcm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "notification_priority": {
-        "enum": [
-          "high",
-          "low"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "notify.v1.credential": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sandbox": {
-            "$ref": "#/components/schemas/string"
+            "description": "[APN only] Whether to send the credential to sandbox APNs",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/credential_push_service"
+            "description": "The Credential type, one of `gcm`, `fcm`, or `apn`",
+            "enum": [
+              "gcm",
+              "apn",
+              "fcm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Credential resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -63,64 +63,125 @@
       "notify.v1.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "alexa_skill_id": {
-            "$ref": "#/components/schemas/string"
+            "description": "Deprecated",
+            "nullable": true,
+            "type": "string"
           },
           "apn_credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Credential to use for APN Bindings",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "default_alexa_notification_protocol_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "Deprecated",
+            "nullable": true,
+            "type": "string"
           },
           "default_apn_notification_protocol_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The protocol version to use for sending APNS notifications",
+            "nullable": true,
+            "type": "string"
           },
           "default_fcm_notification_protocol_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The protocol version to use for sending FCM notifications",
+            "nullable": true,
+            "type": "string"
           },
           "default_gcm_notification_protocol_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The protocol version to use for sending GCM notifications",
+            "nullable": true,
+            "type": "string"
           },
           "delivery_callback_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Enable delivery callbacks",
+            "nullable": true,
+            "type": "boolean"
           },
           "delivery_callback_url": {
-            "$ref": "#/components/schemas/string"
+            "description": "Webhook URL",
+            "nullable": true,
+            "type": "string"
           },
           "facebook_messenger_page_id": {
-            "$ref": "#/components/schemas/string"
+            "description": "Deprecated",
+            "nullable": true,
+            "type": "string"
           },
           "fcm_credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Credential to use for FCM Bindings",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "gcm_credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Credential to use for GCM Bindings",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the resources related to the service",
+            "nullable": true,
+            "type": "object"
           },
           "log_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to log notifications",
+            "nullable": true,
+            "type": "boolean"
           },
           "messaging_service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The SID of the Messaging Service to use for SMS Bindings",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Service resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -128,46 +189,92 @@
       "notify.v1.service.binding": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "address": {
-            "$ref": "#/components/schemas/string"
+            "description": "The channel-specific address",
+            "nullable": true,
+            "type": "string"
           },
           "binding_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of the Binding",
+            "nullable": true,
+            "type": "string"
           },
           "credential_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Credential resource to be used to send notifications to this Binding",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "endpoint": {
-            "$ref": "#/components/schemas/string"
+            "description": "Deprecated",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The `identity` value that identifies the new resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "notification_protocol_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The protocol version to use to send the notification",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "tags": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The list of tags associated with this Binding",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Binding resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -175,133 +282,130 @@
       "notify.v1.service.notification": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "action": {
-            "$ref": "#/components/schemas/string"
+            "description": "The actions to display for the notification",
+            "nullable": true,
+            "type": "string"
           },
           "alexa": {
-            "$ref": "#/components/schemas/object"
+            "description": "Deprecated",
+            "nullable": true,
+            "type": "object"
           },
           "apn": {
-            "$ref": "#/components/schemas/object"
+            "description": "The APNS-specific payload that overrides corresponding attributes in a generic payload for APNS Bindings",
+            "nullable": true,
+            "type": "object"
           },
           "body": {
-            "$ref": "#/components/schemas/string"
+            "description": "The notification body text",
+            "nullable": true,
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "The custom key-value pairs of the notification's payload",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "facebook_messenger": {
-            "$ref": "#/components/schemas/object"
+            "description": "Deprecated",
+            "nullable": true,
+            "type": "object"
           },
           "fcm": {
-            "$ref": "#/components/schemas/object"
+            "description": "The FCM-specific payload that overrides corresponding attributes in generic payload for FCM Bindings",
+            "nullable": true,
+            "type": "object"
           },
           "gcm": {
-            "$ref": "#/components/schemas/object"
+            "description": "The GCM-specific payload that overrides corresponding attributes in generic payload for GCM Bindings",
+            "nullable": true,
+            "type": "object"
           },
           "identities": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The list of identity values of the Users to notify",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "priority": {
-            "$ref": "#/components/schemas/notification_priority"
+            "description": "The priority of the notification",
+            "enum": [
+              "high",
+              "low"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "segments": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The list of Segments to notify",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms": {
-            "$ref": "#/components/schemas/object"
+            "description": "The SMS-specific payload that overrides corresponding attributes in generic payload for SMS Bindings",
+            "nullable": true,
+            "type": "object"
           },
           "sound": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the sound to be played for the notification",
+            "nullable": true,
+            "type": "string"
           },
           "tags": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The tags that select the Bindings to notify",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "title": {
-            "$ref": "#/components/schemas/string"
+            "description": "The notification title",
+            "nullable": true,
+            "type": "string"
           },
           "ttl": {
-            "$ref": "#/components/schemas/integer"
+            "description": "How long, in seconds, the notification is valid",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MG": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MG[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_NO": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^NO[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_numbers_v2.json
+++ b/spec/json/twilio_numbers_v2.json
@@ -1,39 +1,6 @@
 {
   "components": {
     "schemas": {
-      "bundle_status": {
-        "enum": [
-          "draft",
-          "pending-review",
-          "in-review",
-          "twilio-rejected",
-          "twilio-approved",
-          "provisionally-approved"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "end_user_type": {
-        "enum": [
-          "individual",
-          "business"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "evaluation_status": {
-        "enum": [
-          "compliant",
-          "noncompliant"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "numbers.v2.regulatory_compliance": {
         "properties": {},
         "type": "object"
@@ -41,40 +8,86 @@
       "numbers.v2.regulatory_compliance.bundle": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "email": {
-            "$ref": "#/components/schemas/string"
+            "description": "The email address",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Assigned Items of the Bundle resource",
+            "nullable": true,
+            "type": "object"
           },
           "regulation_sid": {
-            "$ref": "#/components/schemas/sid_RN"
+            "description": "The unique string of a regulation.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/bundle_status"
+            "description": "The verification status of the Bundle resource",
+            "enum": [
+              "draft",
+              "pending-review",
+              "in-review",
+              "twilio-rejected",
+              "twilio-approved",
+              "provisionally-approved"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call to inform your application of status changes.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Bundle resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "valid_until": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource will be valid until.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -82,28 +95,63 @@
       "numbers.v2.regulatory_compliance.bundle.evaluation": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "bundle_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "regulation_sid": {
-            "$ref": "#/components/schemas/sid_RN"
+            "description": "The unique string of a regulation",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "results": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The results of the Evaluation resource",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_EL"
+            "description": "The unique string that identifies the Evaluation resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^EL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/evaluation_status"
+            "description": "The compliance status of the Evaluation resource",
+            "enum": [
+              "compliant",
+              "noncompliant"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -111,22 +159,48 @@
       "numbers.v2.regulatory_compliance.bundle.item_assignment": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "bundle_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the Bundle resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "object_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The sid of an object bag",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BV"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BV[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Identity resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -134,28 +208,57 @@
       "numbers.v2.regulatory_compliance.end_user": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "The set of parameters that compose the End Users resource",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/end_user_type"
+            "description": "The type of end user of the Bundle resource",
+            "enum": [
+              "individual",
+              "business"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the End User resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -163,19 +266,36 @@
       "numbers.v2.regulatory_compliance.end_user_type": {
         "properties": {
           "fields": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The required information for creating an End-User.",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human-readable description of the End-User Type resource",
+            "nullable": true,
+            "type": "string"
           },
           "machine_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A machine-readable description of the End-User Type resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_OY"
+            "description": "The unique string that identifies the End-User Type resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^OY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the End-User Type resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -183,25 +303,47 @@
       "numbers.v2.regulatory_compliance.regulation": {
         "properties": {
           "end_user_type": {
-            "$ref": "#/components/schemas/regulation_end_user_type"
+            "description": "The type of End User of the Regulation resource",
+            "enum": [
+              "individual",
+              "business"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human-readable description of the Regulation resource",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO country code of the phone number's country",
+            "nullable": true,
+            "type": "string"
           },
           "number_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of phone number restricted by the regulatory requirement",
+            "nullable": true,
+            "type": "string"
           },
           "requirements": {
-            "$ref": "#/components/schemas/object"
+            "description": "The sid of a regulation object that dictates requirements",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RN"
+            "description": "The unique string that identifies the Regulation resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Regulation resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -209,34 +351,71 @@
       "numbers.v2.regulatory_compliance.supporting_document": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "The set of parameters that compose the Supporting Documents resource",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "mime_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The image type of the file",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RD"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/supporting_document_status"
+            "description": "The verification status of the Supporting Document resource",
+            "enum": [
+              "draft",
+              "pending-review",
+              "rejected",
+              "approved",
+              "expired",
+              "provisionally-approved"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of the Supporting Document",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Supporting Document resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -244,129 +423,39 @@
       "numbers.v2.regulatory_compliance.supporting_document_type": {
         "properties": {
           "fields": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The required information for creating a Supporting Document",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human-readable description of the Supporting Document Type resource",
+            "nullable": true,
+            "type": "string"
           },
           "machine_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The machine-readable description of the Supporting Document Type resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_OY"
+            "description": "The unique string that identifies the Supporting Document Type resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^OY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Supporting Document Type resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "regulation_end_user_type": {
-        "enum": [
-          "individual",
-          "business"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BU": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BU[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BV": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BV[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_EL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^EL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_OY": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^OY[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RD": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RD[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "supporting_document_status": {
-        "enum": [
-          "draft",
-          "pending-review",
-          "rejected",
-          "approved",
-          "expired",
-          "provisionally-approved"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_pricing_v1.json
+++ b/spec/json/twilio_pricing_v1.json
@@ -1,168 +1,20 @@
 {
   "components": {
     "schemas": {
-      "currency": {
-        "nullable": true,
-        "type": "string"
-      },
-      "inbound_call_price": {
-        "nullable": true,
-        "properties": {
-          "base_price": {
-            "type": "number"
-          },
-          "current_price": {
-            "type": "number"
-          },
-          "number_type": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "inbound_call_price_list": {
-        "items": {
-          "properties": {
-            "base_price": {
-              "type": "number"
-            },
-            "current_price": {
-              "type": "number"
-            },
-            "number_type": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "inbound_sms_price_list": {
-        "items": {
-          "properties": {
-            "base_price": {
-              "type": "number"
-            },
-            "current_price": {
-              "type": "number"
-            },
-            "number_type": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "iso_country_code": {
-        "nullable": true,
-        "type": "string"
-      },
-      "outbound_call_price": {
-        "nullable": true,
-        "properties": {
-          "base_price": {
-            "type": "number"
-          },
-          "current_price": {
-            "type": "number"
-          }
-        },
-        "type": "object"
-      },
-      "outbound_prefix_price_list": {
-        "items": {
-          "properties": {
-            "base_price": {
-              "type": "number"
-            },
-            "current_price": {
-              "type": "number"
-            },
-            "friendly_name": {
-              "type": "string"
-            },
-            "prefixes": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "outbound_sms_price_list": {
-        "items": {
-          "properties": {
-            "carrier": {
-              "type": "string"
-            },
-            "mcc": {
-              "type": "string"
-            },
-            "mnc": {
-              "type": "string"
-            },
-            "prices": {
-              "items": {
-                "properties": {
-                  "base_price": {
-                    "type": "number"
-                  },
-                  "current_price": {
-                    "type": "number"
-                  },
-                  "number_type": {
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              },
-              "type": "array"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "phone_number_e164": {
-        "nullable": true,
-        "type": "string"
-      },
-      "phone_number_price_list": {
-        "items": {
-          "properties": {
-            "base_price": {
-              "type": "number"
-            },
-            "current_price": {
-              "type": "number"
-            },
-            "number_type": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
       "pricing.v1.messaging": {
         "properties": {
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -170,13 +22,20 @@
       "pricing.v1.messaging.messaging_country": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -184,22 +43,80 @@
       "pricing.v1.messaging.messaging_country-instance": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_sms_prices": {
-            "$ref": "#/components/schemas/inbound_sms_price_list"
+            "description": "The list of InboundPrice records",
+            "items": {
+              "properties": {
+                "base_price": {
+                  "type": "number"
+                },
+                "current_price": {
+                  "type": "number"
+                },
+                "number_type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_sms_prices": {
-            "$ref": "#/components/schemas/outbound_sms_price_list"
+            "description": "The list of OutboundSMSPrice records",
+            "items": {
+              "properties": {
+                "carrier": {
+                  "type": "string"
+                },
+                "mcc": {
+                  "type": "string"
+                },
+                "mnc": {
+                  "type": "string"
+                },
+                "prices": {
+                  "items": {
+                    "properties": {
+                      "base_price": {
+                        "type": "number"
+                      },
+                      "current_price": {
+                        "type": "number"
+                      },
+                      "number_type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which prices are measured, in ISO 4127 format (e.g. usd, eur, jpy)",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -207,13 +124,17 @@
       "pricing.v1.phone_number": {
         "properties": {
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -221,13 +142,20 @@
       "pricing.v1.phone_number.phone_number_country": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code ",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -235,19 +163,44 @@
       "pricing.v1.phone_number.phone_number_country-instance": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code ",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number_prices": {
-            "$ref": "#/components/schemas/phone_number_price_list"
+            "description": "The list of PhoneNumberPrices records",
+            "items": {
+              "properties": {
+                "base_price": {
+                  "type": "number"
+                },
+                "current_price": {
+                  "type": "number"
+                },
+                "number_type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which prices are measured, in ISO 4127 format (e.g. usd, eur, jpy)",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -255,13 +208,17 @@
       "pricing.v1.voice": {
         "properties": {
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -269,13 +226,20 @@
       "pricing.v1.voice.voice_country": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -283,22 +247,69 @@
       "pricing.v1.voice.voice_country-instance": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_call_prices": {
-            "$ref": "#/components/schemas/inbound_call_price_list"
+            "description": "The list of InboundCallPrice records",
+            "items": {
+              "properties": {
+                "base_price": {
+                  "type": "number"
+                },
+                "current_price": {
+                  "type": "number"
+                },
+                "number_type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_prefix_prices": {
-            "$ref": "#/components/schemas/outbound_prefix_price_list"
+            "description": "The list of OutboundPrefixPrice records",
+            "items": {
+              "properties": {
+                "base_price": {
+                  "type": "number"
+                },
+                "current_price": {
+                  "type": "number"
+                },
+                "friendly_name": {
+                  "type": "string"
+                },
+                "prefixes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which prices are measured, in ISO 4127 format (e.g. usd, eur, jpy)",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -306,41 +317,62 @@
       "pricing.v1.voice.voice_number": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_call_price": {
-            "$ref": "#/components/schemas/inbound_call_price"
+            "description": "The InboundCallPrice record",
+            "nullable": true,
+            "properties": {
+              "base_price": {
+                "type": "number"
+              },
+              "current_price": {
+                "type": "number"
+              },
+              "number_type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "number": {
-            "$ref": "#/components/schemas/phone_number_e164"
+            "description": "The phone number",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_call_price": {
-            "$ref": "#/components/schemas/outbound_call_price"
+            "description": "The OutboundCallPrice record",
+            "nullable": true,
+            "properties": {
+              "base_price": {
+                "type": "number"
+              },
+              "current_price": {
+                "type": "number"
+              }
+            },
+            "type": "object"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which prices are measured, in ISO 4127 format (e.g. usd, eur, jpy)",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_pricing_v2.json
+++ b/spec/json/twilio_pricing_v2.json
@@ -1,112 +1,23 @@
 {
   "components": {
     "schemas": {
-      "currency": {
-        "nullable": true,
-        "type": "string"
-      },
-      "inbound_call_price": {
-        "nullable": true,
-        "properties": {
-          "base_price": {
-            "type": "number"
-          },
-          "current_price": {
-            "type": "number"
-          },
-          "number_type": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "inbound_call_price_list": {
-        "items": {
-          "properties": {
-            "base_price": {
-              "type": "number"
-            },
-            "current_price": {
-              "type": "number"
-            },
-            "number_type": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "iso_country_code": {
-        "nullable": true,
-        "type": "string"
-      },
-      "outbound_call_price_with_origin_list": {
-        "items": {
-          "properties": {
-            "base_price": {
-              "type": "number"
-            },
-            "current_price": {
-              "type": "number"
-            },
-            "origination_prefixes": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "outbound_prefix_price_with_origin_list": {
-        "items": {
-          "properties": {
-            "base_price": {
-              "type": "number"
-            },
-            "current_price": {
-              "type": "number"
-            },
-            "destination_prefixes": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "friendly_name": {
-              "type": "string"
-            },
-            "origination_prefixes": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "phone_number_e164": {
-        "nullable": true,
-        "type": "string"
-      },
       "pricing.v2.voice": {
         "properties": {
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the related Countries and Numbers resources",
+            "nullable": true,
+            "type": "object"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The resource name",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -114,13 +25,20 @@
       "pricing.v2.voice.voice_country": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -128,22 +46,75 @@
       "pricing.v2.voice.voice_country-instance": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_call_prices": {
-            "$ref": "#/components/schemas/inbound_call_price_list"
+            "description": "The list of InboundCallPrice records",
+            "items": {
+              "properties": {
+                "base_price": {
+                  "type": "number"
+                },
+                "current_price": {
+                  "type": "number"
+                },
+                "number_type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_prefix_prices": {
-            "$ref": "#/components/schemas/outbound_prefix_price_with_origin_list"
+            "description": "The list of OutboundPrefixPriceWithOrigin records",
+            "items": {
+              "properties": {
+                "base_price": {
+                  "type": "number"
+                },
+                "current_price": {
+                  "type": "number"
+                },
+                "destination_prefixes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "friendly_name": {
+                  "type": "string"
+                },
+                "origination_prefixes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which prices are measured, in ISO 4127 format (e.g. usd, eur, jpy)",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -151,44 +122,76 @@
       "pricing.v2.voice.voice_number": {
         "properties": {
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "destination_number": {
-            "$ref": "#/components/schemas/phone_number_e164"
+            "description": "The destination phone number, in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_call_price": {
-            "$ref": "#/components/schemas/inbound_call_price"
+            "description": "The InboundCallPrice record",
+            "nullable": true,
+            "properties": {
+              "base_price": {
+                "type": "number"
+              },
+              "current_price": {
+                "type": "number"
+              },
+              "number_type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "origination_number": {
-            "$ref": "#/components/schemas/phone_number_e164"
+            "description": "The origination phone number, in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_call_prices": {
-            "$ref": "#/components/schemas/outbound_call_price_with_origin_list"
+            "description": "The list of OutboundCallPriceWithOrigin records",
+            "items": {
+              "properties": {
+                "base_price": {
+                  "type": "number"
+                },
+                "current_price": {
+                  "type": "number"
+                },
+                "origination_prefixes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "price_unit": {
-            "$ref": "#/components/schemas/currency"
+            "description": "The currency in which prices are measured, in ISO 4127 format (e.g. usd, eur, jpy)",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_proxy_v1.json
+++ b/spec/json/twilio_proxy_v1.json
@@ -1,156 +1,102 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "interaction_resource_status": {
-        "enum": [
-          "accepted",
-          "answered",
-          "busy",
-          "canceled",
-          "completed",
-          "deleted",
-          "delivered",
-          "delivery-unknown",
-          "failed",
-          "in-progress",
-          "initiated",
-          "no-answer",
-          "queued",
-          "received",
-          "receiving",
-          "ringing",
-          "scheduled",
-          "sending",
-          "sent",
-          "undelivered",
-          "unknown"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "interaction_type": {
-        "enum": [
-          "message",
-          "voice",
-          "unknown"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "message_interaction_resource_status": {
-        "enum": [
-          "accepted",
-          "answered",
-          "busy",
-          "canceled",
-          "completed",
-          "deleted",
-          "delivered",
-          "delivery-unknown",
-          "failed",
-          "in-progress",
-          "initiated",
-          "no-answer",
-          "queued",
-          "received",
-          "receiving",
-          "ringing",
-          "scheduled",
-          "sending",
-          "sent",
-          "undelivered",
-          "unknown"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "message_interaction_type": {
-        "enum": [
-          "message",
-          "voice",
-          "unknown"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "phone_number": {
-        "nullable": true,
-        "type": "string"
-      },
-      "phone_number_capabilities": {
-        "nullable": true,
-        "properties": {
-          "fax": {
-            "type": "boolean"
-          },
-          "mms": {
-            "type": "boolean"
-          },
-          "sms": {
-            "type": "boolean"
-          },
-          "voice": {
-            "type": "boolean"
-          }
-        },
-        "type": "object"
-      },
       "proxy.v1.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the interaction status changes",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "chat_instance_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Chat Service Instance",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "default_ttl": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Default TTL for a Session, in seconds",
+            "nullable": true,
+            "type": "integer"
           },
           "geo_match_level": {
-            "$ref": "#/components/schemas/service_geo_match_level"
+            "description": "Where a proxy number must be located relative to the participant identifier",
+            "enum": [
+              "area-code",
+              "overlay",
+              "radius",
+              "country"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "intercept_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call on each interaction",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of resources related to the Service",
+            "nullable": true,
+            "type": "object"
           },
           "number_selection_behavior": {
-            "$ref": "#/components/schemas/service_number_selection_behavior"
+            "description": "The preference for Proxy Number selection for the Service instance",
+            "enum": [
+              "avoid-sticky",
+              "prefer-sticky"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "out_of_session_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an inbound call or SMS action occurs on a closed or non-existent Session",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_KS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Service resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -158,40 +104,90 @@
       "proxy.v1.service.phone_number": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "The capabilities of the phone number",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "in_use": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of open session assigned to the number.",
+            "nullable": true,
+            "type": "integer"
           },
           "is_reserved": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Reserve the phone number for manual assignment to participants only",
+            "nullable": true,
+            "type": "boolean"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO Country Code",
+            "nullable": true,
+            "type": "string"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_KS"
+            "description": "The SID of the PhoneNumber resource's parent Service resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the PhoneNumber resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -199,52 +195,112 @@
       "proxy.v1.service.session": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "closed_reason": {
-            "$ref": "#/components/schemas/string"
+            "description": "The reason the Session ended",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_ended": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date when the Session ended",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_expiry": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date when the Session should expire",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_last_interaction": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date when the Session last had an interaction",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_started": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date when the Session started",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of resources related to the Session",
+            "nullable": true,
+            "type": "object"
           },
           "mode": {
-            "$ref": "#/components/schemas/session_mode"
+            "description": "The Mode of the Session",
+            "enum": [
+              "message-only",
+              "voice-only",
+              "voice-and-message"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_KS"
+            "description": "The SID of the resource's parent Service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_KC"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/session_status"
+            "description": "The status of the Session",
+            "enum": [
+              "open",
+              "in-progress",
+              "closed",
+              "failed",
+              "unknown"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "ttl": {
-            "$ref": "#/components/schemas/integer"
+            "description": "When the session will expire",
+            "nullable": true,
+            "type": "integer"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Session resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -252,61 +308,179 @@
       "proxy.v1.service.session.interaction": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/string"
+            "description": "A JSON string that includes the message body of message interactions",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Interaction was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_participant_sid": {
-            "$ref": "#/components/schemas/sid_KP"
+            "description": "The SID of the inbound Participant resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "inbound_resource_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the inbound resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "inbound_resource_status": {
-            "$ref": "#/components/schemas/interaction_resource_status"
+            "description": "The inbound resource status of the Interaction",
+            "enum": [
+              "accepted",
+              "answered",
+              "busy",
+              "canceled",
+              "completed",
+              "deleted",
+              "delivered",
+              "delivery-unknown",
+              "failed",
+              "in-progress",
+              "initiated",
+              "no-answer",
+              "queued",
+              "received",
+              "receiving",
+              "ringing",
+              "scheduled",
+              "sending",
+              "sent",
+              "undelivered",
+              "unknown"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "inbound_resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The inbound resource type",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_resource_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of the Twilio inbound resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_participant_sid": {
-            "$ref": "#/components/schemas/sid_KP"
+            "description": "The SID of the outbound Participant",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "outbound_resource_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the outbound resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "outbound_resource_status": {
-            "$ref": "#/components/schemas/interaction_resource_status"
+            "description": "The outbound resource status of the Interaction",
+            "enum": [
+              "accepted",
+              "answered",
+              "busy",
+              "canceled",
+              "completed",
+              "deleted",
+              "delivered",
+              "delivery-unknown",
+              "failed",
+              "in-progress",
+              "initiated",
+              "no-answer",
+              "queued",
+              "received",
+              "receiving",
+              "ringing",
+              "scheduled",
+              "sending",
+              "sent",
+              "undelivered",
+              "unknown"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "outbound_resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The outbound resource type",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_resource_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of the Twilio outbound resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_KS"
+            "description": "The SID of the resource's parent Service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "session_sid": {
-            "$ref": "#/components/schemas/sid_KC"
+            "description": "The SID of the resource's parent Session",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_KI"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KI[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/interaction_type"
+            "description": "The Type of the Interaction",
+            "enum": [
+              "message",
+              "voice",
+              "unknown"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Interaction resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -314,43 +488,88 @@
       "proxy.v1.service.session.participant": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_deleted": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date the Participant was removed",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the participant",
+            "nullable": true,
+            "type": "string"
           },
           "identifier": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number of the Participant",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs to resources related the participant",
+            "nullable": true,
+            "type": "object"
           },
           "proxy_identifier": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number or short code of the participant's partner",
+            "nullable": true,
+            "type": "string"
           },
           "proxy_identifier_sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The SID of the Proxy Identifier assigned to the Participant",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_KS"
+            "description": "The SID of the resource's parent Service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "session_sid": {
-            "$ref": "#/components/schemas/sid_KC"
+            "description": "The SID of the resource's parent Session",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_KP"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Participant resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -358,64 +577,187 @@
       "proxy.v1.service.session.participant.message_interaction": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/string"
+            "description": "A JSON string that includes the message body sent to the participant",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_participant_sid": {
-            "$ref": "#/components/schemas/sid_KP"
+            "description": "Always empty for Message Interactions",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "inbound_resource_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "Always empty for Message Interactions",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "inbound_resource_status": {
-            "$ref": "#/components/schemas/message_interaction_resource_status"
+            "description": "Always empty for Message Interactions",
+            "enum": [
+              "accepted",
+              "answered",
+              "busy",
+              "canceled",
+              "completed",
+              "deleted",
+              "delivered",
+              "delivery-unknown",
+              "failed",
+              "in-progress",
+              "initiated",
+              "no-answer",
+              "queued",
+              "received",
+              "receiving",
+              "ringing",
+              "scheduled",
+              "sending",
+              "sent",
+              "undelivered",
+              "unknown"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "inbound_resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "Always empty for Message Interactions",
+            "nullable": true,
+            "type": "string"
           },
           "inbound_resource_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "Always empty for Message Interactions",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_participant_sid": {
-            "$ref": "#/components/schemas/sid_KP"
+            "description": "The SID of the outbound Participant resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "outbound_resource_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the outbound Message resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "outbound_resource_status": {
-            "$ref": "#/components/schemas/message_interaction_resource_status"
+            "description": "The outbound resource status",
+            "enum": [
+              "accepted",
+              "answered",
+              "busy",
+              "canceled",
+              "completed",
+              "deleted",
+              "delivered",
+              "delivery-unknown",
+              "failed",
+              "in-progress",
+              "initiated",
+              "no-answer",
+              "queued",
+              "received",
+              "receiving",
+              "ringing",
+              "scheduled",
+              "sending",
+              "sent",
+              "undelivered",
+              "unknown"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "outbound_resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The outbound resource type",
+            "nullable": true,
+            "type": "string"
           },
           "outbound_resource_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of the Twilio message resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_KP"
+            "description": "The SID of the Participant resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_KS"
+            "description": "The SID of the resource's parent Service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "session_sid": {
-            "$ref": "#/components/schemas/sid_KC"
+            "description": "The SID of the resource's parent Session",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_KI"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KI[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/message_interaction_type"
+            "description": "The Type of Message Interaction",
+            "enum": [
+              "message",
+              "voice",
+              "unknown"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the MessageInteraction resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -423,151 +765,83 @@
       "proxy.v1.service.short_code": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/phone_number_capabilities"
+            "description": "The capabilities of the short code",
+            "nullable": true,
+            "properties": {
+              "fax": {
+                "type": "boolean"
+              },
+              "mms": {
+                "type": "boolean"
+              },
+              "sms": {
+                "type": "boolean"
+              },
+              "voice": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "is_reserved": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the short code should be reserved for manual assignment to participants only",
+            "nullable": true,
+            "type": "boolean"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO Country Code",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_KS"
+            "description": "The SID of the resource's parent Service",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^KS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "short_code": {
-            "$ref": "#/components/schemas/string"
+            "description": "The short code's number",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_SC"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the ShortCode resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "service_geo_match_level": {
-        "enum": [
-          "area-code",
-          "overlay",
-          "radius",
-          "country"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "service_number_selection_behavior": {
-        "enum": [
-          "avoid-sticky",
-          "prefer-sticky"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "session_mode": {
-        "enum": [
-          "message-only",
-          "voice-only",
-          "voice-and-message"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "session_status": {
-        "enum": [
-          "open",
-          "in-progress",
-          "closed",
-          "failed",
-          "unknown"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_KC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^KC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_KI": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^KI[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_KP": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^KP[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_KS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^KS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_PN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^PN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_SC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^SC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_serverless_v1.json
+++ b/spec/json/twilio_serverless_v1.json
@@ -1,107 +1,66 @@
 {
   "components": {
     "schemas": {
-      "asset_version_visibility": {
-        "enum": [
-          "public",
-          "private",
-          "protected"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "build_runtime": {
-        "enum": [
-          "node8",
-          "node10",
-          "node12"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "build_status": {
-        "enum": [
-          "building",
-          "completed",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "build_status_status": {
-        "enum": [
-          "building",
-          "completed",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "function_version_visibility": {
-        "enum": [
-          "public",
-          "private",
-          "protected"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "log_level": {
-        "enum": [
-          "info",
-          "warn",
-          "error"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
       "serverless.v1.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Service resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Service resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Service resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Service resource",
+            "nullable": true,
+            "type": "string"
           },
           "include_credentials": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to inject Account credentials into a function invocation context",
+            "nullable": true,
+            "type": "boolean"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Service's nested resources",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The unique string that identifies the Service resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "ui_editable": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Service resource's properties and subresources can be edited via the UI",
+            "nullable": true,
+            "type": "boolean"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A user-defined string that uniquely identifies the Service resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Service resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -109,28 +68,56 @@
       "serverless.v1.service.asset": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Asset resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Asset resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Asset resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Asset resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Asset resource's nested resources",
+            "nullable": true,
+            "type": "object"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Asset resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZH"
+            "description": "The unique string that identifies the Asset resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Asset resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -138,28 +125,63 @@
       "serverless.v1.service.asset.asset_version": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Asset Version resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "asset_sid": {
-            "$ref": "#/components/schemas/sid_ZH"
+            "description": "The SID of the Asset resource that is the parent of the Asset Version",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Asset Version resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "path": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URL-friendly string by which the Asset Version can be referenced",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Asset Version resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZN"
+            "description": "The unique string that identifies the Asset Version resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Asset Version resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "visibility": {
-            "$ref": "#/components/schemas/asset_version_visibility"
+            "description": "The access control that determines how the Asset Version can be accessed",
+            "enum": [
+              "public",
+              "private",
+              "protected"
+            ],
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -167,40 +189,94 @@
       "serverless.v1.service.build": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Build resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "asset_versions": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The list of Asset Version resource SIDs that are included in the Build",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Build resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Build resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "dependencies": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "A list of objects that describe the Dependencies included in the Build",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "function_versions": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The list of Function Version resource SIDs that are included in the Build",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "runtime": {
-            "$ref": "#/components/schemas/build_runtime"
+            "description": "The Runtime version that will be used to run the Build.",
+            "enum": [
+              "node8",
+              "node10",
+              "node12"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Build resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZB"
+            "description": "The unique string that identifies the Build resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/build_status"
+            "description": "The status of the Build",
+            "enum": [
+              "building",
+              "completed",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Build resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -208,19 +284,44 @@
       "serverless.v1.service.build.build_status": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Build resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Build resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZB"
+            "description": "The unique string that identifies the Build resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/build_status_status"
+            "description": "The status of the Build",
+            "enum": [
+              "building",
+              "completed",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Build Status resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -228,37 +329,74 @@
       "serverless.v1.service.environment": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Environment resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "build_sid": {
-            "$ref": "#/components/schemas/sid_ZB"
+            "description": "The SID of the build deployed in the environment",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Environment resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Environment resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "domain_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The base domain name for all Functions and Assets deployed in the Environment",
+            "nullable": true,
+            "type": "string"
           },
           "domain_suffix": {
-            "$ref": "#/components/schemas/string"
+            "description": "A URL-friendly name that represents the environment",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Environment resource's nested resources",
+            "nullable": true,
+            "type": "object"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Environment resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZE"
+            "description": "The unique string that identifies the Environment resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A user-defined string that uniquely identifies the Environment resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Environment resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -266,28 +404,62 @@
       "serverless.v1.service.environment.deployment": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Deployment resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "build_sid": {
-            "$ref": "#/components/schemas/sid_ZB"
+            "description": "The SID of the Build for the deployment",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Deployment resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Deployment resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "environment_sid": {
-            "$ref": "#/components/schemas/sid_ZE"
+            "description": "The SID of the Environment for the Deployment",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Deployment resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZD"
+            "description": "The unique string that identifies the Deployment resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Deployment resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -295,40 +467,95 @@
       "serverless.v1.service.environment.log": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Log resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "build_sid": {
-            "$ref": "#/components/schemas/sid_ZB"
+            "description": "The SID of the build that corresponds to the log",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Log resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "deployment_sid": {
-            "$ref": "#/components/schemas/sid_ZD"
+            "description": "The SID of the deployment that corresponds to the log",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "environment_sid": {
-            "$ref": "#/components/schemas/sid_ZE"
+            "description": "The SID of the environment in which the log occurred",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "function_sid": {
-            "$ref": "#/components/schemas/sid_ZH"
+            "description": "The SID of the function whose invocation produced the log",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "level": {
-            "$ref": "#/components/schemas/log_level"
+            "description": "The log level",
+            "enum": [
+              "info",
+              "warn",
+              "error"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "message": {
-            "$ref": "#/components/schemas/string"
+            "description": "The log message",
+            "nullable": true,
+            "type": "string"
           },
           "request_sid": {
-            "$ref": "#/components/schemas/sid_RQ"
+            "description": "The SID of the request associated with the log",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RQ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Log resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NO"
+            "description": "The unique string that identifies the Log resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Log resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -336,31 +563,64 @@
       "serverless.v1.service.environment.variable": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Variable resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Variable resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Variable resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "environment_sid": {
-            "$ref": "#/components/schemas/sid_ZE"
+            "description": "The SID of the Environment in which the Variable exists",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "key": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string by which the Variable resource can be referenced",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Variable resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZV"
+            "description": "The unique string that identifies the Variable resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZV[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Variable resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "value": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string that contains the actual value of the Variable",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -368,28 +628,56 @@
       "serverless.v1.service.function": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Function resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Function resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Function resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Function resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of nested resources of the Function resource",
+            "nullable": true,
+            "type": "object"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Function resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZH"
+            "description": "The unique string that identifies the Function resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Function resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -397,31 +685,67 @@
       "serverless.v1.service.function.function_version": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Function Version resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Function Version resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "function_sid": {
-            "$ref": "#/components/schemas/sid_ZH"
+            "description": "The SID of the Function resource that is the parent of the Function Version resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "path": {
-            "$ref": "#/components/schemas/string"
+            "description": "The URL-friendly string by which the Function Version resource can be referenced",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Function Version resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZN"
+            "description": "The unique string that identifies the Function Version resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Function Version resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "visibility": {
-            "$ref": "#/components/schemas/function_version_visibility"
+            "description": "The access control that determines how the Function Version resource can be accessed",
+            "enum": [
+              "public",
+              "private",
+              "protected"
+            ],
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -429,108 +753,49 @@
       "serverless.v1.service.function.function_version.function_version_content": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the Function Version resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "content": {
-            "$ref": "#/components/schemas/string"
+            "description": "The content of the Function Version resource",
+            "nullable": true,
+            "type": "string"
           },
           "function_sid": {
-            "$ref": "#/components/schemas/sid_ZH"
+            "description": "The SID of the Function that is the parent of the Function Version",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZH[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_ZS"
+            "description": "The SID of the Service that the Function Version resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ZN"
+            "description": "The unique string that identifies the Function Version resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ZN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_NO": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^NO[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RQ": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RQ[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ZB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ZB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ZD": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ZD[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ZE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ZE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ZH": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ZH[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ZN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ZN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ZS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ZS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ZV": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ZV[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_studio_v1.json
+++ b/spec/json/twilio_studio_v1.json
@@ -1,110 +1,65 @@
 {
   "components": {
     "schemas": {
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "engagement_status": {
-        "enum": [
-          "active",
-          "ended"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "execution_status": {
-        "enum": [
-          "active",
-          "ended"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "flow_status": {
-        "enum": [
-          "draft",
-          "published"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FW": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FW[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
       "studio.v1.flow": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Flow",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/flow_status"
+            "description": "The status of the Flow",
+            "enum": [
+              "draft",
+              "published"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "version": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The latest version number of the Flow's definition",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
@@ -112,37 +67,78 @@
       "studio.v1.flow.engagement": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "contact_channel_address": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number, SIP address or Client identifier that triggered this Engagement",
+            "nullable": true,
+            "type": "string"
           },
           "contact_sid": {
-            "$ref": "#/components/schemas/sid_FC"
+            "description": "The SID of the Contact",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the execution flow",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Engagement was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Engagement was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Engagement's nested resources",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/engagement_status"
+            "description": "The status of the Engagement",
+            "enum": [
+              "active",
+              "ended"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -150,19 +146,39 @@
       "studio.v1.flow.engagement.engagement_context": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "Account SID",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "Flow state",
+            "nullable": true,
+            "type": "object"
           },
           "engagement_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "Engagement SID",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "Flow SID",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -170,40 +186,79 @@
       "studio.v1.flow.engagement.step": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "engagement_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The SID of the Engagement",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The event that caused the Flow to transition to the Step",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "transitioned_from": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Widget that preceded the Widget for the Step",
+            "nullable": true,
+            "type": "string"
           },
           "transitioned_to": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Widget that will follow the Widget for the Step",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -211,22 +266,47 @@
       "studio.v1.flow.engagement.step.step_context": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "engagement_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The SID of the Engagement",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "step_sid": {
-            "$ref": "#/components/schemas/sid_FT"
+            "description": "Step SID",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -234,37 +314,78 @@
       "studio.v1.flow.execution": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "contact_channel_address": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number, SIP address or Client identifier that triggered the Execution",
+            "nullable": true,
+            "type": "string"
           },
           "contact_sid": {
-            "$ref": "#/components/schemas/sid_FC"
+            "description": "The SID of the Contact",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/execution_status"
+            "description": "The status of the Execution",
+            "enum": [
+              "active",
+              "ended"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -272,19 +393,39 @@
       "studio.v1.flow.execution.execution_context": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "execution_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The SID of the Execution",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -292,40 +433,79 @@
       "studio.v1.flow.execution.execution_step": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "execution_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The SID of the Execution",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The event that caused the Flow to transition to the Step",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "transitioned_from": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Widget that preceded the Widget for the Step",
+            "nullable": true,
+            "type": "string"
           },
           "transitioned_to": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Widget that will follow the Widget for the Step",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -333,34 +513,50 @@
       "studio.v1.flow.execution.execution_step.execution_step_context": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "execution_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The SID of the Execution",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "step_sid": {
-            "$ref": "#/components/schemas/sid_FT"
+            "description": "Step SID",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_studio_v2.json
+++ b/spec/json/twilio_studio_v2.json
@@ -1,139 +1,101 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "execution_status": {
-        "enum": [
-          "active",
-          "ended"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "flow_revision_status": {
-        "enum": [
-          "draft",
-          "published"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "flow_status": {
-        "enum": [
-          "draft",
-          "published"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_FW": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^FW[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
       "studio.v2.flow": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "commit_message": {
-            "$ref": "#/components/schemas/string"
+            "description": "Description of change made in the revision",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "definition": {
-            "$ref": "#/components/schemas/object"
+            "description": "JSON representation of flow definition",
+            "nullable": true,
+            "type": "object"
           },
           "errors": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "List of error in the flow definition",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Flow",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs",
+            "nullable": true,
+            "type": "object"
           },
           "revision": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The latest revision number of the Flow's definition",
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/flow_status"
+            "description": "The status of the Flow",
+            "enum": [
+              "draft",
+              "published"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "valid": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Boolean if the flow definition is valid",
+            "nullable": true,
+            "type": "boolean"
           },
           "warnings": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "List of warnings in the flow definition",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "webhook_url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -141,34 +103,70 @@
       "studio.v2.flow.execution": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "contact_channel_address": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number, SIP address or Client identifier that triggered the Execution",
+            "nullable": true,
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/execution_status"
+            "description": "The status of the Execution",
+            "enum": [
+              "active",
+              "ended"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -176,19 +174,39 @@
       "studio.v2.flow.execution.execution_context": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "execution_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The SID of the Execution",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -196,40 +214,79 @@
       "studio.v2.flow.execution.execution_step": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "execution_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The SID of the Execution",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The event that caused the Flow to transition to the Step",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "transitioned_from": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Widget that preceded the Widget for the Step",
+            "nullable": true,
+            "type": "string"
           },
           "transitioned_to": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Widget that will follow the Widget for the Step",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -237,22 +294,47 @@
       "studio.v2.flow.execution.execution_step.execution_step_context": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "context": {
-            "$ref": "#/components/schemas/object"
+            "description": "The current state of the flow",
+            "nullable": true,
+            "type": "object"
           },
           "execution_sid": {
-            "$ref": "#/components/schemas/sid_FN"
+            "description": "The SID of the Execution",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "flow_sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The SID of the Flow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "step_sid": {
-            "$ref": "#/components/schemas/sid_FT"
+            "description": "Step SID",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -260,40 +342,80 @@
       "studio.v2.flow.flow_revision": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "commit_message": {
-            "$ref": "#/components/schemas/string"
+            "description": "Description of change made in the revision",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "definition": {
-            "$ref": "#/components/schemas/object"
+            "description": "JSON representation of flow definition",
+            "nullable": true,
+            "type": "object"
           },
           "errors": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "List of error in the flow definition",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Flow",
+            "nullable": true,
+            "type": "string"
           },
           "revision": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The latest revision number of the Flow's definition",
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/flow_revision_status"
+            "description": "The status of the Flow",
+            "enum": [
+              "draft",
+              "published"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "valid": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Boolean if the flow definition is valid",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -301,13 +423,26 @@
       "studio.v2.flow.test_user": {
         "properties": {
           "sid": {
-            "$ref": "#/components/schemas/sid_FW"
+            "description": "Unique identifier of the flow.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^FW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "test_users": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "List of test user identities that can test draft versions of the flow.",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -315,19 +450,12 @@
       "studio.v2.flow_validate": {
         "properties": {
           "valid": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Boolean if the flow definition is valid",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_supersim_v1.json
+++ b/spec/json/twilio_supersim_v1.json
@@ -1,161 +1,75 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "command_direction": {
-        "enum": [
-          "to_sim",
-          "from_sim"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "command_status": {
-        "enum": [
-          "queued",
-          "sent",
-          "delivered",
-          "received",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "fleet_data_metering": {
-        "enum": [
-          "payg"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "iso_country_code": {
-        "nullable": true,
-        "type": "string"
-      },
-      "long": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_HA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^HA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_HC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^HC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_HF": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^HF[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_HS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^HS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_HW": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^HW[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sim_status": {
-        "enum": [
-          "new",
-          "ready",
-          "active",
-          "inactive",
-          "scheduled"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
       "supersim.v1.command": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "command": {
-            "$ref": "#/components/schemas/string"
+            "description": "The message body of the command sent to or from the SIM",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "direction": {
-            "$ref": "#/components/schemas/command_direction"
+            "description": "The direction of the Command",
+            "enum": [
+              "to_sim",
+              "from_sim"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_HC"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sim_sid": {
-            "$ref": "#/components/schemas/sid_HS"
+            "description": "The SID of the SIM that this Command was sent to or from",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/command_status"
+            "description": "The status of the Command",
+            "enum": [
+              "queued",
+              "sent",
+              "delivered",
+              "received",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Command resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -163,43 +77,93 @@
       "supersim.v1.fleet": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "commands_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Defines whether SIMs in the Fleet are capable of sending and receiving machine-to-machine SMS via Commands",
+            "nullable": true,
+            "type": "boolean"
           },
           "commands_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "A string representing the HTTP method to use when making a request to `commands_url`",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "commands_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that will receive a webhook when a Super SIM in the Fleet is used to send an SMS from your device to the Commands number",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "data_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Defines whether SIMs in the Fleet are capable of using data connectivity",
+            "nullable": true,
+            "type": "boolean"
           },
           "data_limit": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total data usage (download and upload combined) in Megabytes that each Sim resource assigned to the Fleet resource can consume",
+            "nullable": true,
+            "type": "integer"
           },
           "data_metering": {
-            "$ref": "#/components/schemas/fleet_data_metering"
+            "description": "The model by which a SIM is metered and billed",
+            "enum": [
+              "payg"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "network_access_profile_sid": {
-            "$ref": "#/components/schemas/sid_HA"
+            "description": "The SID of the Network Access Profile of the Fleet",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_HF"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Fleet resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -207,19 +171,36 @@
       "supersim.v1.network": {
         "properties": {
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human readable identifier of this resource",
+            "nullable": true,
+            "type": "string"
           },
           "identifiers": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The MCC/MNCs included in the Network resource",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO country code of the Network resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_HW"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Network resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -227,25 +208,47 @@
       "supersim.v1.network_access_profile": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that the Network Access Profile belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_HA"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -253,22 +256,44 @@
       "supersim.v1.network_access_profile.network_access_profile_network": {
         "properties": {
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human readable identifier of this resource",
+            "nullable": true,
+            "type": "string"
           },
           "identifiers": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The MCC/MNCs included in the resource",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO country code of the Network resource",
+            "nullable": true,
+            "type": "string"
           },
           "network_access_profile_sid": {
-            "$ref": "#/components/schemas/sid_HA"
+            "description": "The unique string that identifies the Network Access Profile resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_HW"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -276,31 +301,68 @@
       "supersim.v1.sim": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that the Super SIM belongs to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "fleet_sid": {
-            "$ref": "#/components/schemas/sid_HF"
+            "description": "The unique ID of the Fleet configured for this SIM",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "iccid": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ICCID associated with the SIM",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_HS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/sim_status"
+            "description": "The status of the Super SIM",
+            "enum": [
+              "new",
+              "ready",
+              "active",
+              "inactive",
+              "scheduled"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Sim Resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -308,43 +370,64 @@
       "supersim.v1.usage_record": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that incurred the usage.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "data_download": {
-            "$ref": "#/components/schemas/long"
+            "description": "Total data downloaded in bytes, aggregated by the query parameters.",
+            "nullable": true,
+            "type": "integer"
           },
           "data_total": {
-            "$ref": "#/components/schemas/long"
+            "description": "Total of data_upload and data_download.",
+            "nullable": true,
+            "type": "integer"
           },
           "data_upload": {
-            "$ref": "#/components/schemas/long"
+            "description": "Total data uploaded in bytes, aggregated by the query parameters.",
+            "nullable": true,
+            "type": "integer"
           },
           "fleet_sid": {
-            "$ref": "#/components/schemas/sid_HF"
+            "description": "SID of the Fleet resource on which the usage occurred.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "iso_country": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "Alpha-2 ISO Country Code of the country the usage occurred in.",
+            "nullable": true,
+            "type": "string"
           },
           "network_sid": {
-            "$ref": "#/components/schemas/sid_HW"
+            "description": "SID of the Network resource on which the usage occurred.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "period": {
-            "$ref": "#/components/schemas/object"
+            "description": "The time period for which the usage is reported.",
+            "nullable": true,
+            "type": "object"
           },
           "sim_sid": {
-            "$ref": "#/components/schemas/sid_HS"
+            "description": "SID of a Sim resource to which the UsageRecord belongs.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_sync_v1.json
+++ b/spec/json/twilio_sync_v1.json
@@ -1,119 +1,87 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ES": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ES[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_ET": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^ET[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MP": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MP[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_TO": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^TO[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_TZ": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^TZ[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
       "sync.v1.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "acl_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether token identities in the Service must be granted access to Sync objects by using the Permissions resource",
+            "nullable": true,
+            "type": "boolean"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "reachability_debouncing_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether every endpoint_disconnected event occurs after a configurable delay",
+            "nullable": true,
+            "type": "boolean"
           },
           "reachability_debouncing_window": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The reachability event delay in milliseconds",
+            "nullable": true,
+            "type": "integer"
           },
           "reachability_webhooks_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the service instance calls webhook_url when client endpoints connect to Sync",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Service resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when Sync objects are manipulated",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhooks_from_rest_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Service instance should call webhook_url when the REST API is used to update Sync objects",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -121,40 +89,77 @@
       "sync.v1.service.document": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the Sync Document's creator",
+            "nullable": true,
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "An arbitrary, schema-less object that the Sync Document stores",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_expires": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Sync Document expires",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of resources related to the Sync Document",
+            "nullable": true,
+            "type": "object"
           },
           "revision": {
-            "$ref": "#/components/schemas/string"
+            "description": "The current revision of the Sync Document, represented by a string identifier",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ET"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ET[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Document resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -162,28 +167,54 @@
       "sync.v1.service.document.document_permission": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "document_sid": {
-            "$ref": "#/components/schemas/sid_ET"
+            "description": "The Sync Document SID",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ET[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the user to whom the Sync Document Permission applies",
+            "nullable": true,
+            "type": "string"
           },
           "manage": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Manage access",
+            "nullable": true,
+            "type": "boolean"
           },
           "read": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Read access",
+            "nullable": true,
+            "type": "boolean"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Sync Document Permission resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "write": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Write access",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -191,37 +222,72 @@
       "sync.v1.service.sync_list": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the Sync List's creator",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_expires": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Sync List expires",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Sync List's nested resources",
+            "nullable": true,
+            "type": "object"
           },
           "revision": {
-            "$ref": "#/components/schemas/string"
+            "description": "The current revision of the Sync List, represented as a string",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_ES"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ES[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Sync List resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -229,37 +295,72 @@
       "sync.v1.service.sync_list.sync_list_item": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the List Item's creator",
+            "nullable": true,
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "An arbitrary, schema-less object that the List Item stores",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_expires": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the List Item expires",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "index": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The automatically generated index of the List Item",
+            "nullable": true,
+            "type": "integer"
           },
           "list_sid": {
-            "$ref": "#/components/schemas/sid_ES"
+            "description": "The SID of the Sync List that contains the List Item",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ES[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "revision": {
-            "$ref": "#/components/schemas/string"
+            "description": "The current revision of the item, represented as a string",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the List Item resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -267,28 +368,54 @@
       "sync.v1.service.sync_list.sync_list_permission": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the user to whom the Sync List Permission applies",
+            "nullable": true,
+            "type": "string"
           },
           "list_sid": {
-            "$ref": "#/components/schemas/sid_ES"
+            "description": "The SID of the Sync List to which the Permission applies",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^ES[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "manage": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Manage access",
+            "nullable": true,
+            "type": "boolean"
           },
           "read": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Read access",
+            "nullable": true,
+            "type": "boolean"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Sync List Permission resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "write": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Write access",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -296,37 +423,72 @@
       "sync.v1.service.sync_map": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the Sync Map's creator",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_expires": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Sync Map expires",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Sync Map's nested resources",
+            "nullable": true,
+            "type": "object"
           },
           "revision": {
-            "$ref": "#/components/schemas/string"
+            "description": "The current revision of the Sync Map, represented as a string",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MP"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Sync Map resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -334,37 +496,72 @@
       "sync.v1.service.sync_map.sync_map_item": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the Map Item's creator",
+            "nullable": true,
+            "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "An arbitrary, schema-less object that the Map Item stores",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_expires": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Map Item expires",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "key": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique, user-defined key for the Map Item",
+            "nullable": true,
+            "type": "string"
           },
           "map_sid": {
-            "$ref": "#/components/schemas/sid_MP"
+            "description": "The SID of the Sync Map that contains the Map Item",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "revision": {
-            "$ref": "#/components/schemas/string"
+            "description": "The current revision of the Map Item, represented as a string",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Map Item resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -372,28 +569,54 @@
       "sync.v1.service.sync_map.sync_map_permission": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identity of the user to whom the Sync Document Permission applies",
+            "nullable": true,
+            "type": "string"
           },
           "manage": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Manage access",
+            "nullable": true,
+            "type": "boolean"
           },
           "map_sid": {
-            "$ref": "#/components/schemas/sid_MP"
+            "description": "Sync Map SID",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "read": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Read access",
+            "nullable": true,
+            "type": "boolean"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Sync Map Permission resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "write": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Write access",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -401,34 +624,67 @@
       "sync.v1.service.sync_stream": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/string"
+            "description": "The Identity of the Stream's creator",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_expires": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Message Stream expires",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Stream's nested resources",
+            "nullable": true,
+            "type": "object"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_IS"
+            "description": "The SID of the Sync Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_TO"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TO[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Message Stream resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -436,22 +692,20 @@
       "sync.v1.service.sync_stream.stream_message": {
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "Stream Message body",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_TZ"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TZ[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_taskrouter_v1.json
+++ b/spec/json/twilio_taskrouter_v1.json
@@ -1,202 +1,102 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "long": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "sid": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_EV": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^EV[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_TC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^TC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WK": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WK[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WQ": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WQ[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WS": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WS[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WW": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WW[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "task_queue_task_order": {
-        "enum": [
-          "FIFO",
-          "LIFO"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "task_reservation_status": {
-        "enum": [
-          "pending",
-          "accepted",
-          "rejected",
-          "timeout",
-          "canceled",
-          "rescinded",
-          "wrapping",
-          "completed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "task_status": {
-        "enum": [
-          "pending",
-          "reserved",
-          "assigned",
-          "canceled",
-          "completed",
-          "wrapping"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "taskrouter.v1.workspace": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "default_activity_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the default activity",
+            "nullable": true,
+            "type": "string"
           },
           "default_activity_sid": {
-            "$ref": "#/components/schemas/sid_WA"
+            "description": "The SID of the Activity that will be used when new Workers are created in the Workspace",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "event_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an event occurs",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "events_filter": {
-            "$ref": "#/components/schemas/string"
+            "description": "The list of Workspace events for which to call event_callback_url",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Workspace resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "multi_task_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether multi-tasking is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "prioritize_queue_order": {
-            "$ref": "#/components/schemas/workspace_queue_order"
+            "description": "The type of TaskQueue to prioritize when Workers are receiving Tasks from both types of TaskQueues",
+            "enum": [
+              "FIFO",
+              "LIFO"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "timeout_activity_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the timeout activity",
+            "nullable": true,
+            "type": "string"
           },
           "timeout_activity_sid": {
-            "$ref": "#/components/schemas/sid_WA"
+            "description": "The SID of the Activity that will be assigned to a Worker when a Task reservation times out without a response",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workspace resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -204,28 +104,56 @@
       "taskrouter.v1.workspace.activity": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "available": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Worker should be eligible to receive a Task when it occupies the Activity",
+            "nullable": true,
+            "type": "boolean"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Activity resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WA"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Activity resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Activity",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -233,55 +161,108 @@
       "taskrouter.v1.workspace.event": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "actor_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the resource that triggered the event",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "actor_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of resource that triggered the event",
+            "nullable": true,
+            "type": "string"
           },
           "actor_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource that triggered the event",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "A description of the event",
+            "nullable": true,
+            "type": "string"
           },
           "event_data": {
-            "$ref": "#/components/schemas/object"
+            "description": "Data about the event",
+            "nullable": true,
+            "type": "object"
           },
           "event_date": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The time the event was sent",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "event_date_ms": {
-            "$ref": "#/components/schemas/long"
+            "description": "The time the event was sent in milliseconds",
+            "nullable": true,
+            "type": "integer"
           },
           "event_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The identifier for the event",
+            "nullable": true,
+            "type": "string"
           },
           "resource_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the object the event is most relevant to",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "resource_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of object the event is most relevant to",
+            "nullable": true,
+            "type": "string"
           },
           "resource_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of the resource the event is most relevant to",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_EV"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^EV[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "source": {
-            "$ref": "#/components/schemas/string"
+            "description": "Where the Event originated",
+            "nullable": true,
+            "type": "string"
           },
           "source_ip_address": {
-            "$ref": "#/components/schemas/string"
+            "description": "The IP from which the Event originated",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Event resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Event",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -289,67 +270,139 @@
       "taskrouter.v1.workspace.task": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "addons": {
-            "$ref": "#/components/schemas/string"
+            "description": "An object that contains the addon data for all installed addons",
+            "nullable": true,
+            "type": "string"
           },
           "age": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of seconds since the Task was created",
+            "nullable": true,
+            "type": "integer"
           },
           "assignment_status": {
-            "$ref": "#/components/schemas/task_status"
+            "description": "The current status of the Task's assignment",
+            "enum": [
+              "pending",
+              "reserved",
+              "assigned",
+              "canceled",
+              "completed",
+              "wrapping"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string with custom attributes of the work",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "priority": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Retrieve the list of all Tasks in the Workspace with the specified priority",
+            "nullable": true,
+            "type": "integer"
           },
           "reason": {
-            "$ref": "#/components/schemas/string"
+            "description": "The reason the Task was canceled or completed",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_channel_sid": {
-            "$ref": "#/components/schemas/sid_TC"
+            "description": "The SID of the TaskChannel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_channel_unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique name of the TaskChannel",
+            "nullable": true,
+            "type": "string"
           },
           "task_queue_entered_date": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Task entered the TaskQueue.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "task_queue_friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly name of the TaskQueue",
+            "nullable": true,
+            "type": "string"
           },
           "task_queue_sid": {
-            "$ref": "#/components/schemas/sid_WQ"
+            "description": "The SID of the TaskQueue",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WQ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "timeout": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The amount of time in seconds that the Task can live before being assigned",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Task resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workflow_friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly name of the Workflow that is controlling the Task",
+            "nullable": true,
+            "type": "string"
           },
           "workflow_sid": {
-            "$ref": "#/components/schemas/sid_WW"
+            "description": "The SID of the Workflow that is controlling the Task",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Task",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -357,37 +410,87 @@
       "taskrouter.v1.workspace.task.task_reservation": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "reservation_status": {
-            "$ref": "#/components/schemas/task_reservation_status"
+            "description": "The current status of the reservation",
+            "enum": [
+              "pending",
+              "accepted",
+              "rejected",
+              "timeout",
+              "canceled",
+              "rescinded",
+              "wrapping",
+              "completed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_sid": {
-            "$ref": "#/components/schemas/sid_WT"
+            "description": "The SID of the reserved Task resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the TaskReservation reservation",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "worker_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly_name of the Worker that is reserved",
+            "nullable": true,
+            "type": "string"
           },
           "worker_sid": {
-            "$ref": "#/components/schemas/sid_WK"
+            "description": "The SID of the reserved Worker resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that this task is contained within.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -395,34 +498,66 @@
       "taskrouter.v1.workspace.task_channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_optimized_routing": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Task Channel will prioritize Workers that have been idle",
+            "nullable": true,
+            "type": "boolean"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_TC"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the Task Channel",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Task Channel resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Task Channel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -430,49 +565,101 @@
       "taskrouter.v1.workspace.task_queue": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assignment_activity_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the Activity to assign Workers when a task is assigned for them",
+            "nullable": true,
+            "type": "string"
           },
           "assignment_activity_sid": {
-            "$ref": "#/components/schemas/sid_WA"
+            "description": "The SID of the Activity to assign Workers when a task is assigned for them",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "max_reserved_workers": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The maximum number of Workers to reserve",
+            "nullable": true,
+            "type": "integer"
           },
           "reservation_activity_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the Activity to assign Workers once a task is reserved for them",
+            "nullable": true,
+            "type": "string"
           },
           "reservation_activity_sid": {
-            "$ref": "#/components/schemas/sid_WA"
+            "description": "The SID of the Activity to assign Workers once a task is reserved for them",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WQ"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WQ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "target_workers": {
-            "$ref": "#/components/schemas/string"
+            "description": "A string describing the Worker selection criteria for any Tasks that enter the TaskQueue",
+            "nullable": true,
+            "type": "string"
           },
           "task_order": {
-            "$ref": "#/components/schemas/task_queue_task_order"
+            "description": "How Tasks will be assigned to Workers",
+            "enum": [
+              "FIFO",
+              "LIFO"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the TaskQueue resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the TaskQueue",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -480,70 +667,126 @@
       "taskrouter.v1.workspace.task_queue.task_queue_cumulative_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "avg_task_acceptance_time": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The average time in seconds between Task creation and acceptance",
+            "nullable": true,
+            "type": "integer"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The end of the interval during which these statistics were calculated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "reservations_accepted": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations accepted for Tasks in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_canceled": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations canceled for Tasks in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_created": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations created for Tasks in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_rejected": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations rejected for Tasks in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_rescinded": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations rescinded",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_timed_out": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that timed out for Tasks in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "split_by_wait_time": {
-            "$ref": "#/components/schemas/object"
+            "description": "A list of objects that describe the Tasks canceled and reservations accepted above and below the specified thresholds",
+            "nullable": true,
+            "type": "object"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The beginning of the interval during which these statistics were calculated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "task_queue_sid": {
-            "$ref": "#/components/schemas/sid_WQ"
+            "description": "The SID of the TaskQueue from which these statistics were calculated",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WQ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "tasks_canceled": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks canceled in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_completed": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks completed in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_deleted": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks deleted in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_entered": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks entered into the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_moved": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were moved from one queue to another",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the TaskQueue statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "wait_duration_in_queue_until_accepted": {
-            "$ref": "#/components/schemas/object"
+            "description": "The relative wait duration statistics for Tasks accepted while in the TaskQueue",
+            "nullable": true,
+            "type": "object"
           },
           "wait_duration_until_accepted": {
-            "$ref": "#/components/schemas/object"
+            "description": "The wait duration statistics for Tasks accepted while in the TaskQueue",
+            "nullable": true,
+            "type": "object"
           },
           "wait_duration_until_canceled": {
-            "$ref": "#/components/schemas/object"
+            "description": "The wait duration statistics for Tasks canceled while in the TaskQueue",
+            "nullable": true,
+            "type": "object"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the TaskQueue",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -551,46 +794,93 @@
       "taskrouter.v1.workspace.task_queue.task_queue_real_time_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "activity_statistics": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The number of current Workers by Activity",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "longest_relative_task_age_in_queue": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The relative age in the TaskQueue for the longest waiting Task.",
+            "nullable": true,
+            "type": "integer"
           },
           "longest_relative_task_sid_in_queue": {
-            "$ref": "#/components/schemas/sid_WT"
+            "description": "The SID of the Task waiting in the TaskQueue the longest.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "longest_task_waiting_age": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The age of the longest waiting Task",
+            "nullable": true,
+            "type": "integer"
           },
           "longest_task_waiting_sid": {
-            "$ref": "#/components/schemas/sid_WT"
+            "description": "The SID of the longest waiting Task",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_queue_sid": {
-            "$ref": "#/components/schemas/sid_WQ"
+            "description": "The SID of the TaskQueue from which these statistics were calculated",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WQ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "tasks_by_priority": {
-            "$ref": "#/components/schemas/object"
+            "description": "The number of Tasks by priority",
+            "nullable": true,
+            "type": "object"
           },
           "tasks_by_status": {
-            "$ref": "#/components/schemas/object"
+            "description": "The number of Tasks by their current status",
+            "nullable": true,
+            "type": "object"
           },
           "total_available_workers": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Workers available for Tasks in the TaskQueue",
+            "nullable": true,
+            "type": "integer"
           },
           "total_eligible_workers": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Workers eligible for Tasks in the TaskQueue, independent of their Activity state",
+            "nullable": true,
+            "type": "integer"
           },
           "total_tasks": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the TaskQueue statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the TaskQueue",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -598,22 +888,44 @@
       "taskrouter.v1.workspace.task_queue.task_queue_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cumulative": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the cumulative statistics for the TaskQueue",
+            "nullable": true,
+            "type": "object"
           },
           "realtime": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the real-time statistics for the TaskQueue",
+            "nullable": true,
+            "type": "object"
           },
           "task_queue_sid": {
-            "$ref": "#/components/schemas/sid_WQ"
+            "description": "The SID of the TaskQueue from which these statistics were calculated",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WQ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the TaskQueue statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the TaskQueue",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -621,19 +933,38 @@
       "taskrouter.v1.workspace.task_queue.task_queues_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cumulative": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the cumulative statistics for the TaskQueues",
+            "nullable": true,
+            "type": "object"
           },
           "realtime": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the real-time statistics for the TaskQueues",
+            "nullable": true,
+            "type": "object"
           },
           "task_queue_sid": {
-            "$ref": "#/components/schemas/sid_WQ"
+            "description": "The SID of the TaskQueue from which these statistics were calculated",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WQ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the TaskQueues",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -641,43 +972,85 @@
       "taskrouter.v1.workspace.worker": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "activity_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly_name of the Worker's current Activity",
+            "nullable": true,
+            "type": "string"
           },
           "activity_sid": {
-            "$ref": "#/components/schemas/sid_WA"
+            "description": "The SID of the Worker's current Activity",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/string"
+            "description": "The JSON string that describes the Worker",
+            "nullable": true,
+            "type": "string"
           },
           "available": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Worker is available to perform tasks",
+            "nullable": true,
+            "type": "boolean"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_status_changed": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date and time in GMT of the last change to the Worker's activity",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WK"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Worker resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Worker",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -685,43 +1058,87 @@
       "taskrouter.v1.workspace.worker.worker_channel": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assigned_tasks": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks assigned to Worker for the TaskChannel type",
+            "nullable": true,
+            "type": "integer"
           },
           "available": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the Worker should receive Tasks of the TaskChannel type",
+            "nullable": true,
+            "type": "boolean"
           },
           "available_capacity_percentage": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The current available capacity between 0 to 100 for the TaskChannel",
+            "nullable": true,
+            "type": "integer"
           },
           "configured_capacity": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The current configured capacity for the WorkerChannel",
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WC"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_channel_sid": {
-            "$ref": "#/components/schemas/sid_TC"
+            "description": "The SID of the TaskChannel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_channel_unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique name of the TaskChannel, such as 'voice' or 'sms'",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the WorkerChannel resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "worker_sid": {
-            "$ref": "#/components/schemas/sid_WK"
+            "description": "The SID of the Worker that contains the WorkerChannel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the WorkerChannel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -729,19 +1146,39 @@
       "taskrouter.v1.workspace.worker.worker_instance_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cumulative": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the cumulative statistics for the Worker",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the WorkerChannel statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "worker_sid": {
-            "$ref": "#/components/schemas/sid_WK"
+            "description": "The SID of the Worker that contains the WorkerChannel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the WorkerChannel",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -749,37 +1186,87 @@
       "taskrouter.v1.workspace.worker.worker_reservation": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "reservation_status": {
-            "$ref": "#/components/schemas/worker_reservation_status"
+            "description": "The current status of the reservation",
+            "enum": [
+              "pending",
+              "accepted",
+              "rejected",
+              "timeout",
+              "canceled",
+              "rescinded",
+              "wrapping",
+              "completed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WR"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_sid": {
-            "$ref": "#/components/schemas/sid_WT"
+            "description": "The SID of the reserved Task resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the WorkerReservation resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "worker_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly_name of the Worker that is reserved",
+            "nullable": true,
+            "type": "string"
           },
           "worker_sid": {
-            "$ref": "#/components/schemas/sid_WK"
+            "description": "The SID of the reserved Worker resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that this worker is contained within.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -787,19 +1274,36 @@
       "taskrouter.v1.workspace.worker.worker_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cumulative": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the cumulative statistics for the Worker",
+            "nullable": true,
+            "type": "object"
           },
           "realtime": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the real-time statistics for the Worker",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Worker statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Worker",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -807,40 +1311,76 @@
       "taskrouter.v1.workspace.worker.workers_cumulative_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "activity_durations": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The minimum, average, maximum, and total time that Workers spent in each Activity",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The end of the interval during which these statistics were calculated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "reservations_accepted": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were accepted",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_canceled": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were canceled",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_created": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were created",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_rejected": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were rejected",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_rescinded": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were rescinded",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_timed_out": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were timed out",
+            "nullable": true,
+            "type": "integer"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The beginning of the interval during which these statistics were calculated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workers statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Workers",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -848,19 +1388,39 @@
       "taskrouter.v1.workspace.worker.workers_real_time_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "activity_statistics": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The number of current Workers by Activity",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "total_workers": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Workers",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workers statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Workers",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -868,43 +1428,83 @@
       "taskrouter.v1.workspace.workflow": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "assignment_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when a task managed by the Workflow is assigned to a Worker",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "configuration": {
-            "$ref": "#/components/schemas/string"
+            "description": "A JSON string that contains the Workflow's configuration",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "document_content_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The MIME type of the document",
+            "nullable": true,
+            "type": "string"
           },
           "fallback_assignment_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when a call to the `assignment_callback_url` fails",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Workflow resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WW"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "task_reservation_timeout": {
-            "$ref": "#/components/schemas/integer"
+            "description": "How long TaskRouter will wait for a confirmation response from your application after it assigns a Task to a Worker",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workflow resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Workflow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -912,70 +1512,126 @@
       "taskrouter.v1.workspace.workflow.workflow_cumulative_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "avg_task_acceptance_time": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The average time in seconds between Task creation and acceptance",
+            "nullable": true,
+            "type": "integer"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The end of the interval during which these statistics were calculated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "reservations_accepted": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations accepted by Workers",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_canceled": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were canceled",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_created": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were created for Workers",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_rejected": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were rejected",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_rescinded": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were rescinded",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_timed_out": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were timed out",
+            "nullable": true,
+            "type": "integer"
           },
           "split_by_wait_time": {
-            "$ref": "#/components/schemas/object"
+            "description": "A list of objects that describe the Tasks canceled and reservations accepted above and below the specified thresholds",
+            "nullable": true,
+            "type": "object"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The beginning of the interval during which these statistics were calculated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "tasks_canceled": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were canceled",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_completed": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were completed",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_deleted": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were deleted",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_entered": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that entered the Workflow",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_moved": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were moved from one queue to another",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_timed_out_in_workflow": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were timed out of their Workflows",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workflow statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "wait_duration_until_accepted": {
-            "$ref": "#/components/schemas/object"
+            "description": "The wait duration statistics for Tasks that were accepted",
+            "nullable": true,
+            "type": "object"
           },
           "wait_duration_until_canceled": {
-            "$ref": "#/components/schemas/object"
+            "description": "The wait duration statistics for Tasks that were canceled",
+            "nullable": true,
+            "type": "object"
           },
           "workflow_sid": {
-            "$ref": "#/components/schemas/sid_WW"
+            "description": "Returns the list of Tasks that are being controlled by the Workflow with the specified Sid value",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Workflow.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -983,31 +1639,62 @@
       "taskrouter.v1.workspace.workflow.workflow_real_time_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "longest_task_waiting_age": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The age of the longest waiting Task",
+            "nullable": true,
+            "type": "integer"
           },
           "longest_task_waiting_sid": {
-            "$ref": "#/components/schemas/sid_WT"
+            "description": "The SID of the longest waiting Task",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "tasks_by_priority": {
-            "$ref": "#/components/schemas/object"
+            "description": "The number of Tasks by priority",
+            "nullable": true,
+            "type": "object"
           },
           "tasks_by_status": {
-            "$ref": "#/components/schemas/object"
+            "description": "The number of Tasks by their current status",
+            "nullable": true,
+            "type": "object"
           },
           "total_tasks": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workflow statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workflow_sid": {
-            "$ref": "#/components/schemas/sid_WW"
+            "description": "Returns the list of Tasks that are being controlled by the Workflow with the specified SID value",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Workflow.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1015,22 +1702,44 @@
       "taskrouter.v1.workspace.workflow.workflow_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cumulative": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the cumulative statistics for the Workflow",
+            "nullable": true,
+            "type": "object"
           },
           "realtime": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the real-time statistics for the Workflow",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workflow statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workflow_sid": {
-            "$ref": "#/components/schemas/sid_WW"
+            "description": "Returns the list of Tasks that are being controlled by the Workflow with the specified SID value",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace that contains the Workflow",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1038,67 +1747,118 @@
       "taskrouter.v1.workspace.workspace_cumulative_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "avg_task_acceptance_time": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The average time in seconds between Task creation and acceptance",
+            "nullable": true,
+            "type": "integer"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The end of the interval during which these statistics were calculated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "reservations_accepted": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations accepted by Workers",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_canceled": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were canceled",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_created": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were created for Workers",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_rejected": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were rejected",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_rescinded": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were rescinded",
+            "nullable": true,
+            "type": "integer"
           },
           "reservations_timed_out": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Reservations that were timed out",
+            "nullable": true,
+            "type": "integer"
           },
           "split_by_wait_time": {
-            "$ref": "#/components/schemas/object"
+            "description": "A list of objects that describe the Tasks canceled and reservations accepted above and below the specified thresholds",
+            "nullable": true,
+            "type": "object"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The beginning of the interval during which these statistics were calculated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "tasks_canceled": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were canceled",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_completed": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were completed",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_created": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks created",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_deleted": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were deleted",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_moved": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were moved from one queue to another",
+            "nullable": true,
+            "type": "integer"
           },
           "tasks_timed_out_in_workflow": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks that were timed out of their Workflows",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workspace statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "wait_duration_until_accepted": {
-            "$ref": "#/components/schemas/object"
+            "description": "The wait duration statistics for Tasks that were accepted",
+            "nullable": true,
+            "type": "object"
           },
           "wait_duration_until_canceled": {
-            "$ref": "#/components/schemas/object"
+            "description": "The wait duration statistics for Tasks that were canceled",
+            "nullable": true,
+            "type": "object"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1106,34 +1866,67 @@
       "taskrouter.v1.workspace.workspace_real_time_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "activity_statistics": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The number of current Workers by Activity",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "longest_task_waiting_age": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The age of the longest waiting Task",
+            "nullable": true,
+            "type": "integer"
           },
           "longest_task_waiting_sid": {
-            "$ref": "#/components/schemas/sid_WT"
+            "description": "The SID of the longest waiting Task",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "tasks_by_priority": {
-            "$ref": "#/components/schemas/object"
+            "description": "The number of Tasks by priority",
+            "nullable": true,
+            "type": "object"
           },
           "tasks_by_status": {
-            "$ref": "#/components/schemas/object"
+            "description": "The number of Tasks by their current status",
+            "nullable": true,
+            "type": "object"
           },
           "total_tasks": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Tasks",
+            "nullable": true,
+            "type": "integer"
           },
           "total_workers": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total number of Workers in the Workspace",
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workspace statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1141,53 +1934,39 @@
       "taskrouter.v1.workspace.workspace_statistics": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cumulative": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that contains the cumulative statistics for the Workspace",
+            "nullable": true,
+            "type": "object"
           },
           "realtime": {
-            "$ref": "#/components/schemas/object"
+            "description": "n object that contains the real-time statistics for the Workspace",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Workspace statistics resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "workspace_sid": {
-            "$ref": "#/components/schemas/sid_WS"
+            "description": "The SID of the Workspace",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WS[0-9a-fA-F]{32}$",
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "worker_reservation_status": {
-        "enum": [
-          "pending",
-          "accepted",
-          "rejected",
-          "timeout",
-          "canceled",
-          "rescinded",
-          "wrapping",
-          "completed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "workspace_queue_order": {
-        "enum": [
-          "FIFO",
-          "LIFO"
-        ],
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_trunking_v1.json
+++ b/spec/json/twilio_trunking_v1.json
@@ -1,190 +1,113 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "phone_number": {
-        "nullable": true,
-        "type": "string"
-      },
-      "phone_number_address_requirement": {
-        "enum": [
-          "none",
-          "any",
-          "local",
-          "foreign"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "recording_recording_mode": {
-        "enum": [
-          "do-not-record",
-          "record-from-ringing",
-          "record-from-answer",
-          "record-from-ringing-dual",
-          "record-from-answer-dual"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "recording_recording_trim": {
-        "enum": [
-          "trim-silence",
-          "do-not-trim"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AP": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AP[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_OU": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^OU[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_PN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^PN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_TK": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^TK[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "string_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "trunk_transfer_setting": {
-        "enum": [
-          "disable-all",
-          "enable-all",
-          "sip-only"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "trunking.v1.trunk": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "auth_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The types of authentication mapped to the domain",
+            "nullable": true,
+            "type": "string"
           },
           "auth_type_set": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "Reserved",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "cnam_lookup_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether Caller ID Name (CNAM) lookup is enabled for the trunk",
+            "nullable": true,
+            "type": "boolean"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "disaster_recovery_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call the disaster_recovery_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "disaster_recovery_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The HTTP URL that we call if an error occurs while sending SIP traffic towards your configured Origination URL",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "domain_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique address you reserve on Twilio to which you route your SIP traffic",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "recording": {
-            "$ref": "#/components/schemas/object"
+            "description": "The recording settings for the trunk",
+            "nullable": true,
+            "type": "object"
           },
           "secure": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether Secure Trunking is enabled for the trunk",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "transfer_mode": {
-            "$ref": "#/components/schemas/trunk_transfer_setting"
+            "description": "The call transfer settings for the trunk",
+            "enum": [
+              "disable-all",
+              "enable-all",
+              "sip-only"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -192,25 +115,51 @@
       "trunking.v1.trunk.credential_list": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk the credential list in associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -218,25 +167,51 @@
       "trunking.v1.trunk.ip_access_control_list": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_AL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -244,37 +219,72 @@
       "trunking.v1.trunk.origination_url": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the URL is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "priority": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The relative importance of the URI",
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_OU"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^OU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sip_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The SIP address you want Twilio to route your Origination calls to",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk that owns the Origination URL",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "weight": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The value that determines the relative load the URI should receive compared to others with the same priority",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
@@ -282,82 +292,203 @@
       "trunking.v1.trunk.phone_number": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "address_requirements": {
-            "$ref": "#/components/schemas/phone_number_address_requirement"
+            "description": "Whether the phone number requires an Address registered with Twilio",
+            "enum": [
+              "none",
+              "any",
+              "local",
+              "foreign"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "api_version": {
-            "$ref": "#/components/schemas/string"
+            "description": "The API version used to start a new TwiML session",
+            "nullable": true,
+            "type": "string"
           },
           "beta": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the phone number is new to the Twilio platform",
+            "nullable": true,
+            "type": "boolean"
           },
           "capabilities": {
-            "$ref": "#/components/schemas/string_map"
+            "description": "Indicate if a phone can receive calls or messages",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "phone_number": {
-            "$ref": "#/components/schemas/phone_number"
+            "description": "The phone number in E.164 format",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PN"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles SMS messages sent to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call when an error occurs while retrieving or executing the TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with sms_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives an incoming SMS message",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trunk_sid": {
-            "$ref": "#/components/schemas/sid_TK"
+            "description": "The SID of the Trunk that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^TK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_application_sid": {
-            "$ref": "#/components/schemas/sid_AP"
+            "description": "The SID of the application that handles calls to the phone number",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "voice_caller_id_lookup": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to lookup the caller's name",
+            "nullable": true,
+            "type": "boolean"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method that we use to call voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs in TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with the voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the phone number receives a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -365,22 +496,28 @@
       "trunking.v1.trunk.recording": {
         "properties": {
           "mode": {
-            "$ref": "#/components/schemas/recording_recording_mode"
+            "description": "The recording mode for the trunk.",
+            "enum": [
+              "do-not-record",
+              "record-from-ringing",
+              "record-from-answer",
+              "record-from-ringing-dual",
+              "record-from-answer-dual"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trim": {
-            "$ref": "#/components/schemas/recording_recording_trim"
+            "description": "The recording trim setting for the trunk.",
+            "enum": [
+              "trim-silence",
+              "do-not-trim"
+            ],
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_trusthub_v1.json
+++ b/spec/json/twilio_trusthub_v1.json
@@ -1,183 +1,88 @@
 {
   "components": {
     "schemas": {
-      "customer_profile_evaluation_status": {
-        "enum": [
-          "compliant",
-          "noncompliant"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "customer_profile_status": {
-        "enum": [
-          "draft",
-          "pending-review",
-          "in-review",
-          "twilio-rejected",
-          "twilio-approved"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "sid": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BU": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BU[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BV": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BV[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_EL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^EL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_OY": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^OY[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RD": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RD[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RN": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RN[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "supporting_document_status": {
-        "enum": [
-          "draft",
-          "pending-review",
-          "rejected",
-          "approved",
-          "expired",
-          "provisionally-approved"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "trust_product_evaluation_status": {
-        "enum": [
-          "compliant",
-          "noncompliant"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "trust_product_status": {
-        "enum": [
-          "draft",
-          "pending-review",
-          "in-review",
-          "twilio-rejected",
-          "twilio-approved"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "trusthub.v1.customer_profile": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "email": {
-            "$ref": "#/components/schemas/string"
+            "description": "The email address",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Assigned Items of the Customer-Profile resource",
+            "nullable": true,
+            "type": "object"
           },
           "policy_sid": {
-            "$ref": "#/components/schemas/sid_RN"
+            "description": "The unique string of a policy.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/customer_profile_status"
+            "description": "The verification status of the Customer-Profile resource",
+            "enum": [
+              "draft",
+              "pending-review",
+              "in-review",
+              "twilio-rejected",
+              "twilio-approved"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call to inform your application of status changes.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Customer-Profile resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "valid_until": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource will be valid until.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -185,25 +90,53 @@
       "trusthub.v1.customer_profile.customer_profile_channel_endpoint_assignment": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_endpoint_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The sid of an channel endpoint",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_endpoint_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of channel endpoint",
+            "nullable": true,
+            "type": "string"
           },
           "customer_profile_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the CustomerProfile resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RA"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Identity resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -211,22 +144,48 @@
       "trusthub.v1.customer_profile.customer_profile_entity_assignment": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "customer_profile_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the CustomerProfile resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "object_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The sid of an object bag",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BV"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BV[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Identity resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -234,28 +193,63 @@
       "trusthub.v1.customer_profile.customer_profile_evaluation": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "customer_profile_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "policy_sid": {
-            "$ref": "#/components/schemas/sid_RN"
+            "description": "The unique string of a policy",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "results": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The results of the Evaluation resource",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_EL"
+            "description": "The unique string that identifies the Evaluation resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^EL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/customer_profile_evaluation_status"
+            "description": "The compliance status of the Evaluation resource",
+            "enum": [
+              "compliant",
+              "noncompliant"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -263,28 +257,53 @@
       "trusthub.v1.end_user": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "The set of parameters that compose the End Users resource",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of end user of the Bundle resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the End User resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -292,19 +311,36 @@
       "trusthub.v1.end_user_type": {
         "properties": {
           "fields": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The required information for creating an End-User.",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human-readable description of the End-User Type resource",
+            "nullable": true,
+            "type": "string"
           },
           "machine_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A machine-readable description of the End-User Type resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_OY"
+            "description": "The unique string that identifies the End-User Type resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^OY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the End-User Type resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -312,16 +348,28 @@
       "trusthub.v1.policies": {
         "properties": {
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human-readable description of the Policy resource",
+            "nullable": true,
+            "type": "string"
           },
           "requirements": {
-            "$ref": "#/components/schemas/object"
+            "description": "The sid of a Policy object that dictates requirements",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RN"
+            "description": "The unique string that identifies the Policy resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Policy resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -329,34 +377,71 @@
       "trusthub.v1.supporting_document": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "attributes": {
-            "$ref": "#/components/schemas/object"
+            "description": "The set of parameters that compose the Supporting Documents resource",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "mime_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The image type of the file",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RD"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/supporting_document_status"
+            "description": "The verification status of the Supporting Document resource",
+            "enum": [
+              "draft",
+              "pending-review",
+              "rejected",
+              "approved",
+              "expired",
+              "provisionally-approved"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of the Supporting Document",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Supporting Document resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -364,19 +449,36 @@
       "trusthub.v1.supporting_document_type": {
         "properties": {
           "fields": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The required information for creating a Supporting Document",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human-readable description of the Supporting Document Type resource",
+            "nullable": true,
+            "type": "string"
           },
           "machine_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The machine-readable description of the Supporting Document Type resource",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_OY"
+            "description": "The unique string that identifies the Supporting Document Type resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^OY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Supporting Document Type resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -384,40 +486,85 @@
       "trusthub.v1.trust_product": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "email": {
-            "$ref": "#/components/schemas/string"
+            "description": "The email address",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of the Assigned Items of the Customer-Profile resource",
+            "nullable": true,
+            "type": "object"
           },
           "policy_sid": {
-            "$ref": "#/components/schemas/sid_RN"
+            "description": "The unique string of a policy.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/trust_product_status"
+            "description": "The verification status of the Customer-Profile resource",
+            "enum": [
+              "draft",
+              "pending-review",
+              "in-review",
+              "twilio-rejected",
+              "twilio-approved"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call to inform your application of status changes.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Customer-Profile resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "valid_until": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource will be valid until.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -425,25 +572,53 @@
       "trusthub.v1.trust_product.trust_product_channel_endpoint_assignment": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_endpoint_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The sid of an channel endpoint",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel_endpoint_type": {
-            "$ref": "#/components/schemas/string"
+            "description": "The type of channel endpoint",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RA"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "trust_product_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the CustomerProfile resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Identity resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -451,22 +626,48 @@
       "trusthub.v1.trust_product.trust_product_entity_assignment": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "object_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The sid of an object bag",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BV"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BV[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "trust_product_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the TrustProduct resource.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Identity resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -474,40 +675,66 @@
       "trusthub.v1.trust_product.trust_product_evaluation": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "policy_sid": {
-            "$ref": "#/components/schemas/sid_RN"
+            "description": "The unique string of a policy",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RN[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "results": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "The results of the Evaluation resource",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_EL"
+            "description": "The unique string that identifies the Evaluation resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^EL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/trust_product_evaluation_status"
+            "description": "The compliance status of the Evaluation resource",
+            "enum": [
+              "compliant",
+              "noncompliant"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trust_product_sid": {
-            "$ref": "#/components/schemas/sid_BU"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BU[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_verify_v2.json
+++ b/spec/json/twilio_verify_v2.json
@@ -1,223 +1,31 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "challenge_challenge_reasons": {
-        "enum": [
-          "none",
-          "not_needed",
-          "not_requested"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "challenge_challenge_statuses": {
-        "enum": [
-          "pending",
-          "expired",
-          "approved",
-          "denied"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "challenge_factor_types": {
-        "enum": [
-          "push"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "factor_factor_statuses": {
-        "enum": [
-          "unverified",
-          "verified"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "factor_factor_types": {
-        "enum": [
-          "push"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "form_form_types": {
-        "enum": [
-          "form-push"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "object_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MG": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MG[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RK": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RK[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_VA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^VA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_VE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^VE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_VL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^VL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_YC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^YC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_YE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^YE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_YF": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^YF[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_YW": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^YW[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
-      "verification_attempt_channels": {
-        "enum": [
-          "sms",
-          "call",
-          "email"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "verification_attempt_conversion_status": {
-        "enum": [
-          "converted",
-          "unconverted"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "verification_channel": {
-        "enum": [
-          "sms",
-          "call",
-          "email"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "verification_check_channel": {
-        "enum": [
-          "sms",
-          "call",
-          "email"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
       "verify.v2.form": {
         "properties": {
           "form_meta": {
-            "$ref": "#/components/schemas/object"
+            "description": "Additional information for the available forms for this type.",
+            "nullable": true,
+            "type": "object"
           },
           "form_type": {
-            "$ref": "#/components/schemas/form_form_types"
+            "description": "The Type of this Form",
+            "enum": [
+              "form-push"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "forms": {
-            "$ref": "#/components/schemas/object"
+            "description": "Object that contains the available forms for this type.",
+            "nullable": true,
+            "type": "object"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to access the forms for this type.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -225,52 +33,93 @@
       "verify.v2.service": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "code_length": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The length of the verification code",
+            "nullable": true,
+            "type": "integer"
           },
           "custom_code_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to allow sending verifications with a custom code.",
+            "nullable": true,
+            "type": "boolean"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "do_not_share_warning_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to add a security warning at the end of an SMS.",
+            "nullable": true,
+            "type": "boolean"
           },
           "dtmf_input_required": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to ask the user to press a number before delivering the verify code in a phone call",
+            "nullable": true,
+            "type": "boolean"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the verification service",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "lookup_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to perform a lookup with each verification",
+            "nullable": true,
+            "type": "boolean"
           },
           "psd2_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to pass PSD2 transaction parameters when starting a verification",
+            "nullable": true,
+            "type": "boolean"
           },
           "push": {
-            "$ref": "#/components/schemas/object"
+            "description": "The service level configuration of factor push type.",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "skip_sms_to_landlines": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to skip sending SMS verifications to landlines",
+            "nullable": true,
+            "type": "boolean"
           },
           "tts_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of an alternative text-to-speech service to use in phone calls",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -278,7 +127,9 @@
       "verify.v2.service.access_token": {
         "properties": {
           "token": {
-            "$ref": "#/components/schemas/string"
+            "description": "Generated access token.",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -286,28 +137,56 @@
       "verify.v2.service.entity": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "Account Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Entity was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Entity was updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "Unique external identifier of the Entity",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "Nested resource URLs.",
+            "nullable": true,
+            "type": "object"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "Service Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_YE"
+            "description": "A string that uniquely identifies this Entity.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^YE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -315,52 +194,118 @@
       "verify.v2.service.entity.challenge": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "Account Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Challenge was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_responded": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Challenge was responded",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Challenge was updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "details": {
-            "$ref": "#/components/schemas/object"
+            "description": "Details about the Challenge.",
+            "nullable": true,
+            "type": "object"
           },
           "entity_sid": {
-            "$ref": "#/components/schemas/sid_YE"
+            "description": "Entity Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^YE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "expiration_date": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date-time when this Challenge expires",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "factor_sid": {
-            "$ref": "#/components/schemas/sid_YF"
+            "description": "Factor Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^YF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "factor_type": {
-            "$ref": "#/components/schemas/challenge_factor_types"
+            "description": "The Factor Type of this Challenge",
+            "enum": [
+              "push"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "hidden_details": {
-            "$ref": "#/components/schemas/object"
+            "description": "Hidden details about the Challenge",
+            "nullable": true,
+            "type": "object"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "Unique external identifier of the Entity",
+            "nullable": true,
+            "type": "string"
           },
           "responded_reason": {
-            "$ref": "#/components/schemas/challenge_challenge_reasons"
+            "description": "The Reason of this Challenge `status`",
+            "enum": [
+              "none",
+              "not_needed",
+              "not_requested"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "Service Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_YC"
+            "description": "A string that uniquely identifies this Challenge.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^YC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/challenge_challenge_statuses"
+            "description": "The Status of this Challenge",
+            "enum": [
+              "pending",
+              "expired",
+              "approved",
+              "denied"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -368,40 +313,86 @@
       "verify.v2.service.entity.factor": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "Account Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "config": {
-            "$ref": "#/components/schemas/object"
+            "description": "Configurations for a `factor_type`.",
+            "nullable": true,
+            "type": "object"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Factor was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Factor was updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "entity_sid": {
-            "$ref": "#/components/schemas/sid_YE"
+            "description": "Entity Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^YE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "factor_type": {
-            "$ref": "#/components/schemas/factor_factor_types"
+            "description": "The Type of this Factor",
+            "enum": [
+              "push"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A human readable description of this resource.",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "Unique external identifier of the Entity",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "Service Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_YF"
+            "description": "A string that uniquely identifies this Factor.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^YF[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/factor_factor_statuses"
+            "description": "The Status of this Factor",
+            "enum": [
+              "unverified",
+              "verified"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -409,25 +400,51 @@
       "verify.v2.service.messaging_configuration": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ISO-3166-1 country code of the country or `all`.",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "messaging_service_sid": {
-            "$ref": "#/components/schemas/sid_MG"
+            "description": "The SID of the Messaging Service used for this configuration.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MG[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -435,31 +452,61 @@
       "verify.v2.service.rate_limit": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "description": {
-            "$ref": "#/components/schemas/string"
+            "description": "Description of this Rate Limit",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RK"
+            "description": "A string that uniquely identifies this Rate Limit.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "A unique, developer assigned name of this Rate Limit.",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -467,31 +514,64 @@
       "verify.v2.service.rate_limit.bucket": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "interval": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Number of seconds that the rate limit will be enforced over.",
+            "nullable": true,
+            "type": "integer"
           },
           "max": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Max number of requests.",
+            "nullable": true,
+            "type": "integer"
           },
           "rate_limit_sid": {
-            "$ref": "#/components/schemas/sid_RK"
+            "description": "Rate Limit Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BL"
+            "description": "A string that uniquely identifies this Bucket.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of this resource.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -499,46 +579,94 @@
       "verify.v2.service.verification": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "amount": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of the associated PSD2 compliant transaction.",
+            "nullable": true,
+            "type": "string"
           },
           "channel": {
-            "$ref": "#/components/schemas/verification_channel"
+            "description": "The verification method used.",
+            "enum": [
+              "sms",
+              "call",
+              "email"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "lookup": {
-            "$ref": "#/components/schemas/object"
+            "description": "Information about the phone number being verified",
+            "nullable": true,
+            "type": "object"
           },
           "payee": {
-            "$ref": "#/components/schemas/string"
+            "description": "The payee of the associated PSD2 compliant transaction",
+            "nullable": true,
+            "type": "string"
           },
           "send_code_attempts": {
-            "$ref": "#/components/schemas/object_list"
+            "description": "An array of verification attempt objects.",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_VE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/string"
+            "description": "The status of the verification resource",
+            "nullable": true,
+            "type": "string"
           },
           "to": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number or email being verified",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Verification resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "valid": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the verification was successful",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -546,37 +674,75 @@
       "verify.v2.service.verification_check": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "amount": {
-            "$ref": "#/components/schemas/string"
+            "description": "The amount of the associated PSD2 compliant transaction.",
+            "nullable": true,
+            "type": "string"
           },
           "channel": {
-            "$ref": "#/components/schemas/verification_check_channel"
+            "description": "The verification method to use",
+            "enum": [
+              "sms",
+              "call",
+              "email"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Verification Check resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Verification Check resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "payee": {
-            "$ref": "#/components/schemas/string"
+            "description": "The payee of the associated PSD2 compliant transaction",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "The SID of the Service that the resource is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_VE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/string"
+            "description": "The status of the verification resource",
+            "nullable": true,
+            "type": "string"
           },
           "to": {
-            "$ref": "#/components/schemas/string"
+            "description": "The phone number or email being verified",
+            "nullable": true,
+            "type": "string"
           },
           "valid": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the verification was successful",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -584,37 +750,83 @@
       "verify.v2.service.webhook": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "event_types": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The array of events that this Webhook is subscribed to.",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the webhook",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "description": "Service Sid.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_YW"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^YW[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/webhook_status"
+            "description": "The webhook status",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the Webhook resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "webhook_method": {
-            "$ref": "#/components/schemas/webhook_methods"
+            "description": "The method used when calling the webhook's URL.",
+            "enum": [
+              "GET",
+              "POST"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "webhook_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL associated with this Webhook.",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -622,50 +834,71 @@
       "verify.v2.verification_attempt": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "Account Sid",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "channel": {
-            "$ref": "#/components/schemas/verification_attempt_channels"
+            "description": "Channel used for the attempt",
+            "enum": [
+              "sms",
+              "call",
+              "email"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "channel_data": {
-            "$ref": "#/components/schemas/object"
+            "description": "Object with the channel information for an attempt",
+            "nullable": true,
+            "type": "object"
           },
           "conversion_status": {
-            "$ref": "#/components/schemas/verification_attempt_conversion_status"
+            "description": "Status of a conversion",
+            "enum": [
+              "converted",
+              "unconverted"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Attempt was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date this Attempt was updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "service_sid": {
-            "$ref": "#/components/schemas/sid_VA"
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_VL"
+            "description": "A string that uniquely identifies this Verification Attempt",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^VL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
-      },
-      "webhook_methods": {
-        "enum": [
-          "GET",
-          "POST"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "webhook_status": {
-        "enum": [
-          "enabled",
-          "disabled"
-        ],
-        "nullable": true,
-        "type": "string"
       }
     },
     "securitySchemes": {

--- a/spec/json/twilio_video_v1.json
+++ b/spec/json/twilio_video_v1.json
@@ -1,365 +1,127 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "composition_format": {
-        "enum": [
-          "mp4",
-          "webm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "composition_hook_format": {
-        "enum": [
-          "mp4",
-          "webm"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "composition_status": {
-        "enum": [
-          "enqueued",
-          "processing",
-          "completed",
-          "deleted",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "long": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "recording_codec": {
-        "enum": [
-          "VP8",
-          "H264",
-          "OPUS",
-          "PCMU"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "recording_format": {
-        "enum": [
-          "mka",
-          "mkv"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "recording_rule_list": {
-        "items": {
-          "properties": {
-            "all": {
-              "type": "boolean"
-            },
-            "kind": {
-              "type": "string"
-            },
-            "publisher": {
-              "type": "string"
-            },
-            "track": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "recording_status": {
-        "enum": [
-          "processing",
-          "completed",
-          "deleted",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "recording_type": {
-        "enum": [
-          "audio",
-          "video",
-          "data"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_participant_published_track_kind": {
-        "enum": [
-          "audio",
-          "video",
-          "data"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_participant_status": {
-        "enum": [
-          "connected",
-          "disconnected"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_participant_subscribed_track_kind": {
-        "enum": [
-          "audio",
-          "video",
-          "data"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_recording_codec": {
-        "enum": [
-          "VP8",
-          "H264",
-          "OPUS",
-          "PCMU"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_recording_format": {
-        "enum": [
-          "mka",
-          "mkv"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_recording_status": {
-        "enum": [
-          "processing",
-          "completed",
-          "deleted",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_recording_type": {
-        "enum": [
-          "audio",
-          "video",
-          "data"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_room_status": {
-        "enum": [
-          "in-progress",
-          "completed",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_room_type": {
-        "enum": [
-          "go",
-          "peer-to-peer",
-          "group",
-          "group-small"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "room_video_codec_list": {
-        "items": {
-          "enum": [
-            "VP8",
-            "H264"
-          ],
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "sid": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CJ": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CJ[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_CR": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^CR[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_HK": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^HK[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_MT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^MT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_PA": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^PA[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RM": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RM[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_RT": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^RT[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "subscribe_rule_list": {
-        "items": {
-          "type": "object"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
       "video.v1.composition": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "audio_sources": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The array of track names to include in the composition",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "audio_sources_excluded": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The array of track names to exclude from the composition",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "bitrate": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The average bit rate of the composition's media",
+            "nullable": true,
+            "type": "integer"
           },
           "date_completed": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "Date when the media processing task finished",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_deleted": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the composition generated media was deleted",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The duration of the composition's media file in seconds",
+            "nullable": true,
+            "type": "integer"
           },
           "format": {
-            "$ref": "#/components/schemas/composition_format"
+            "description": "The container format of the composition's media files as specified in the POST request that created the Composition resource",
+            "enum": [
+              "mp4",
+              "webm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URL of the media file associated with the composition",
+            "nullable": true,
+            "type": "object"
           },
           "resolution": {
-            "$ref": "#/components/schemas/string"
+            "description": "The dimensions of the video image in pixels expressed as columns (width) and rows (height)",
+            "nullable": true,
+            "type": "string"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "description": "The SID of the Group Room that generated the audio and video tracks used in the composition",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_CJ"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CJ[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "size": {
-            "$ref": "#/components/schemas/long"
+            "description": "The size of the composed media file in bytes",
+            "nullable": true,
+            "type": "integer"
           },
           "status": {
-            "$ref": "#/components/schemas/composition_status"
+            "description": "The status of the composition",
+            "enum": [
+              "enqueued",
+              "processing",
+              "completed",
+              "deleted",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trim": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to remove intervals with no media",
+            "nullable": true,
+            "type": "boolean"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "video_layout": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that describes the video layout of the composition",
+            "nullable": true,
+            "type": "object"
           }
         },
         "type": "object"
@@ -367,49 +129,107 @@
       "video.v1.composition_hook": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "audio_sources": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The array of track names to include in the compositions created by the composition hook",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "audio_sources_excluded": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The array of track names to exclude from the compositions created by the composition hook",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the CompositionHook is active",
+            "nullable": true,
+            "type": "boolean"
           },
           "format": {
-            "$ref": "#/components/schemas/composition_hook_format"
+            "description": "The container format of the media files used by the compositions created by the composition hook",
+            "enum": [
+              "mp4",
+              "webm"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "resolution": {
-            "$ref": "#/components/schemas/string"
+            "description": "The dimensions of the video image in pixels expressed as columns (width) and rows (height)",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_HK"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^HK[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we should use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "trim": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether intervals with no media are clipped",
+            "nullable": true,
+            "type": "boolean"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "video_layout": {
-            "$ref": "#/components/schemas/object"
+            "description": "A JSON object that describes the video layout of the Composition",
+            "nullable": true,
+            "type": "object"
           }
         },
         "type": "object"
@@ -417,28 +237,55 @@
       "video.v1.composition_settings": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "aws_credentials_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the stored Credential resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "aws_s3_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of the AWS S3 bucket where the compositions are stored",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "aws_storage_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether all compositions are written to the aws_s3_url",
+            "nullable": true,
+            "type": "boolean"
           },
           "encryption_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether all compositions are stored in an encrypted form",
+            "nullable": true,
+            "type": "boolean"
           },
           "encryption_key_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Public Key resource used for encryption",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -446,49 +293,111 @@
       "video.v1.recording": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "codec": {
-            "$ref": "#/components/schemas/recording_codec"
+            "description": "The codec used to encode the track",
+            "enum": [
+              "VP8",
+              "H264",
+              "OPUS",
+              "PCMU"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "container_format": {
-            "$ref": "#/components/schemas/recording_format"
+            "description": "The file format for the recording",
+            "enum": [
+              "mka",
+              "mkv"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The duration of the recording in seconds",
+            "nullable": true,
+            "type": "integer"
           },
           "grouping_sids": {
-            "$ref": "#/components/schemas/object"
+            "description": "A list of SIDs related to the recording",
+            "nullable": true,
+            "type": "object"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "offset": {
-            "$ref": "#/components/schemas/long"
+            "description": "The number of milliseconds between a point in time that is common to all rooms in a group and when the source room of the recording started",
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "size": {
-            "$ref": "#/components/schemas/long"
+            "description": "The size of the recorded track, in bytes",
+            "nullable": true,
+            "type": "integer"
           },
           "source_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the recording source",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/recording_status"
+            "description": "The status of the recording",
+            "enum": [
+              "processing",
+              "completed",
+              "deleted",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "track_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name that was given to the source track of the recording",
+            "nullable": true,
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/recording_type"
+            "description": "The recording's media type",
+            "enum": [
+              "audio",
+              "video",
+              "data"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -496,28 +405,55 @@
       "video.v1.recording_settings": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "aws_credentials_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the stored Credential resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "aws_s3_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL of the AWS S3 bucket where the recordings are stored",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "aws_storage_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether all recordings are written to the aws_s3_url",
+            "nullable": true,
+            "type": "boolean"
           },
           "encryption_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether all recordings are stored in an encrypted form",
+            "nullable": true,
+            "type": "boolean"
           },
           "encryption_key_sid": {
-            "$ref": "#/components/schemas/sid_CR"
+            "description": "The SID of the Public Key resource used for encryption",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^CR[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -525,61 +461,136 @@
       "video.v1.room": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The duration of the room in seconds",
+            "nullable": true,
+            "type": "integer"
           },
           "enable_turn": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Enable Twilio's Network Traversal TURN service",
+            "nullable": true,
+            "type": "boolean"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The UTC end time of the room in UTC ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "max_concurrent_published_tracks": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The maximum number of published tracks allowed in the room at the same time",
+            "nullable": true,
+            "type": "integer"
           },
           "max_participants": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The maximum number of concurrent Participants allowed in the room",
+            "nullable": true,
+            "type": "integer"
           },
           "media_region": {
-            "$ref": "#/components/schemas/string"
+            "description": "The region for the media server in Group Rooms",
+            "nullable": true,
+            "type": "string"
           },
           "record_participants_on_connect": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to start recording when Participants connect",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/room_room_status"
+            "description": "The status of the room",
+            "enum": [
+              "in-progress",
+              "completed",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "status_callback": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL to send status information to your application",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/room_room_type"
+            "description": "The type of room",
+            "enum": [
+              "go",
+              "peer-to-peer",
+              "group",
+              "group-small"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "video_codecs": {
-            "$ref": "#/components/schemas/room_video_codec_list"
+            "description": "An array of the video codecs that are supported when publishing a track in the room",
+            "items": {
+              "enum": [
+                "VP8",
+                "H264"
+              ],
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           }
         },
         "type": "object"
@@ -587,40 +598,82 @@
       "video.v1.room.room_participant": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/integer"
+            "description": "Duration of time in seconds the participant was connected",
+            "nullable": true,
+            "type": "integer"
           },
           "end_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The time when the participant disconnected from the room in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "identity": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that identifies the resource's User",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "description": "The SID of the participant's room",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_PA"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "start_time": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The time of participant connected to the room in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/room_participant_status"
+            "description": "The status of the Participant",
+            "enum": [
+              "connected",
+              "disconnected"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -628,31 +681,66 @@
       "video.v1.room.room_participant.room_participant_published_track": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the track is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "kind": {
-            "$ref": "#/components/schemas/room_participant_published_track_kind"
+            "description": "The track type",
+            "enum": [
+              "audio",
+              "video",
+              "data"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The track name",
+            "nullable": true,
+            "type": "string"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_PA"
+            "description": "The SID of the Participant resource with the published track",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "description": "The SID of the Room resource where the track is published",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -660,19 +748,40 @@
       "video.v1.room.room_participant.room_participant_subscribe_rule": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_PA"
+            "description": "The SID of the Participant resource for the Subscribe Rules",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "description": "The SID of the Room resource for the Subscribe Rules",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "rules": {
-            "$ref": "#/components/schemas/subscribe_rule_list"
+            "description": "A collection of Subscribe Rules that describe how to include or exclude matching tracks",
+            "items": {
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           }
         },
         "type": "object"
@@ -680,34 +789,74 @@
       "video.v1.room.room_participant.room_participant_subscribed_track": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the track is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "kind": {
-            "$ref": "#/components/schemas/room_participant_subscribed_track_kind"
+            "description": "The track type",
+            "enum": [
+              "audio",
+              "video",
+              "data"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The track name",
+            "nullable": true,
+            "type": "string"
           },
           "participant_sid": {
-            "$ref": "#/components/schemas/sid_PA"
+            "description": "The SID of the participant that subscribes to the track",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "publisher_sid": {
-            "$ref": "#/components/schemas/sid_PA"
+            "description": "The SID of the participant that publishes the track",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^PA[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "description": "The SID of the room where the track is published",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_MT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^MT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -715,52 +864,119 @@
       "video.v1.room.room_recording": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "codec": {
-            "$ref": "#/components/schemas/room_recording_codec"
+            "description": "The codec used for the recording",
+            "enum": [
+              "VP8",
+              "H264",
+              "OPUS",
+              "PCMU"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "container_format": {
-            "$ref": "#/components/schemas/room_recording_format"
+            "description": "The file format for the recording",
+            "enum": [
+              "mka",
+              "mkv"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The duration of the recording in seconds",
+            "nullable": true,
+            "type": "integer"
           },
           "grouping_sids": {
-            "$ref": "#/components/schemas/object"
+            "description": "A list of SIDs related to the Recording",
+            "nullable": true,
+            "type": "object"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "offset": {
-            "$ref": "#/components/schemas/long"
+            "description": "The number of milliseconds between a point in time that is common to all rooms in a group and when the source room of the recording started",
+            "nullable": true,
+            "type": "integer"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "description": "The SID of the Room resource the recording is associated with",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_RT"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RT[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "size": {
-            "$ref": "#/components/schemas/long"
+            "description": "The size of the recorded track in bytes",
+            "nullable": true,
+            "type": "integer"
           },
           "source_sid": {
-            "$ref": "#/components/schemas/sid"
+            "description": "The SID of the recording source",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^[a-zA-Z]{2}[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/room_recording_status"
+            "description": "The status of the recording",
+            "enum": [
+              "processing",
+              "completed",
+              "deleted",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "track_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name that was given to the source track of the recording",
+            "nullable": true,
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/room_recording_type"
+            "description": "The recording's media type",
+            "enum": [
+              "audio",
+              "video",
+              "data"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -768,16 +984,49 @@
       "video.v1.room.room_recording_rule": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "room_sid": {
-            "$ref": "#/components/schemas/sid_RM"
+            "description": "The SID of the Room resource for the Recording Rules",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^RM[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "rules": {
-            "$ref": "#/components/schemas/recording_rule_list"
+            "description": "A collection of recording Rules that describe how to include or exclude matching tracks for recording",
+            "items": {
+              "properties": {
+                "all": {
+                  "type": "boolean"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "publisher": {
+                  "type": "string"
+                },
+                "track": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "nullable": true,
+            "type": "array"
           }
         },
         "type": "object"

--- a/spec/json/twilio_voice_v1.json
+++ b/spec/json/twilio_voice_v1.json
@@ -1,150 +1,124 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "iso_country_code": {
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_BY": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^BY[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IB": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IB[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_IL": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^IL[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_NE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^NE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_NY": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^NY[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_SD": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^SD[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
       "voice.v1.byoc_trunk": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cnam_lookup_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether Caller ID Name (CNAM) lookup is enabled for the trunk",
+            "nullable": true,
+            "type": "boolean"
           },
           "connection_policy_sid": {
-            "$ref": "#/components/schemas/sid_NY"
+            "description": "Origination Connection Policy (to your Carrier)",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "from_domain_sid": {
-            "$ref": "#/components/schemas/sid_SD"
+            "description": "The SID of the SIP Domain that should be used in the `From` header of originating calls",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_BY"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^BY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call status_callback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL that we call with status updates",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method used with voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs while executing TwiML",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method to use with voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when receiving a call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -152,25 +126,48 @@
       "voice.v1.connection_policy": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related resources",
+            "nullable": true,
+            "type": "object"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NY"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -178,37 +175,72 @@
       "voice.v1.connection_policy.connection_policy_target": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "connection_policy_sid": {
-            "$ref": "#/components/schemas/sid_NY"
+            "description": "The SID of the Connection Policy that owns the Target",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NY[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT when the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether the target is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "priority": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The relative importance of the target",
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_NE"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^NE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "target": {
-            "$ref": "#/components/schemas/url"
+            "description": "The SIP address you want Twilio to route your calls to",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "weight": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The value that determines the relative load the Target should receive compared to others with the same priority",
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
@@ -220,31 +252,53 @@
       "voice.v1.dialing_permissions.dialing_permissions_country": {
         "properties": {
           "continent": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the continent in which the country is located",
+            "nullable": true,
+            "type": "string"
           },
           "country_codes": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The E.164 assigned country codes(s)",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "high_risk_special_numbers_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether dialing to high-risk special services numbers is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "high_risk_tollfraud_numbers_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether dialing to high-risk toll fraud numbers is enabled, else `false`",
+            "nullable": true,
+            "type": "boolean"
           },
           "iso_code": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of URLs related to this resource",
+            "nullable": true,
+            "type": "object"
           },
           "low_risk_numbers_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether dialing to low-risk numbers is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of this resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -252,31 +306,53 @@
       "voice.v1.dialing_permissions.dialing_permissions_country-instance": {
         "properties": {
           "continent": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the continent in which the country is located",
+            "nullable": true,
+            "type": "string"
           },
           "country_codes": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The E.164 assigned country codes(s)",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "high_risk_special_numbers_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether dialing to high-risk special services numbers is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "high_risk_tollfraud_numbers_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether dialing to high-risk toll fraud numbers is enabled, else `false`",
+            "nullable": true,
+            "type": "boolean"
           },
           "iso_code": {
-            "$ref": "#/components/schemas/iso_country_code"
+            "description": "The ISO country code",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "A list of URLs related to this resource",
+            "nullable": true,
+            "type": "object"
           },
           "low_risk_numbers_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether dialing to low-risk numbers is enabled",
+            "nullable": true,
+            "type": "boolean"
           },
           "name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The name of the country",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of this resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -284,7 +360,9 @@
       "voice.v1.dialing_permissions.dialing_permissions_country.dialing_permissions_hrs_prefixes": {
         "properties": {
           "prefix": {
-            "$ref": "#/components/schemas/string"
+            "description": "A prefix that includes the E.164 assigned country code",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -292,10 +370,14 @@
       "voice.v1.dialing_permissions.dialing_permissions_country_bulk_update": {
         "properties": {
           "update_count": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of countries updated",
+            "nullable": true,
+            "type": "integer"
           },
           "update_request": {
-            "$ref": "#/components/schemas/string"
+            "description": "A URL encoded JSON array of update objects",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -303,10 +385,15 @@
       "voice.v1.dialing_permissions.dialing_permissions_settings": {
         "properties": {
           "dialing_permissions_inheritance": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "`true` if the sub-account will inherit voice dialing permissions from the Master Project; otherwise `false`",
+            "nullable": true,
+            "type": "boolean"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of this resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -314,28 +401,53 @@
       "voice.v1.ip_record": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cidr_prefix_length": {
-            "$ref": "#/components/schemas/integer"
+            "description": "An integer representing the length of the [CIDR](https://tools.ietf.org/html/rfc4632) prefix to use with this IP address. By default the entire IP address is used, which for IPv4 is value 32.",
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "ip_address": {
-            "$ref": "#/components/schemas/string"
+            "description": "An IP address in dotted decimal notation, IPv4 only.",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IL"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -343,22 +455,46 @@
       "voice.v1.source_ip_mapping": {
         "properties": {
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT that the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The RFC 2822 date and time in GMT that the resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "ip_record_sid": {
-            "$ref": "#/components/schemas/sid_IL"
+            "description": "The unique string that identifies an IP Record",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IL[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_IB"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^IB[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sip_domain_sid": {
-            "$ref": "#/components/schemas/sid_SD"
+            "description": "The unique string that identifies a SIP Domain",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^SD[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"

--- a/spec/json/twilio_wireless_v1.json
+++ b/spec/json/twilio_wireless_v1.json
@@ -1,160 +1,30 @@
 {
   "components": {
     "schemas": {
-      "boolean": {
-        "nullable": true,
-        "type": "boolean"
-      },
-      "command_command_mode": {
-        "enum": [
-          "text",
-          "binary"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "command_direction": {
-        "enum": [
-          "from_sim",
-          "to_sim"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "command_status": {
-        "enum": [
-          "queued",
-          "sent",
-          "delivered",
-          "received",
-          "failed"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "command_transport": {
-        "enum": [
-          "sms",
-          "ip"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "date_time_iso8601": {
-        "format": "date-time",
-        "nullable": true,
-        "type": "string"
-      },
-      "http_method": {
-        "enum": [
-          "HEAD",
-          "GET",
-          "POST",
-          "PATCH",
-          "PUT",
-          "DELETE"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "integer": {
-        "nullable": true,
-        "type": "integer"
-      },
-      "object": {
-        "nullable": true,
-        "type": "object"
-      },
-      "sid_AC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^AC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_DC": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^DC[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_DE": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^DE[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_WP": {
-        "maxLength": 34,
-        "minLength": 34,
-        "nullable": true,
-        "pattern": "^WP[0-9a-fA-F]{32}$",
-        "type": "string"
-      },
-      "sid_like_DE": {
-        "nullable": true,
-        "type": "string"
-      },
-      "sid_like_WN": {
-        "nullable": true,
-        "type": "string"
-      },
-      "sim_reset_status": {
-        "enum": [
-          "resetting"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "sim_status": {
-        "enum": [
-          "new",
-          "ready",
-          "active",
-          "suspended",
-          "deactivated",
-          "canceled",
-          "scheduled",
-          "updating"
-        ],
-        "nullable": true,
-        "type": "string"
-      },
-      "string": {
-        "nullable": true,
-        "type": "string"
-      },
-      "string_list": {
-        "items": {
-          "type": "string"
-        },
-        "nullable": true,
-        "type": "array"
-      },
-      "uri_map": {
-        "nullable": true,
-        "type": "object"
-      },
-      "url": {
-        "format": "uri",
-        "nullable": true,
-        "type": "string"
-      },
       "wireless.v1.account_usage_record": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "commands": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that describes the aggregated Commands usage for all SIMs during the specified period",
+            "nullable": true,
+            "type": "object"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that describes the aggregated Data usage for all SIMs over the period",
+            "nullable": true,
+            "type": "object"
           },
           "period": {
-            "$ref": "#/components/schemas/object"
+            "description": "The time period for which usage is reported",
+            "nullable": true,
+            "type": "object"
           }
         },
         "type": "object"
@@ -162,40 +32,95 @@
       "wireless.v1.command": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "command": {
-            "$ref": "#/components/schemas/string"
+            "description": "The message being sent to or from the SIM",
+            "nullable": true,
+            "type": "string"
           },
           "command_mode": {
-            "$ref": "#/components/schemas/command_command_mode"
+            "description": "The mode used to send the SMS message",
+            "enum": [
+              "text",
+              "binary"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was last updated format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "delivery_receipt_requested": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether to request a delivery receipt",
+            "nullable": true,
+            "type": "boolean"
           },
           "direction": {
-            "$ref": "#/components/schemas/command_direction"
+            "description": "The direction of the Command",
+            "enum": [
+              "from_sim",
+              "to_sim"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_DC"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sim_sid": {
-            "$ref": "#/components/schemas/sid_DE"
+            "description": "The SID of the Sim resource that the Command was sent to or from",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/command_status"
+            "description": "The status of the Command",
+            "enum": [
+              "queued",
+              "sent",
+              "delivered",
+              "received",
+              "failed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "transport": {
-            "$ref": "#/components/schemas/command_transport"
+            "description": "The type of transport used",
+            "enum": [
+              "sms",
+              "ip"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -203,52 +128,96 @@
       "wireless.v1.rate_plan": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "data_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether SIMs can use GPRS/3G/4G/LTE data connectivity",
+            "nullable": true,
+            "type": "boolean"
           },
           "data_limit": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total data usage in Megabytes that the Network allows during one month on the home network",
+            "nullable": true,
+            "type": "integer"
           },
           "data_metering": {
-            "$ref": "#/components/schemas/string"
+            "description": "The model used to meter data usage",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date when the resource was created, given as GMT in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date when the resource was last updated, given as GMT in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the resource",
+            "nullable": true,
+            "type": "string"
           },
           "international_roaming": {
-            "$ref": "#/components/schemas/string_list"
+            "description": "The services that SIMs capable of using GPRS/3G/4G/LTE data connectivity can use outside of the United States",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "international_roaming_data_limit": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total data usage (download and upload combined) in Megabytes that the Network allows during one month when roaming outside the United States",
+            "nullable": true,
+            "type": "integer"
           },
           "messaging_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether SIMs can make, send, and receive SMS using Commands",
+            "nullable": true,
+            "type": "boolean"
           },
           "national_roaming_data_limit": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The total data usage in Megabytes that the Network allows during one month on non-home networks in the United States",
+            "nullable": true,
+            "type": "integer"
           },
           "national_roaming_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether SIMs can roam on networks other than the home network in the United States",
+            "nullable": true,
+            "type": "boolean"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_WP"
+            "description": "The unique string that identifies the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_enabled": {
-            "$ref": "#/components/schemas/boolean"
+            "description": "Whether SIMs can make and receive voice calls",
+            "nullable": true,
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -256,76 +225,194 @@
       "wireless.v1.sim": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account to which the Sim resource belongs",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "commands_callback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call commands_callback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "commands_callback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the SIM originates a machine-to-machine Command",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the resource was created",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The ISO 8601 date and time in GMT when the Sim resource was last updated",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "e_id": {
-            "$ref": "#/components/schemas/string"
+            "description": "Deprecated",
+            "nullable": true,
+            "type": "string"
           },
           "friendly_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The string that you assigned to describe the Sim resource",
+            "nullable": true,
+            "type": "string"
           },
           "iccid": {
-            "$ref": "#/components/schemas/string"
+            "description": "The ICCID associated with the SIM",
+            "nullable": true,
+            "type": "string"
           },
           "ip_address": {
-            "$ref": "#/components/schemas/string"
+            "description": "Deprecated",
+            "nullable": true,
+            "type": "string"
           },
           "links": {
-            "$ref": "#/components/schemas/uri_map"
+            "description": "The URLs of related subresources",
+            "nullable": true,
+            "type": "object"
           },
           "rate_plan_sid": {
-            "$ref": "#/components/schemas/sid_WP"
+            "description": "The SID of the RatePlan resource to which the Sim resource is assigned.",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^WP[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "reset_status": {
-            "$ref": "#/components/schemas/sim_reset_status"
+            "description": "The connectivity reset status of the SIM",
+            "enum": [
+              "resetting"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_DE"
+            "description": "The unique string that identifies the Sim resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^DE[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "sms_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call sms_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs while retrieving or executing the TwiML requested from the sms_url",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "sms_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call sms_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "sms_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the SIM-connected device sends an SMS message that is not a Command",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/sim_status"
+            "description": "The status of the Sim resource",
+            "enum": [
+              "new",
+              "ready",
+              "active",
+              "suspended",
+              "deactivated",
+              "canceled",
+              "scheduled",
+              "updating"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "unique_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "An application-defined string that uniquely identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The absolute URL of the resource",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call voice_fallback_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_fallback_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when an error occurs while retrieving or executing the TwiML requested from voice_url",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "voice_method": {
-            "$ref": "#/components/schemas/http_method"
+            "description": "The HTTP method we use to call voice_url",
+            "enum": [
+              "HEAD",
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "voice_url": {
-            "$ref": "#/components/schemas/url"
+            "description": "The URL we call when the SIM-connected device makes a voice call",
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -333,52 +420,90 @@
       "wireless.v1.sim.data_session": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "cell_id": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique ID of the cellular tower that the device was attached to at the moment when the Data Session was last updated",
+            "nullable": true,
+            "type": "string"
           },
           "cell_location_estimate": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object with the estimated location where the device's Data Session took place",
+            "nullable": true,
+            "type": "object"
           },
           "end": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that the record ended, given as GMT in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "imei": {
-            "$ref": "#/components/schemas/string"
+            "description": "The unique ID of the device using the SIM to connect",
+            "nullable": true,
+            "type": "string"
           },
           "last_updated": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that the resource was last updated, given as GMT in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "operator_country": {
-            "$ref": "#/components/schemas/string"
+            "description": "The three letter country code representing where the device's Data Session took place",
+            "nullable": true,
+            "type": "string"
           },
           "operator_mcc": {
-            "$ref": "#/components/schemas/string"
+            "description": "The 'mobile country code' is the unique ID of the home country where the Data Session took place",
+            "nullable": true,
+            "type": "string"
           },
           "operator_mnc": {
-            "$ref": "#/components/schemas/string"
+            "description": "The 'mobile network code' is the unique ID specific to the mobile operator network where the Data Session took place",
+            "nullable": true,
+            "type": "string"
           },
           "operator_name": {
-            "$ref": "#/components/schemas/string"
+            "description": "The friendly name of the mobile operator network that the SIM-connected device is attached to",
+            "nullable": true,
+            "type": "string"
           },
           "packets_downloaded": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of packets downloaded by the device between the start time and when the Data Session was last updated",
+            "nullable": true,
+            "type": "integer"
           },
           "packets_uploaded": {
-            "$ref": "#/components/schemas/integer"
+            "description": "The number of packets uploaded by the device between the start time and when the Data Session was last updated",
+            "nullable": true,
+            "type": "integer"
           },
           "radio_link": {
-            "$ref": "#/components/schemas/string"
+            "description": "The generation of wireless technology that the device was using",
+            "nullable": true,
+            "type": "string"
           },
           "sid": {
-            "$ref": "#/components/schemas/sid_like_WN"
+            "description": "The unique string that identifies the resource",
+            "nullable": true,
+            "type": "string"
           },
           "sim_sid": {
-            "$ref": "#/components/schemas/sid_like_DE"
+            "description": "The SID of the Sim resource that the Data Session is for",
+            "nullable": true,
+            "type": "string"
           },
           "start": {
-            "$ref": "#/components/schemas/date_time_iso8601"
+            "description": "The date that the Data Session started, given as GMT in ISO 8601 format",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -386,19 +511,32 @@
       "wireless.v1.sim.usage_record": {
         "properties": {
           "account_sid": {
-            "$ref": "#/components/schemas/sid_AC"
+            "description": "The SID of the Account that created the resource",
+            "maxLength": 34,
+            "minLength": 34,
+            "nullable": true,
+            "pattern": "^AC[0-9a-fA-F]{32}$",
+            "type": "string"
           },
           "commands": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that describes the SIM's usage of Commands during the specified period",
+            "nullable": true,
+            "type": "object"
           },
           "data": {
-            "$ref": "#/components/schemas/object"
+            "description": "An object that describes the SIM's data usage during the specified period",
+            "nullable": true,
+            "type": "object"
           },
           "period": {
-            "$ref": "#/components/schemas/object"
+            "description": "The time period for which the usage is reported",
+            "nullable": true,
+            "type": "object"
           },
           "sim_sid": {
-            "$ref": "#/components/schemas/sid_like_DE"
+            "description": "The SID of the Sim resource that this Usage Record is for",
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"

--- a/spec/yaml/twilio_accounts_v1.yaml
+++ b/spec/yaml/twilio_accounts_v1.yaml
@@ -3,15 +3,34 @@ components:
     accounts.v1.auth_token_promotion:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that the secondary Auth Token was created
+            for
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         auth_token:
-          $ref: '#/components/schemas/string'
+          description: The promoted Auth Token
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 formatted date and time in UTC when the resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 formatted date and time in UTC when the resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URI for this resource, relative to `https://accounts.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     accounts.v1.credential:
       properties: {}
@@ -19,69 +38,110 @@ components:
     accounts.v1.credential.credential_aws:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URI for this resource, relative to `https://accounts.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     accounts.v1.credential.credential_public_key:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Credential that the
+            PublicKey resource belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URI for this resource, relative to `https://accounts.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     accounts.v1.secondary_auth_token:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that the secondary Auth Token was created
+            for
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 formatted date and time in UTC when the resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 formatted date and time in UTC when the resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         secondary_auth_token:
-          $ref: '#/components/schemas/string'
+          description: The generated secondary Auth Token
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URI for this resource, relative to `https://accounts.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_api_v2010.yaml
+++ b/spec/yaml/twilio_api_v2010.yaml
@@ -1,1480 +1,4011 @@
 components:
   schemas:
-    account_status:
-      enum:
-      - active
-      - suspended
-      - closed
-      nullable: true
-      type: string
-    account_type:
-      enum:
-      - Trial
-      - Full
-      nullable: true
-      type: string
     api.v2010.account:
       properties:
         auth_token:
-          $ref: '#/components/schemas/string'
+          description: The authorization token for this account
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this account was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this account was last updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human readable description of this account
+          nullable: true
+          type: string
         owner_account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique 34 character id representing the parent of this
+            account
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/account_status'
+          description: The status of this account
+          enum:
+          - active
+          - suspended
+          - closed
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: Account Instance Subresources
+          nullable: true
+          type: object
         type:
-          $ref: '#/components/schemas/account_type'
+          description: The type of this account
+          enum:
+          - Trial
+          - Full
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI for this resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.address:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that is responsible for the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         city:
-          $ref: '#/components/schemas/string'
+          description: The city in which the address is located
+          nullable: true
+          type: string
         customer_name:
-          $ref: '#/components/schemas/string'
+          description: The name associated with the address
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         emergency_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether emergency calling has been enabled on this number
+          nullable: true
+          type: boolean
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code of the address
+          nullable: true
+          type: string
         postal_code:
-          $ref: '#/components/schemas/string'
+          description: The postal code of the address
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: The state or region of the address
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         street:
-          $ref: '#/components/schemas/string'
+          description: The number and street address of the address
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         validated:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the address has been validated to comply with local
+            regulation
+          nullable: true
+          type: boolean
         verified:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the address has been verified to comply with regulation
+          nullable: true
+          type: boolean
       type: object
     api.v2010.account.address.dependent_phone_number:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         address_requirements:
-          $ref: '#/components/schemas/dependent_phone_number_address_requirement'
+          description: Whether the phone number requires an Address registered with
+            Twilio
+          enum:
+          - none
+          - any
+          - local
+          - foreign
+          nullable: true
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to start a new TwiML session
+          nullable: true
+          type: string
         capabilities:
-          $ref: '#/components/schemas/object'
+          description: Indicate if a phone can receive calls or messages
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         emergency_address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The emergency address configuration to use for emergency calling
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         emergency_status:
-          $ref: '#/components/schemas/dependent_phone_number_emergency_status'
+          description: Whether the phone number is enabled for emergency calling
+          enum:
+          - Active
+          - Inactive
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/phone_number'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         sms_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles SMS messages sent to
+            the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when an error occurs while retrieving
+            or executing the TwiML
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with sms_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives an incoming
+            SMS message
+          format: uri
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk that handles calls to the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         voice_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles calls to the phone
+            number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         voice_caller_id_lookup:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to lookup the caller's name
+          nullable: true
+          type: boolean
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs in TwiML
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with the voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.application:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to start a new TwiML session
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         message_status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send message status information to your application
+          format: uri
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when an error occurs while retrieving
+            or executing the TwiML
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with sms_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives an incoming
+            SMS message
+          format: uri
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         voice_caller_id_lookup:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to lookup the caller's name
+          nullable: true
+          type: boolean
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when a TwiML error occurs
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with the voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.authorized_connect_app:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         connect_app_company_name:
-          $ref: '#/components/schemas/string'
+          description: The company name set for the Connect App
+          nullable: true
+          type: string
         connect_app_description:
-          $ref: '#/components/schemas/string'
+          description: A detailed description of the app
+          nullable: true
+          type: string
         connect_app_friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The name of the Connect App
+          nullable: true
+          type: string
         connect_app_homepage_url:
-          $ref: '#/components/schemas/url'
+          description: The public URL for the Connect App
+          format: uri
+          nullable: true
+          type: string
         connect_app_sid:
-          $ref: '#/components/schemas/sid_CN'
+          description: The SID that we assigned to the Connect App
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CN[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         permissions:
-          $ref: '#/components/schemas/authorized_connect_app_permission_list'
+          description: Permissions authorized to the app
+          items:
+            enum:
+            - get-all
+            - post-all
+            type: string
+          nullable: true
+          type: array
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.available_phone_number_country:
       properties:
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether all phone numbers available in the country are new
+            to the Twilio platform.
+          nullable: true
+          type: boolean
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         country_code:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO-3166-1 country code of the country.
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/url'
+          description: The URI of the Country resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.available_phone_number_country.available_phone_number_local:
       properties:
         address_requirements:
-          $ref: '#/components/schemas/string'
+          description: The type of Address resource the phone number requires
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Whether a phone number can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         friendly_name:
-          $ref: '#/components/schemas/phone_number'
+          description: A formatted version of the phone number
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code of this phone number
+          nullable: true
+          type: string
         lata:
-          $ref: '#/components/schemas/string'
+          description: The LATA of this phone number
+          nullable: true
+          type: string
         latitude:
-          $ref: '#/components/schemas/decimal'
+          description: The latitude of this phone number's location
+          nullable: true
+          type: number
         locality:
-          $ref: '#/components/schemas/string'
+          description: The locality or city of this phone number's location
+          nullable: true
+          type: string
         longitude:
-          $ref: '#/components/schemas/decimal'
+          description: The longitude of this phone number's location
+          nullable: true
+          type: number
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         postal_code:
-          $ref: '#/components/schemas/string'
+          description: The postal or ZIP code of this phone number's location
+          nullable: true
+          type: string
         rate_center:
-          $ref: '#/components/schemas/string'
+          description: The rate center of this phone number
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: The two-letter state or province abbreviation of this phone
+            number's location
+          nullable: true
+          type: string
       type: object
     api.v2010.account.available_phone_number_country.available_phone_number_machine_to_machine:
       properties:
         address_requirements:
-          $ref: '#/components/schemas/string'
+          description: The type of Address resource the phone number requires
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Whether a phone number can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         friendly_name:
-          $ref: '#/components/schemas/phone_number'
+          description: A formatted version of the phone number
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code of this phone number
+          nullable: true
+          type: string
         lata:
-          $ref: '#/components/schemas/string'
+          description: The LATA of this phone number
+          nullable: true
+          type: string
         latitude:
-          $ref: '#/components/schemas/decimal'
+          description: The latitude of this phone number's location
+          nullable: true
+          type: number
         locality:
-          $ref: '#/components/schemas/string'
+          description: The locality or city of this phone number's location
+          nullable: true
+          type: string
         longitude:
-          $ref: '#/components/schemas/decimal'
+          description: The longitude of this phone number's location
+          nullable: true
+          type: number
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         postal_code:
-          $ref: '#/components/schemas/string'
+          description: The postal or ZIP code of this phone number's location
+          nullable: true
+          type: string
         rate_center:
-          $ref: '#/components/schemas/string'
+          description: The rate center of this phone number
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: The two-letter state or province abbreviation of this phone
+            number's location
+          nullable: true
+          type: string
       type: object
     api.v2010.account.available_phone_number_country.available_phone_number_mobile:
       properties:
         address_requirements:
-          $ref: '#/components/schemas/string'
+          description: The type of Address resource the phone number requires
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Whether a phone number can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         friendly_name:
-          $ref: '#/components/schemas/phone_number'
+          description: A formatted version of the phone number
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code of this phone number
+          nullable: true
+          type: string
         lata:
-          $ref: '#/components/schemas/string'
+          description: The LATA of this phone number
+          nullable: true
+          type: string
         latitude:
-          $ref: '#/components/schemas/decimal'
+          description: The latitude of this phone number's location
+          nullable: true
+          type: number
         locality:
-          $ref: '#/components/schemas/string'
+          description: The locality or city of this phone number's location
+          nullable: true
+          type: string
         longitude:
-          $ref: '#/components/schemas/decimal'
+          description: The longitude of this phone number's location
+          nullable: true
+          type: number
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         postal_code:
-          $ref: '#/components/schemas/string'
+          description: The postal or ZIP code of this phone number's location
+          nullable: true
+          type: string
         rate_center:
-          $ref: '#/components/schemas/string'
+          description: The rate center of this phone number
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: The two-letter state or province abbreviation of this phone
+            number's location
+          nullable: true
+          type: string
       type: object
     api.v2010.account.available_phone_number_country.available_phone_number_national:
       properties:
         address_requirements:
-          $ref: '#/components/schemas/string'
+          description: The type of Address resource the phone number requires
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Whether a phone number can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         friendly_name:
-          $ref: '#/components/schemas/phone_number'
+          description: A formatted version of the phone number
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code of this phone number
+          nullable: true
+          type: string
         lata:
-          $ref: '#/components/schemas/string'
+          description: The LATA of this phone number
+          nullable: true
+          type: string
         latitude:
-          $ref: '#/components/schemas/decimal'
+          description: The latitude of this phone number's location
+          nullable: true
+          type: number
         locality:
-          $ref: '#/components/schemas/string'
+          description: The locality or city of this phone number's location
+          nullable: true
+          type: string
         longitude:
-          $ref: '#/components/schemas/decimal'
+          description: The longitude of this phone number's location
+          nullable: true
+          type: number
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         postal_code:
-          $ref: '#/components/schemas/string'
+          description: The postal or ZIP code of this phone number's location
+          nullable: true
+          type: string
         rate_center:
-          $ref: '#/components/schemas/string'
+          description: The rate center of this phone number
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: The two-letter state or province abbreviation of this phone
+            number's location
+          nullable: true
+          type: string
       type: object
     api.v2010.account.available_phone_number_country.available_phone_number_shared_cost:
       properties:
         address_requirements:
-          $ref: '#/components/schemas/string'
+          description: The type of Address resource the phone number requires
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Whether a phone number can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         friendly_name:
-          $ref: '#/components/schemas/phone_number'
+          description: A formatted version of the phone number
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code of this phone number
+          nullable: true
+          type: string
         lata:
-          $ref: '#/components/schemas/string'
+          description: The LATA of this phone number
+          nullable: true
+          type: string
         latitude:
-          $ref: '#/components/schemas/decimal'
+          description: The latitude of this phone number's location
+          nullable: true
+          type: number
         locality:
-          $ref: '#/components/schemas/string'
+          description: The locality or city of this phone number's location
+          nullable: true
+          type: string
         longitude:
-          $ref: '#/components/schemas/decimal'
+          description: The longitude of this phone number's location
+          nullable: true
+          type: number
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         postal_code:
-          $ref: '#/components/schemas/string'
+          description: The postal or ZIP code of this phone number's location
+          nullable: true
+          type: string
         rate_center:
-          $ref: '#/components/schemas/string'
+          description: The rate center of this phone number
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: The two-letter state or province abbreviation of this phone
+            number's location
+          nullable: true
+          type: string
       type: object
     api.v2010.account.available_phone_number_country.available_phone_number_toll_free:
       properties:
         address_requirements:
-          $ref: '#/components/schemas/string'
+          description: The type of Address resource the phone number requires
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Whether a phone number can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         friendly_name:
-          $ref: '#/components/schemas/phone_number'
+          description: A formatted version of the phone number
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code of this phone number
+          nullable: true
+          type: string
         lata:
-          $ref: '#/components/schemas/string'
+          description: The LATA of this phone number
+          nullable: true
+          type: string
         latitude:
-          $ref: '#/components/schemas/decimal'
+          description: The latitude of this phone number's location
+          nullable: true
+          type: number
         locality:
-          $ref: '#/components/schemas/string'
+          description: The locality or city of this phone number's location
+          nullable: true
+          type: string
         longitude:
-          $ref: '#/components/schemas/decimal'
+          description: The longitude of this phone number's location
+          nullable: true
+          type: number
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         postal_code:
-          $ref: '#/components/schemas/string'
+          description: The postal or ZIP code of this phone number's location
+          nullable: true
+          type: string
         rate_center:
-          $ref: '#/components/schemas/string'
+          description: The rate center of this phone number
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: The two-letter state or province abbreviation of this phone
+            number's location
+          nullable: true
+          type: string
       type: object
     api.v2010.account.available_phone_number_country.available_phone_number_voip:
       properties:
         address_requirements:
-          $ref: '#/components/schemas/string'
+          description: The type of Address resource the phone number requires
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Whether a phone number can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         friendly_name:
-          $ref: '#/components/schemas/phone_number'
+          description: A formatted version of the phone number
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code of this phone number
+          nullable: true
+          type: string
         lata:
-          $ref: '#/components/schemas/string'
+          description: The LATA of this phone number
+          nullable: true
+          type: string
         latitude:
-          $ref: '#/components/schemas/decimal'
+          description: The latitude of this phone number's location
+          nullable: true
+          type: number
         locality:
-          $ref: '#/components/schemas/string'
+          description: The locality or city of this phone number's location
+          nullable: true
+          type: string
         longitude:
-          $ref: '#/components/schemas/decimal'
+          description: The longitude of this phone number's location
+          nullable: true
+          type: number
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         postal_code:
-          $ref: '#/components/schemas/string'
+          description: The postal or ZIP code of this phone number's location
+          nullable: true
+          type: string
         rate_center:
-          $ref: '#/components/schemas/string'
+          description: The rate center of this phone number
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: The two-letter state or province abbreviation of this phone
+            number's location
+          nullable: true
+          type: string
       type: object
     api.v2010.account.balance:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: Account Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         balance:
-          $ref: '#/components/schemas/string'
+          description: Account balance
+          nullable: true
+          type: string
         currency:
-          $ref: '#/components/schemas/string'
+          description: Currency units
+          nullable: true
+          type: string
       type: object
     api.v2010.account.call:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         annotation:
-          $ref: '#/components/schemas/string'
+          description: The annotation provided for the call
+          nullable: true
+          type: string
         answered_by:
-          $ref: '#/components/schemas/string'
+          description: Either `human` or `machine` if this call was initiated with
+            answering machine detection. Empty otherwise.
+          nullable: true
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API Version used to create the call
+          nullable: true
+          type: string
         caller_name:
-          $ref: '#/components/schemas/string'
+          description: The caller's name if this call was an incoming call to a phone
+            number with caller ID Lookup enabled. Otherwise, empty.
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         direction:
-          $ref: '#/components/schemas/string'
+          description: A string describing the direction of the call. `inbound` for
+            inbound calls, `outbound-api` for calls initiated via the REST API or
+            `outbound-dial` for calls initiated by a `Dial` verb.
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/string'
+          description: The length of the call in seconds.
+          nullable: true
+          type: string
         end_time:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The end time of the call. Null if the call did not complete
+            successfully.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         forwarded_from:
-          $ref: '#/components/schemas/string'
+          description: The forwarding phone number if this call was an incoming call
+            forwarded from another number (depends on carrier supporting forwarding).
+            Otherwise, empty.
+          nullable: true
+          type: string
         from:
-          $ref: '#/components/schemas/string'
+          description: The phone number, SIP address or Client identifier that made
+            this call. Phone numbers are in E.164 format (e.g., +16175551212). SIP
+            addresses are formatted as `name@company.com`. Client identifiers are
+            formatted `client:name`.
+          nullable: true
+          type: string
         from_formatted:
-          $ref: '#/components/schemas/string'
+          description: The calling phone number, SIP address, or Client identifier
+            formatted for display.
+          nullable: true
+          type: string
         group_sid:
-          $ref: '#/components/schemas/sid_GP'
+          description: The Group SID associated with this call. If no Group is associated
+            with the call, the field is empty.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^GP[0-9a-fA-F]{32}$
+          type: string
         parent_call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID that identifies the call that created this leg.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         phone_number_sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: If the call was inbound, this is the SID of the IncomingPhoneNumber
+            resource that received the call. If the call was outbound, it is the SID
+            of the OutgoingCallerId resource from which the call was placed.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         price:
-          $ref: '#/components/schemas/string'
+          description: The charge for this call, in the currency associated with the
+            account. Populated after the call is completed. May not be immediately
+            available.
+          nullable: true
+          type: string
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `Price` is measured.
+          nullable: true
+          type: string
         queue_time:
-          $ref: '#/components/schemas/string'
+          description: The wait time in milliseconds before the call is placed.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The unique string that identifies this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         start_time:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The start time of the call. Null if the call has not yet been
+            dialed.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/call_status'
+          description: The status of this call.
+          enum:
+          - queued
+          - ringing
+          - in-progress
+          - completed
+          - busy
+          - failed
+          - no-answer
+          - canceled
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related subresources identified by their relative
+            URIs
+          nullable: true
+          type: object
         to:
-          $ref: '#/components/schemas/string'
+          description: The phone number, SIP address or Client identifier that received
+            this call. Phone numbers are in E.164 format (e.g., +16175551212). SIP
+            addresses are formatted as `name@company.com`. Client identifiers are
+            formatted `client:name`.
+          nullable: true
+          type: string
         to_formatted:
-          $ref: '#/components/schemas/string'
+          description: The phone number, SIP address or Client identifier that received
+            this call. Formatted for display.
+          nullable: true
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The (optional) unique identifier of the trunk resource that
+            was used for this call.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of this resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.call.call_event:
       properties:
         request:
-          $ref: '#/components/schemas/object'
+          description: Call Request.
+          nullable: true
+          type: object
         response:
-          $ref: '#/components/schemas/object'
+          description: Call Response with Events.
+          nullable: true
+          type: object
       type: object
     api.v2010.account.call.call_feedback:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique sid that identifies this account
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this resource was last updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         issues:
-          $ref: '#/components/schemas/call_feedback_issues_list'
+          description: Issues experienced during the call
+          items:
+            enum:
+            - audio-latency
+            - digits-not-captured
+            - dropped-call
+            - imperfect-audio
+            - incorrect-caller-id
+            - one-way-audio
+            - post-dial-delay
+            - unsolicited-call
+            type: string
+          nullable: true
+          type: array
         quality_score:
-          $ref: '#/components/schemas/integer'
+          description: 1 to 5 quality score
+          nullable: true
+          type: integer
         sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: A string that uniquely identifies this feedback resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
       type: object
     api.v2010.account.call.call_feedback_summary:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique sid that identifies this account
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         call_count:
-          $ref: '#/components/schemas/integer'
+          description: The total number of calls
+          nullable: true
+          type: integer
         call_feedback_count:
-          $ref: '#/components/schemas/integer'
+          description: The total number of calls with a feedback entry
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this resource was last updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The latest feedback entry date in the summary
+          format: date-time
+          nullable: true
+          type: string
         include_subaccounts:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the feedback summary includes subaccounts
+          nullable: true
+          type: boolean
         issues:
-          $ref: '#/components/schemas/feedback_issue_list'
+          description: Issues experienced during the call
+          items:
+            properties:
+              count:
+                type: number
+              description:
+                type: string
+              percentage_of_total_calls:
+                type: string
+            type: object
+          nullable: true
+          type: array
         quality_score_average:
-          $ref: '#/components/schemas/decimal'
+          description: The average QualityScore of the feedback entries
+          nullable: true
+          type: number
         quality_score_median:
-          $ref: '#/components/schemas/decimal'
+          description: The median QualityScore of the feedback entries
+          nullable: true
+          type: number
         quality_score_standard_deviation:
-          $ref: '#/components/schemas/decimal'
+          description: The standard deviation of the quality scores
+          nullable: true
+          type: number
         sid:
-          $ref: '#/components/schemas/sid_FS'
+          description: A string that uniquely identifies this feedback entry
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FS[0-9a-fA-F]{32}$
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The earliest feedback entry date in the summary
+          format: date-time
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/call_feedback_summary_status'
+          description: The status of the feedback summary
+          enum:
+          - queued
+          - in-progress
+          - completed
+          - failed
+          nullable: true
+          type: string
       type: object
     api.v2010.account.call.call_notification:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the Call Notification resource
+          nullable: true
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/string'
+          description: A unique error code corresponding to the notification
+          nullable: true
+          type: string
         log:
-          $ref: '#/components/schemas/string'
+          description: An integer log level
+          nullable: true
+          type: string
         message_date:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date the notification was generated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         message_text:
-          $ref: '#/components/schemas/string'
+          description: The text of the notification
+          nullable: true
+          type: string
         more_info:
-          $ref: '#/components/schemas/url'
+          description: A URL for more information about the error code
+          format: uri
+          nullable: true
+          type: string
         request_method:
-          $ref: '#/components/schemas/http_method'
+          description: HTTP method used with the request url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         request_url:
-          $ref: '#/components/schemas/url'
+          description: URL of the resource that generated the notification
+          format: uri
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_NO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NO[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.call.call_notification-instance:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the Call Notification resource
+          nullable: true
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/string'
+          description: A unique error code corresponding to the notification
+          nullable: true
+          type: string
         log:
-          $ref: '#/components/schemas/string'
+          description: An integer log level
+          nullable: true
+          type: string
         message_date:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date the notification was generated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         message_text:
-          $ref: '#/components/schemas/string'
+          description: The text of the notification
+          nullable: true
+          type: string
         more_info:
-          $ref: '#/components/schemas/url'
+          description: A URL for more information about the error code
+          format: uri
+          nullable: true
+          type: string
         request_method:
-          $ref: '#/components/schemas/http_method'
+          description: HTTP method used with the request url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         request_url:
-          $ref: '#/components/schemas/url'
+          description: URL of the resource that generated the notification
+          format: uri
+          nullable: true
+          type: string
         request_variables:
-          $ref: '#/components/schemas/string'
+          description: Twilio-generated HTTP variables sent to the server
+          nullable: true
+          type: string
         response_body:
-          $ref: '#/components/schemas/string'
+          description: The HTTP body returned by your server
+          nullable: true
+          type: string
         response_headers:
-          $ref: '#/components/schemas/string'
+          description: The HTTP headers returned by your server
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_NO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NO[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.call.call_recording:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to make the recording
+          nullable: true
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         channels:
-          $ref: '#/components/schemas/integer'
+          description: The number of channels in the final recording file
+          nullable: true
+          type: integer
         conference_sid:
-          $ref: '#/components/schemas/sid_CF'
+          description: The Conference SID that identifies the conference associated
+            with the recording
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CF[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/string'
+          description: The length of the recording in seconds
+          nullable: true
+          type: string
         encryption_details:
-          $ref: '#/components/schemas/object'
+          description: How to decrypt the recording.
+          nullable: true
+          type: object
         error_code:
-          $ref: '#/components/schemas/integer'
+          description: More information about why the recording is missing, if status
+            is `absent`.
+          nullable: true
+          type: integer
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The one-time cost of creating the recording.
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency used in the price property.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RE[0-9a-fA-F]{32}$
+          type: string
         source:
-          $ref: '#/components/schemas/call_recording_source'
+          description: How the recording was created
+          enum:
+          - DialVerb
+          - Conference
+          - OutboundAPI
+          - Trunking
+          - RecordVerb
+          - StartCallRecordingAPI
+          - StartConferenceRecordingAPI
+          nullable: true
+          type: string
         start_time:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The start time of the recording, given in RFC 2822 format
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/call_recording_status'
+          description: The status of the recording
+          enum:
+          - in-progress
+          - paused
+          - stopped
+          - processing
+          - completed
+          - absent
+          nullable: true
+          type: string
         track:
-          $ref: '#/components/schemas/string'
+          description: 'The recorded track. Can be: `inbound`, `outbound`, or `both`.'
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.call.payments:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Payments resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PK'
+          description: The SID of the Payments resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PK[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.conference:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create this conference
+          nullable: true
+          type: string
         call_sid_ending_conference:
-          $ref: '#/components/schemas/sid_CA'
+          description: The call SID that caused the conference to end
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A string that you assigned to describe this conference room
+          nullable: true
+          type: string
         reason_conference_ended:
-          $ref: '#/components/schemas/conference_reason_conference_ended'
+          description: The reason why a conference ended.
+          enum:
+          - conference-ended-via-api
+          - participant-with-end-conference-on-exit-left
+          - participant-with-end-conference-on-exit-kicked
+          - last-participant-kicked
+          - last-participant-left
+          nullable: true
+          type: string
         region:
-          $ref: '#/components/schemas/string'
+          description: A string that represents the Twilio Region where the conference
+            was mixed
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CF'
+          description: The unique string that identifies this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CF[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/conference_status'
+          description: The status of this conference
+          enum:
+          - init
+          - in-progress
+          - completed
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of this resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.conference.conference_recording:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the recording
+          nullable: true
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         channels:
-          $ref: '#/components/schemas/integer'
+          description: The number of channels in the final recording file as an integer
+          nullable: true
+          type: integer
         conference_sid:
-          $ref: '#/components/schemas/sid_CF'
+          description: The Conference SID that identifies the conference associated
+            with the recording
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CF[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/string'
+          description: The length of the recording in seconds
+          nullable: true
+          type: string
         encryption_details:
-          $ref: '#/components/schemas/object'
+          description: How to decrypt the recording.
+          nullable: true
+          type: object
         error_code:
-          $ref: '#/components/schemas/integer'
+          description: More information about why the recording is missing, if status
+            is `absent`.
+          nullable: true
+          type: integer
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The one-time cost of creating the recording.
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency used in the price property.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RE[0-9a-fA-F]{32}$
+          type: string
         source:
-          $ref: '#/components/schemas/conference_recording_source'
+          description: How the recording was created
+          enum:
+          - DialVerb
+          - Conference
+          - OutboundAPI
+          - Trunking
+          - RecordVerb
+          - StartCallRecordingAPI
+          - StartConferenceRecordingAPI
+          nullable: true
+          type: string
         start_time:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The start time of the recording, given in RFC 2822 format
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/conference_recording_status'
+          description: The status of the recording
+          enum:
+          - in-progress
+          - paused
+          - stopped
+          - processing
+          - completed
+          - absent
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.conference.participant:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         call_sid_to_coach:
-          $ref: '#/components/schemas/sid_CF'
+          description: The SID of the participant who is being `coached`
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CF[0-9a-fA-F]{32}$
+          type: string
         coaching:
-          $ref: '#/components/schemas/boolean'
+          description: Indicates if the participant changed to coach
+          nullable: true
+          type: boolean
         conference_sid:
-          $ref: '#/components/schemas/sid_CF'
+          description: The SID of the conference the participant is in
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CF[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         end_conference_on_exit:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the conference ends when the participant leaves
+          nullable: true
+          type: boolean
         hold:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the participant is on hold
+          nullable: true
+          type: boolean
         label:
-          $ref: '#/components/schemas/string'
+          description: The label of this participant
+          nullable: true
+          type: string
         muted:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the participant is muted
+          nullable: true
+          type: boolean
         start_conference_on_enter:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the conference starts when the participant joins the
+            conference
+          nullable: true
+          type: boolean
         status:
-          $ref: '#/components/schemas/participant_status'
+          description: The status of the participant's call in a session
+          enum:
+          - queued
+          - connecting
+          - ringing
+          - connected
+          - complete
+          - failed
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.connect_app:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         authorize_redirect_url:
-          $ref: '#/components/schemas/url'
+          description: The URL to redirect the user to after authorization
+          format: uri
+          nullable: true
+          type: string
         company_name:
-          $ref: '#/components/schemas/string'
+          description: The company name set for the Connect App
+          nullable: true
+          type: string
         deauthorize_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call deauthorize_callback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         deauthorize_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call to de-authorize the Connect App
+          format: uri
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: The description of the Connect App
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         homepage_url:
-          $ref: '#/components/schemas/url'
+          description: The URL users can obtain more information
+          format: uri
+          nullable: true
+          type: string
         permissions:
-          $ref: '#/components/schemas/connect_app_permission_list'
+          description: The set of permissions that your ConnectApp requests
+          items:
+            enum:
+            - get-all
+            - post-all
+            type: string
+          nullable: true
+          type: array
         sid:
-          $ref: '#/components/schemas/sid_CN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CN[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.incoming_phone_number:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         address_requirements:
-          $ref: '#/components/schemas/incoming_phone_number_address_requirement'
+          description: Whether the phone number requires an Address registered with
+            Twilio.
+          enum:
+          - none
+          - any
+          - local
+          - foreign
+          nullable: true
+          type: string
         address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The SID of the Address resource associated with the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to start a new TwiML session
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         bundle_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The SID of the Bundle resource associated with number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Indicate if a phone can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         emergency_address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The emergency address configuration to use for emergency calling
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         emergency_status:
-          $ref: '#/components/schemas/incoming_phone_number_emergency_status'
+          description: Whether the phone number is enabled for emergency calling
+          enum:
+          - Active
+          - Inactive
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         identity_sid:
-          $ref: '#/components/schemas/sid_RI'
+          description: The SID of the Identity resource associated with number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RI[0-9a-fA-F]{32}$
+          type: string
         origin:
-          $ref: '#/components/schemas/string'
+          description: The phone number's origin. Can be twilio or hosted.
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         sms_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles SMS messages sent to
+            the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when an error occurs while retrieving
+            or executing the TwiML
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with sms_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives an incoming
+            SMS message
+          format: uri
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk that handles calls to the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         voice_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles calls to the phone
+            number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         voice_caller_id_lookup:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to lookup the caller's name
+          nullable: true
+          type: boolean
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs in TwiML
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with the voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_receive_mode:
-          $ref: '#/components/schemas/incoming_phone_number_voice_receive_mode'
+          enum:
+          - voice
+          - fax
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.incoming_phone_number.incoming_phone_number_assigned_add_on:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         configuration:
-          $ref: '#/components/schemas/object'
+          description: A JSON string that represents the current configuration
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A short description of the Add-on functionality
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         resource_sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The SID of the Phone Number that installed this Add-on
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_XE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XE[0-9a-fA-F]{32}$
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     ? api.v2010.account.incoming_phone_number.incoming_phone_number_assigned_add_on.incoming_phone_number_assigned_add_on_extension
     : properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assigned_add_on_sid:
-          $ref: '#/components/schemas/sid_XE'
+          description: The SID that uniquely identifies the assigned Add-on installation
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XE[0-9a-fA-F]{32}$
+          type: string
         enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Extension will be invoked
+          nullable: true
+          type: boolean
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         product_name:
-          $ref: '#/components/schemas/string'
+          description: A string that you assigned to describe the Product this Extension
+            is used within
+          nullable: true
+          type: string
         resource_sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The SID of the Phone Number to which the Add-on is assigned
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_XF'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XF[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.incoming_phone_number.incoming_phone_number_local:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         address_requirements:
-          $ref: '#/components/schemas/incoming_phone_number_local_address_requirement'
+          description: Whether the phone number requires an Address registered with
+            Twilio.
+          enum:
+          - none
+          - any
+          - local
+          - foreign
+          nullable: true
+          type: string
         address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The SID of the Address resource associated with the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to start a new TwiML session
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         bundle_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The SID of the Bundle resource associated with number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Indicate if a phone can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         emergency_address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The emergency address configuration to use for emergency calling
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         emergency_status:
-          $ref: '#/components/schemas/incoming_phone_number_local_emergency_status'
+          description: Whether the phone number is enabled for emergency calling
+          enum:
+          - Active
+          - Inactive
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         identity_sid:
-          $ref: '#/components/schemas/sid_RI'
+          description: The SID of the Identity resource associated with number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RI[0-9a-fA-F]{32}$
+          type: string
         origin:
-          $ref: '#/components/schemas/string'
+          description: The phone number's origin. Can be twilio or hosted.
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         sms_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the Application resource to handle SMS messages
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when an error occurs while retrieving
+            or executing the TwiML
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with sms_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives an incoming
+            SMS message
+          format: uri
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk that handles calls to the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         voice_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles calls to the phone
+            number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         voice_caller_id_lookup:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to lookup the caller's name
+          nullable: true
+          type: boolean
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs in TwiML
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with the voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_receive_mode:
-          $ref: '#/components/schemas/incoming_phone_number_local_voice_receive_mode'
+          enum:
+          - voice
+          - fax
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when this phone number receives a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.incoming_phone_number.incoming_phone_number_mobile:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         address_requirements:
-          $ref: '#/components/schemas/incoming_phone_number_mobile_address_requirement'
+          description: Whether the phone number requires an Address registered with
+            Twilio.
+          enum:
+          - none
+          - any
+          - local
+          - foreign
+          nullable: true
+          type: string
         address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The SID of the Address resource associated with the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to start a new TwiML session
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         bundle_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The SID of the Bundle resource associated with number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Indicate if a phone can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         emergency_address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The emergency address configuration to use for emergency calling
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         emergency_status:
-          $ref: '#/components/schemas/incoming_phone_number_mobile_emergency_status'
+          description: Whether the phone number is enabled for emergency calling
+          enum:
+          - Active
+          - Inactive
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         identity_sid:
-          $ref: '#/components/schemas/sid_RI'
+          description: The SID of the Identity resource associated with number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RI[0-9a-fA-F]{32}$
+          type: string
         origin:
-          $ref: '#/components/schemas/string'
+          description: The phone number's origin. Can be twilio or hosted.
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         sms_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles SMS messages sent to
+            the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when an error occurs while retrieving
+            or executing the TwiML
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with sms_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives an incoming
+            SMS message
+          format: uri
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk that handles calls to the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         voice_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles calls to the phone
+            number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         voice_caller_id_lookup:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to lookup the caller's name
+          nullable: true
+          type: boolean
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs in TwiML
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with the voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_receive_mode:
-          $ref: '#/components/schemas/incoming_phone_number_mobile_voice_receive_mode'
+          enum:
+          - voice
+          - fax
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.incoming_phone_number.incoming_phone_number_toll_free:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         address_requirements:
-          $ref: '#/components/schemas/incoming_phone_number_toll_free_address_requirement'
+          description: Whether the phone number requires an Address registered with
+            Twilio.
+          enum:
+          - none
+          - any
+          - local
+          - foreign
+          nullable: true
+          type: string
         address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The SID of the Address resource associated with the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to start a new TwiML session
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         bundle_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The SID of the Bundle resource associated with number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: Indicate if a phone can receive calls or messages
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         emergency_address_sid:
-          $ref: '#/components/schemas/sid_AD'
+          description: The emergency address configuration to use for emergency calling
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AD[0-9a-fA-F]{32}$
+          type: string
         emergency_status:
-          $ref: '#/components/schemas/incoming_phone_number_toll_free_emergency_status'
+          description: Whether the phone number is enabled for emergency calling
+          enum:
+          - Active
+          - Inactive
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         identity_sid:
-          $ref: '#/components/schemas/sid_RI'
+          description: The SID of the Identity resource associated with number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RI[0-9a-fA-F]{32}$
+          type: string
         origin:
-          $ref: '#/components/schemas/string'
+          description: The phone number's origin. Can be twilio or hosted.
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         sms_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles SMS messages sent to
+            the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when an error occurs while retrieving
+            or executing the TwiML
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with sms_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives an incoming
+            SMS message
+          format: uri
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk that handles calls to the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         voice_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles calls to the phone
+            number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         voice_caller_id_lookup:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to lookup the caller's name
+          nullable: true
+          type: boolean
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs in TwiML
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with the voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_receive_mode:
-          $ref: '#/components/schemas/incoming_phone_number_toll_free_voice_receive_mode'
+          enum:
+          - voice
+          - fax
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.key:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_SK'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SK[0-9a-fA-F]{32}$
+          type: string
       type: object
     api.v2010.account.message:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to process the message
+          nullable: true
+          type: string
         body:
-          $ref: '#/components/schemas/string'
+          description: The message text
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_sent:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT when the message was sent
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         direction:
-          $ref: '#/components/schemas/message_direction'
+          description: The direction of the message
+          enum:
+          - inbound
+          - outbound-api
+          - outbound-call
+          - outbound-reply
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/integer'
+          description: The error code associated with the message
+          nullable: true
+          type: integer
         error_message:
-          $ref: '#/components/schemas/string'
+          description: The description of the error_code
+          nullable: true
+          type: string
         from:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number that initiated the message
+          nullable: true
+          type: string
         messaging_service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The SID of the Messaging Service used with the message.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         num_media:
-          $ref: '#/components/schemas/string'
+          description: The number of media files associated with the message
+          nullable: true
+          type: string
         num_segments:
-          $ref: '#/components/schemas/string'
+          description: The number of messages used to deliver the message body
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/string'
+          description: The amount billed for the message
+          nullable: true
+          type: string
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which price is measured
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MM'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^(SM|MM)[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/message_status'
+          description: The status of the message
+          enum:
+          - queued
+          - sending
+          - sent
+          - failed
+          - delivered
+          - undelivered
+          - receiving
+          - received
+          - accepted
+          - scheduled
+          - read
+          - partially_delivered
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         to:
-          $ref: '#/components/schemas/string'
+          description: The phone number that received the message
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/string'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          nullable: true
+          type: string
       type: object
     api.v2010.account.message.media:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         content_type:
-          $ref: '#/components/schemas/string'
+          description: The default mime-type of the media
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         parent_sid:
-          $ref: '#/components/schemas/sid_MM'
+          description: The SID of the resource that created the media
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^(SM|MM)[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ME'
+          description: The unique string that identifies this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ME[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of this resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.message.message_feedback:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         message_sid:
-          $ref: '#/components/schemas/sid_MM'
+          description: The SID of the Message resource for which the feedback was
+            provided
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^(SM|MM)[0-9a-fA-F]{32}$
+          type: string
         outcome:
-          $ref: '#/components/schemas/message_feedback_outcome'
+          description: Whether the feedback has arrived
+          enum:
+          - confirmed
+          - unconfirmed
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/string'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          nullable: true
+          type: string
       type: object
     api.v2010.account.new_key:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         secret:
-          $ref: '#/components/schemas/base64'
+          description: The secret your application uses to sign Access Tokens and
+            to authenticate to the REST API.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_SK'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SK[0-9a-fA-F]{32}$
+          type: string
       type: object
     api.v2010.account.new_signing_key:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         secret:
-          $ref: '#/components/schemas/base64'
+          description: The secret your application uses to sign Access Tokens and
+            to authenticate to the REST API.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_SK'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SK[0-9a-fA-F]{32}$
+          type: string
       type: object
     api.v2010.account.notification:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to generate the notification
+          nullable: true
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/string'
+          description: A unique error code corresponding to the notification
+          nullable: true
+          type: string
         log:
-          $ref: '#/components/schemas/string'
+          description: An integer log level
+          nullable: true
+          type: string
         message_date:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date the notification was generated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         message_text:
-          $ref: '#/components/schemas/string'
+          description: The text of the notification
+          nullable: true
+          type: string
         more_info:
-          $ref: '#/components/schemas/url'
+          description: A URL for more information about the error code
+          format: uri
+          nullable: true
+          type: string
         request_method:
-          $ref: '#/components/schemas/http_method'
+          description: HTTP method used with the request url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         request_url:
-          $ref: '#/components/schemas/url'
+          description: URL of the resource that generated the notification
+          format: uri
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_NO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NO[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.notification-instance:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to generate the notification
+          nullable: true
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/string'
+          description: A unique error code corresponding to the notification
+          nullable: true
+          type: string
         log:
-          $ref: '#/components/schemas/string'
+          description: An integer log level
+          nullable: true
+          type: string
         message_date:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date the notification was generated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         message_text:
-          $ref: '#/components/schemas/string'
+          description: The text of the notification
+          nullable: true
+          type: string
         more_info:
-          $ref: '#/components/schemas/url'
+          description: A URL for more information about the error code
+          format: uri
+          nullable: true
+          type: string
         request_method:
-          $ref: '#/components/schemas/http_method'
+          description: HTTP method used with the request url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         request_url:
-          $ref: '#/components/schemas/url'
+          description: URL of the resource that generated the notification
+          format: uri
+          nullable: true
+          type: string
         request_variables:
-          $ref: '#/components/schemas/string'
+          description: Twilio-generated HTTP variables sent to the server
+          nullable: true
+          type: string
         response_body:
-          $ref: '#/components/schemas/string'
+          description: The HTTP body returned by your server
+          nullable: true
+          type: string
         response_headers:
-          $ref: '#/components/schemas/string'
+          description: The HTTP headers returned by your server
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_NO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NO[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.outgoing_caller_id:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.queue:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         average_wait_time:
-          $ref: '#/components/schemas/integer'
+          description: Average wait time of members in the queue
+          nullable: true
+          type: integer
         current_size:
-          $ref: '#/components/schemas/integer'
+          description: The number of calls currently in the queue.
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A string that you assigned to describe this resource
+          nullable: true
+          type: string
         max_size:
-          $ref: '#/components/schemas/integer'
+          description: The max number of calls allowed in the queue
+          nullable: true
+          type: integer
         sid:
-          $ref: '#/components/schemas/sid_QU'
+          description: The unique string that identifies this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^QU[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of this resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.queue.member:
       properties:
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         date_enqueued:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date the member was enqueued
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         position:
-          $ref: '#/components/schemas/integer'
+          description: This member's current position in the queue.
+          nullable: true
+          type: integer
         queue_sid:
-          $ref: '#/components/schemas/sid_QU'
+          description: The SID of the Queue the member is in
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^QU[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         wait_time:
-          $ref: '#/components/schemas/integer'
+          description: The number of seconds the member has been in the queue.
+          nullable: true
+          type: integer
       type: object
     api.v2010.account.recording:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used during the recording.
+          nullable: true
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         channels:
-          $ref: '#/components/schemas/integer'
+          description: The number of channels in the final recording file as an integer.
+          nullable: true
+          type: integer
         conference_sid:
-          $ref: '#/components/schemas/sid_CF'
+          description: The unique ID for the conference associated with the recording.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CF[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/string'
+          description: The length of the recording in seconds.
+          nullable: true
+          type: string
         encryption_details:
-          $ref: '#/components/schemas/object'
+          description: How to decrypt the recording.
+          nullable: true
+          type: object
         error_code:
-          $ref: '#/components/schemas/integer'
+          description: More information about why the recording is missing, if status
+            is `absent`.
+          nullable: true
+          type: integer
         price:
-          $ref: '#/components/schemas/string'
+          description: The one-time cost of creating the recording.
+          nullable: true
+          type: string
         price_unit:
-          $ref: '#/components/schemas/string'
+          description: The currency used in the price property.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RE[0-9a-fA-F]{32}$
+          type: string
         source:
-          $ref: '#/components/schemas/recording_source'
+          description: How the recording was created
+          enum:
+          - DialVerb
+          - Conference
+          - OutboundAPI
+          - Trunking
+          - RecordVerb
+          - StartCallRecordingAPI
+          - StartConferenceRecordingAPI
+          nullable: true
+          type: string
         start_time:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The start time of the recording, given in RFC 2822 format
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/recording_status'
+          description: The status of the recording.
+          enum:
+          - in-progress
+          - paused
+          - stopped
+          - processing
+          - completed
+          - absent
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.recording.recording_add_on_result:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         add_on_configuration_sid:
-          $ref: '#/components/schemas/sid_XE'
+          description: The SID of the Add-on configuration
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XE[0-9a-fA-F]{32}$
+          type: string
         add_on_sid:
-          $ref: '#/components/schemas/sid_XB'
+          description: The SID of the Add-on to which the result belongs
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XB[0-9a-fA-F]{32}$
+          type: string
         date_completed:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date and time in GMT that the result was completed
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         reference_sid:
-          $ref: '#/components/schemas/sid_RE'
+          description: The SID of the recording to which the AddOnResult resource
+            belongs
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RE[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_XR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XR[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/recording_add_on_result_status'
+          description: The status of the result
+          enum:
+          - canceled
+          - completed
+          - deleted
+          - failed
+          - in-progress
+          - init
+          - processing
+          - queued
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
       type: object
     api.v2010.account.recording.recording_add_on_result.recording_add_on_result_payload:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         add_on_configuration_sid:
-          $ref: '#/components/schemas/sid_XE'
+          description: The SID of the Add-on configuration
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XE[0-9a-fA-F]{32}$
+          type: string
         add_on_result_sid:
-          $ref: '#/components/schemas/sid_XR'
+          description: The SID of the AddOnResult to which the payload belongs
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XR[0-9a-fA-F]{32}$
+          type: string
         add_on_sid:
-          $ref: '#/components/schemas/sid_XB'
+          description: The SID of the Add-on to which the result belongs
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XB[0-9a-fA-F]{32}$
+          type: string
         content_type:
-          $ref: '#/components/schemas/string'
+          description: The MIME type of the payload
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         label:
-          $ref: '#/components/schemas/string'
+          description: The string that describes the payload
+          nullable: true
+          type: string
         reference_sid:
-          $ref: '#/components/schemas/sid_RE'
+          description: The SID of the recording to which the AddOnResult resource
+            that contains the payload belongs
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RE[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_XH'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^XH[0-9a-fA-F]{32}$
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
       type: object
     api.v2010.account.recording.recording_transcription:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the transcription
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/string'
+          description: The duration of the transcribed audio in seconds.
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The charge for the transcription
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which price is measured
+          nullable: true
+          type: string
         recording_sid:
-          $ref: '#/components/schemas/sid_RE'
+          description: The SID that identifies the transcription's recording
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RE[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_TR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TR[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/recording_transcription_status'
+          description: The status of the transcription
+          enum:
+          - in-progress
+          - completed
+          - failed
+          nullable: true
+          type: string
         transcription_text:
-          $ref: '#/components/schemas/string'
+          description: The text content of the transcription.
+          nullable: true
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: The transcription type
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.short_code:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to start a new TwiML session
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that this resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A string that you assigned to describe this resource
+          nullable: true
+          type: string
         short_code:
-          $ref: '#/components/schemas/string'
+          description: The short code. e.g., 894546.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_SC'
+          description: The unique string that identifies this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SC[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: HTTP method we use to call the sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: URL Twilio will request if an error occurs in executing TwiML
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: HTTP method to use when requesting the sms url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: URL we call when receiving an incoming SMS message to this
+            short code
+          format: uri
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of this resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.signing_key:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_SK'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SK[0-9a-fA-F]{32}$
+          type: string
       type: object
     api.v2010.account.sip:
       properties: {}
@@ -1482,81 +4013,215 @@ components:
     api.v2010.account.sip.sip_credential_list:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique sid that identifies this account
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this resource was last updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: Human readable descriptive text
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CL'
+          description: A string that uniquely identifies this credential
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CL[0-9a-fA-F]{32}$
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: The list of credentials associated with this credential list.
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI for this resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.sip.sip_credential_list.sip_credential:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique id of the Account that is responsible for this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         credential_list_sid:
-          $ref: '#/components/schemas/sid_CL'
+          description: The unique id that identifies the credential list that includes
+            this credential
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CL[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date that this resource was created, given as GMT in RFC
+            2822 format.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date that this resource was last updated, given as GMT
+            in RFC 2822 format.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI for this resource, relative to https://api.twilio.com
+          format: uri
+          nullable: true
+          type: string
         username:
-          $ref: '#/components/schemas/string'
+          description: The username for this credential.
+          nullable: true
+          type: string
       type: object
     api.v2010.account.sip.sip_domain:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to process the call
+          nullable: true
+          type: string
         auth_type:
-          $ref: '#/components/schemas/string'
+          description: The types of authentication mapped to the domain
+          nullable: true
+          type: string
         byoc_trunk_sid:
-          $ref: '#/components/schemas/sid_BY'
+          description: The SID of the BYOC Trunk resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BY[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         domain_name:
-          $ref: '#/components/schemas/string'
+          description: The unique address on Twilio to route SIP traffic
+          nullable: true
+          type: string
         emergency_caller_sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: Whether an emergency caller sid is configured for the domain.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         emergency_calling_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether emergency calling is enabled for the domain.
+          nullable: true
+          type: boolean
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         secure:
-          $ref: '#/components/schemas/boolean'
+          description: Whether secure SIP is enabled for the domain
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_SD'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SD[0-9a-fA-F]{32}$
+          type: string
         sip_registration:
-          $ref: '#/components/schemas/boolean'
+          description: Whether SIP registration is allowed
+          nullable: true
+          type: boolean
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list mapping resources associated with the SIP Domain resource
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs while executing TwiML
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call voice_status_callback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_status_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call with status updates
+          format: uri
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when receiving a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.sip.sip_domain.sip_auth:
       properties: {}
@@ -1567,28 +4232,66 @@ components:
     api.v2010.account.sip.sip_domain.sip_auth.sip_auth_calls.sip_auth_calls_credential_list_mapping:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CL[0-9a-fA-F]{32}$
+          type: string
       type: object
     api.v2010.account.sip.sip_domain.sip_auth.sip_auth_calls.sip_auth_calls_ip_access_control_list_mapping:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AL[0-9a-fA-F]{32}$
+          type: string
       type: object
     api.v2010.account.sip.sip_domain.sip_auth.sip_auth_registrations:
       properties: {}
@@ -1596,133 +4299,339 @@ components:
     api.v2010.account.sip.sip_domain.sip_auth.sip_auth_registrations.sip_auth_registrations_credential_list_mapping:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CL[0-9a-fA-F]{32}$
+          type: string
       type: object
     api.v2010.account.sip.sip_domain.sip_credential_list_mapping:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique id of the Account that is responsible for this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date that this resource was created, given as GMT in RFC
+            2822 format.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date that this resource was last updated, given as GMT
+            in RFC 2822 format.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human readable descriptive text for this resource, up to
+            64 characters long.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CL'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CL[0-9a-fA-F]{32}$
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: The credentials associated with this resource.
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI for this resource, relative to https://api.twilio.com
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.sip.sip_domain.sip_ip_access_control_list_mapping:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique id of the Account that is responsible for this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date that this resource was created, given as GMT in RFC
+            2822 format.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date that this resource was last updated, given as GMT
+            in RFC 2822 format.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human readable descriptive text for this resource, up to
+            64 characters long.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AL'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AL[0-9a-fA-F]{32}$
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: The list of IP addresses associated with this domain.
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI for this resource, relative to https://api.twilio.com
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.sip.sip_ip_access_control_list:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique sid that identifies this account
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date this resource was last updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human readable description of this resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AL'
+          description: A string that uniquely identifies this resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AL[0-9a-fA-F]{32}$
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: The IP addresses associated with this resource.
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI for this resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.sip.sip_ip_access_control_list.sip_ip_address:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique id of the Account that is responsible for this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cidr_prefix_length:
-          $ref: '#/components/schemas/integer'
+          description: An integer representing the length of the CIDR prefix to use
+            with this IP address when accepting traffic. By default the entire IP
+            address is used.
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date that this resource was created, given as GMT in RFC
+            2822 format.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The date that this resource was last updated, given as GMT
+            in RFC 2822 format.
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human readable descriptive text for this resource, up to
+            64 characters long.
+          nullable: true
+          type: string
         ip_access_control_list_sid:
-          $ref: '#/components/schemas/sid_AL'
+          description: The unique id of the IpAccessControlList resource that includes
+            this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AL[0-9a-fA-F]{32}$
+          type: string
         ip_address:
-          $ref: '#/components/schemas/string'
+          description: An IP address in dotted decimal notation from which you want
+            to accept traffic. Any SIP requests from this IP address will be allowed
+            by Twilio. IPv4 only supported today.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IP'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IP[0-9a-fA-F]{32}$
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI for this resource, relative to https://api.twilio.com
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.token:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         ice_servers:
-          $ref: '#/components/schemas/ice_server_list'
+          description: An array representing the ephemeral credentials
+          items:
+            properties:
+              credential:
+                type: string
+              url:
+                type: string
+              urls:
+                type: string
+              username:
+                type: string
+            type: object
+          nullable: true
+          type: array
         password:
-          $ref: '#/components/schemas/string'
+          description: The temporary password used for authenticating
+          nullable: true
+          type: string
         ttl:
-          $ref: '#/components/schemas/string'
+          description: The duration in seconds the credentials are valid
+          nullable: true
+          type: string
         username:
-          $ref: '#/components/schemas/string'
+          description: The temporary username that uniquely identifies a Token
+          nullable: true
+          type: string
       type: object
     api.v2010.account.transcription:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the transcription
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/string'
+          description: The duration of the transcribed audio in seconds.
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The charge for the transcription
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which price is measured
+          nullable: true
+          type: string
         recording_sid:
-          $ref: '#/components/schemas/sid_RE'
+          description: The SID that identifies the transcription's recording
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RE[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_TR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TR[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/transcription_status'
+          description: The status of the transcription
+          enum:
+          - in-progress
+          - completed
+          - failed
+          nullable: true
+          type: string
         transcription_text:
-          $ref: '#/components/schemas/string'
+          description: The text content of the transcription.
+          nullable: true
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: The transcription type
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage:
       properties: {}
@@ -1730,3374 +4639,3140 @@ components:
     api.v2010.account.usage.usage_record:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_record.usage_record_all_time:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_all_time_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_record.usage_record_daily:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_daily_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_record.usage_record_last_month:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_last_month_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_record.usage_record_monthly:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_monthly_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_record.usage_record_this_month:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_this_month_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_record.usage_record_today:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_today_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_record.usage_record_yearly:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_yearly_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_record.usage_record_yesterday:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account accrued the usage
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         as_of:
-          $ref: '#/components/schemas/string'
+          description: Usage records up to date as of this timestamp
+          nullable: true
+          type: string
         category:
-          $ref: '#/components/schemas/usage_record_yesterday_category'
+          description: The category of usage
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         count:
-          $ref: '#/components/schemas/string'
+          description: The number of usage events
+          nullable: true
+          type: string
         count_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which count is measured
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A plain-language description of the usage category
+          nullable: true
+          type: string
         end_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The last date for which usage is included in the UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The total price of the usage
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which `price` is measured
+          nullable: true
+          type: string
         start_date:
-          $ref: '#/components/schemas/date_iso8601'
+          description: The first date for which usage is included in this UsageRecord
+          format: date-time
+          nullable: true
+          type: string
         subresource_uris:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of related resources identified by their relative URIs
+          nullable: true
+          type: object
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage:
-          $ref: '#/components/schemas/string'
+          description: The amount of usage
+          nullable: true
+          type: string
         usage_unit:
-          $ref: '#/components/schemas/string'
+          description: The units in which usage is measured
+          nullable: true
+          type: string
       type: object
     api.v2010.account.usage.usage_trigger:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that this trigger monitors
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to create the resource
+          nullable: true
+          type: string
         callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call callback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         callback_url:
-          $ref: '#/components/schemas/url'
+          description: he URL we call when the trigger fires
+          format: uri
+          nullable: true
+          type: string
         current_value:
-          $ref: '#/components/schemas/string'
+          description: The current value of the field the trigger is watching
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_fired:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the trigger was last
+            fired
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_rfc2822'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time-rfc-2822
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the trigger
+          nullable: true
+          type: string
         recurring:
-          $ref: '#/components/schemas/usage_trigger_recurring'
+          description: The frequency of a recurring UsageTrigger
+          enum:
+          - daily
+          - monthly
+          - yearly
+          - alltime
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_UT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UT[0-9a-fA-F]{32}$
+          type: string
         trigger_by:
-          $ref: '#/components/schemas/usage_trigger_trigger_field'
+          description: The field in the UsageRecord resource that fires the trigger
+          enum:
+          - count
+          - usage
+          - price
+          nullable: true
+          type: string
         trigger_value:
-          $ref: '#/components/schemas/string'
+          description: The value at which the trigger will fire
+          nullable: true
+          type: string
         uri:
-          $ref: '#/components/schemas/uri'
+          description: The URI of the resource, relative to `https://api.twilio.com`
+          format: uri
+          nullable: true
+          type: string
         usage_category:
-          $ref: '#/components/schemas/usage_trigger_usage_category'
+          description: The usage category the trigger watches
+          enum:
+          - agent-conference
+          - answering-machine-detection
+          - authy-authentications
+          - authy-calls-outbound
+          - authy-monthly-fees
+          - authy-phone-intelligence
+          - authy-phone-verifications
+          - authy-sms-outbound
+          - call-progess-events
+          - calleridlookups
+          - calls
+          - calls-client
+          - calls-globalconference
+          - calls-inbound
+          - calls-inbound-local
+          - calls-inbound-mobile
+          - calls-inbound-tollfree
+          - calls-outbound
+          - calls-pay-verb-transactions
+          - calls-recordings
+          - calls-sip
+          - calls-sip-inbound
+          - calls-sip-outbound
+          - carrier-lookups
+          - conversations
+          - conversations-api-requests
+          - conversations-conversation-events
+          - conversations-endpoint-connectivity
+          - conversations-events
+          - conversations-participant-events
+          - conversations-participants
+          - cps
+          - fraud-lookups
+          - group-rooms
+          - group-rooms-data-track
+          - group-rooms-encrypted-media-recorded
+          - group-rooms-media-downloaded
+          - group-rooms-media-recorded
+          - group-rooms-media-routed
+          - group-rooms-media-stored
+          - group-rooms-participant-minutes
+          - group-rooms-recorded-minutes
+          - imp-v1-usage
+          - lookups
+          - marketplace
+          - marketplace-algorithmia-named-entity-recognition
+          - marketplace-cadence-transcription
+          - marketplace-cadence-translation
+          - marketplace-capio-speech-to-text
+          - marketplace-convriza-ababa
+          - marketplace-deepgram-phrase-detector
+          - marketplace-digital-segment-business-info
+          - marketplace-facebook-offline-conversions
+          - marketplace-google-speech-to-text
+          - marketplace-ibm-watson-message-insights
+          - marketplace-ibm-watson-message-sentiment
+          - marketplace-ibm-watson-recording-analysis
+          - marketplace-ibm-watson-tone-analyzer
+          - marketplace-icehook-systems-scout
+          - marketplace-infogroup-dataaxle-bizinfo
+          - marketplace-keen-io-contact-center-analytics
+          - marketplace-marchex-cleancall
+          - marketplace-marchex-sentiment-analysis-for-sms
+          - marketplace-marketplace-nextcaller-social-id
+          - marketplace-mobile-commons-opt-out-classifier
+          - marketplace-nexiwave-voicemail-to-text
+          - marketplace-nextcaller-advanced-caller-identification
+          - marketplace-nomorobo-spam-score
+          - marketplace-payfone-tcpa-compliance
+          - marketplace-remeeting-automatic-speech-recognition
+          - marketplace-tcpa-defense-solutions-blacklist-feed
+          - marketplace-telo-opencnam
+          - marketplace-truecnam-true-spam
+          - marketplace-twilio-caller-name-lookup-us
+          - marketplace-twilio-carrier-information-lookup
+          - marketplace-voicebase-pci
+          - marketplace-voicebase-transcription
+          - marketplace-voicebase-transcription-custom-vocabulary
+          - marketplace-whitepages-pro-caller-identification
+          - marketplace-whitepages-pro-phone-intelligence
+          - marketplace-whitepages-pro-phone-reputation
+          - marketplace-wolfarm-spoken-results
+          - marketplace-wolfram-short-answer
+          - marketplace-ytica-contact-center-reporting-analytics
+          - mediastorage
+          - mms
+          - mms-inbound
+          - mms-inbound-longcode
+          - mms-inbound-shortcode
+          - mms-messages-carrierfees
+          - mms-outbound
+          - mms-outbound-longcode
+          - mms-outbound-shortcode
+          - monitor-reads
+          - monitor-storage
+          - monitor-writes
+          - notify
+          - notify-actions-attempts
+          - notify-channels
+          - number-format-lookups
+          - pchat
+          - pchat-users
+          - peer-to-peer-rooms-participant-minutes
+          - pfax
+          - pfax-minutes
+          - pfax-minutes-inbound
+          - pfax-minutes-outbound
+          - pfax-pages
+          - phonenumbers
+          - phonenumbers-cps
+          - phonenumbers-emergency
+          - phonenumbers-local
+          - phonenumbers-mobile
+          - phonenumbers-setups
+          - phonenumbers-tollfree
+          - premiumsupport
+          - proxy
+          - proxy-active-sessions
+          - pstnconnectivity
+          - pv
+          - pv-composition-media-downloaded
+          - pv-composition-media-encrypted
+          - pv-composition-media-stored
+          - pv-composition-minutes
+          - pv-recording-compositions
+          - pv-room-participants
+          - pv-room-participants-au1
+          - pv-room-participants-br1
+          - pv-room-participants-ie1
+          - pv-room-participants-jp1
+          - pv-room-participants-sg1
+          - pv-room-participants-us1
+          - pv-room-participants-us2
+          - pv-rooms
+          - pv-sip-endpoint-registrations
+          - recordings
+          - recordingstorage
+          - rooms-group-bandwidth
+          - rooms-group-minutes
+          - rooms-peer-to-peer-minutes
+          - shortcodes
+          - shortcodes-customerowned
+          - shortcodes-mms-enablement
+          - shortcodes-mps
+          - shortcodes-random
+          - shortcodes-uk
+          - shortcodes-vanity
+          - small-group-rooms
+          - small-group-rooms-data-track
+          - small-group-rooms-participant-minutes
+          - sms
+          - sms-inbound
+          - sms-inbound-longcode
+          - sms-inbound-shortcode
+          - sms-messages-carrierfees
+          - sms-messages-features
+          - sms-messages-features-senderid
+          - sms-outbound
+          - sms-outbound-content-inspection
+          - sms-outbound-longcode
+          - sms-outbound-shortcode
+          - speech-recognition
+          - studio-engagements
+          - sync
+          - sync-actions
+          - sync-endpoint-hours
+          - sync-endpoint-hours-above-daily-cap
+          - taskrouter-tasks
+          - totalprice
+          - transcriptions
+          - trunking-cps
+          - trunking-emergency-calls
+          - trunking-origination
+          - trunking-origination-local
+          - trunking-origination-mobile
+          - trunking-origination-tollfree
+          - trunking-recordings
+          - trunking-secure
+          - trunking-termination
+          - turnmegabytes
+          - turnmegabytes-australia
+          - turnmegabytes-brasil
+          - turnmegabytes-germany
+          - turnmegabytes-india
+          - turnmegabytes-ireland
+          - turnmegabytes-japan
+          - turnmegabytes-singapore
+          - turnmegabytes-useast
+          - turnmegabytes-uswest
+          - twilio-interconnect
+          - verify-push
+          - video-recordings
+          - voice-insights
+          - voice-insights-client-insights-on-demand-minute
+          - voice-insights-ptsn-insights-on-demand-minute
+          - voice-insights-sip-interface-insights-on-demand-minute
+          - voice-insights-sip-trunking-insights-on-demand-minute
+          - wireless
+          - wireless-orders
+          - wireless-orders-artwork
+          - wireless-orders-bulk
+          - wireless-orders-esim
+          - wireless-orders-starter
+          - wireless-usage
+          - wireless-usage-commands
+          - wireless-usage-commands-africa
+          - wireless-usage-commands-asia
+          - wireless-usage-commands-centralandsouthamerica
+          - wireless-usage-commands-europe
+          - wireless-usage-commands-home
+          - wireless-usage-commands-northamerica
+          - wireless-usage-commands-oceania
+          - wireless-usage-commands-roaming
+          - wireless-usage-data
+          - wireless-usage-data-africa
+          - wireless-usage-data-asia
+          - wireless-usage-data-centralandsouthamerica
+          - wireless-usage-data-custom-additionalmb
+          - wireless-usage-data-custom-first5mb
+          - wireless-usage-data-domestic-roaming
+          - wireless-usage-data-europe
+          - wireless-usage-data-individual-additionalgb
+          - wireless-usage-data-individual-firstgb
+          - wireless-usage-data-international-roaming-canada
+          - wireless-usage-data-international-roaming-india
+          - wireless-usage-data-international-roaming-mexico
+          - wireless-usage-data-northamerica
+          - wireless-usage-data-oceania
+          - wireless-usage-data-pooled
+          - wireless-usage-data-pooled-downlink
+          - wireless-usage-data-pooled-uplink
+          - wireless-usage-mrc
+          - wireless-usage-mrc-custom
+          - wireless-usage-mrc-individual
+          - wireless-usage-mrc-pooled
+          - wireless-usage-mrc-suspended
+          - wireless-usage-sms
+          - wireless-usage-voice
+          nullable: true
+          type: string
         usage_record_uri:
-          $ref: '#/components/schemas/string'
+          description: The URI of the UsageRecord resource this trigger watches
+          nullable: true
+          type: string
       type: object
     api.v2010.account.validation_request:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          description: The SID of the Call the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number to verify in E.164 format
+          nullable: true
+          type: string
         validation_code:
-          $ref: '#/components/schemas/string'
+          description: The 6 digit validation code that someone must enter to validate
+            the Caller ID  when `phone_number` is called
+          nullable: true
+          type: string
       type: object
-    authorized_connect_app_permission_list:
-      items:
-        enum:
-        - get-all
-        - post-all
-        type: string
-      nullable: true
-      type: array
-    base64:
-      nullable: true
-      type: string
-    boolean:
-      nullable: true
-      type: boolean
-    call_feedback_issues_list:
-      items:
-        enum:
-        - audio-latency
-        - digits-not-captured
-        - dropped-call
-        - imperfect-audio
-        - incorrect-caller-id
-        - one-way-audio
-        - post-dial-delay
-        - unsolicited-call
-        type: string
-      nullable: true
-      type: array
-    call_feedback_summary_status:
-      enum:
-      - queued
-      - in-progress
-      - completed
-      - failed
-      nullable: true
-      type: string
-    call_recording_source:
-      enum:
-      - DialVerb
-      - Conference
-      - OutboundAPI
-      - Trunking
-      - RecordVerb
-      - StartCallRecordingAPI
-      - StartConferenceRecordingAPI
-      nullable: true
-      type: string
-    call_recording_status:
-      enum:
-      - in-progress
-      - paused
-      - stopped
-      - processing
-      - completed
-      - absent
-      nullable: true
-      type: string
-    call_status:
-      enum:
-      - queued
-      - ringing
-      - in-progress
-      - completed
-      - busy
-      - failed
-      - no-answer
-      - canceled
-      nullable: true
-      type: string
-    conference_reason_conference_ended:
-      enum:
-      - conference-ended-via-api
-      - participant-with-end-conference-on-exit-left
-      - participant-with-end-conference-on-exit-kicked
-      - last-participant-kicked
-      - last-participant-left
-      nullable: true
-      type: string
-    conference_recording_source:
-      enum:
-      - DialVerb
-      - Conference
-      - OutboundAPI
-      - Trunking
-      - RecordVerb
-      - StartCallRecordingAPI
-      - StartConferenceRecordingAPI
-      nullable: true
-      type: string
-    conference_recording_status:
-      enum:
-      - in-progress
-      - paused
-      - stopped
-      - processing
-      - completed
-      - absent
-      nullable: true
-      type: string
-    conference_status:
-      enum:
-      - init
-      - in-progress
-      - completed
-      nullable: true
-      type: string
-    connect_app_permission_list:
-      items:
-        enum:
-        - get-all
-        - post-all
-        type: string
-      nullable: true
-      type: array
-    currency:
-      nullable: true
-      type: string
-    date_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    date_time_rfc2822:
-      format: date-time-rfc-2822
-      nullable: true
-      type: string
-    decimal:
-      nullable: true
-      type: number
-    dependent_phone_number_address_requirement:
-      enum:
-      - none
-      - any
-      - local
-      - foreign
-      nullable: true
-      type: string
-    dependent_phone_number_emergency_status:
-      enum:
-      - Active
-      - Inactive
-      nullable: true
-      type: string
-    feedback_issue_list:
-      items:
-        properties:
-          count:
-            type: number
-          description:
-            type: string
-          percentage_of_total_calls:
-            type: string
-        type: object
-      nullable: true
-      type: array
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
-    ice_server_list:
-      items:
-        properties:
-          credential:
-            type: string
-          url:
-            type: string
-          urls:
-            type: string
-          username:
-            type: string
-        type: object
-      nullable: true
-      type: array
-    incoming_phone_number_address_requirement:
-      enum:
-      - none
-      - any
-      - local
-      - foreign
-      nullable: true
-      type: string
-    incoming_phone_number_emergency_status:
-      enum:
-      - Active
-      - Inactive
-      nullable: true
-      type: string
-    incoming_phone_number_local_address_requirement:
-      enum:
-      - none
-      - any
-      - local
-      - foreign
-      nullable: true
-      type: string
-    incoming_phone_number_local_emergency_status:
-      enum:
-      - Active
-      - Inactive
-      nullable: true
-      type: string
-    incoming_phone_number_local_voice_receive_mode:
-      enum:
-      - voice
-      - fax
-      nullable: true
-      type: string
-    incoming_phone_number_mobile_address_requirement:
-      enum:
-      - none
-      - any
-      - local
-      - foreign
-      nullable: true
-      type: string
-    incoming_phone_number_mobile_emergency_status:
-      enum:
-      - Active
-      - Inactive
-      nullable: true
-      type: string
-    incoming_phone_number_mobile_voice_receive_mode:
-      enum:
-      - voice
-      - fax
-      nullable: true
-      type: string
-    incoming_phone_number_toll_free_address_requirement:
-      enum:
-      - none
-      - any
-      - local
-      - foreign
-      nullable: true
-      type: string
-    incoming_phone_number_toll_free_emergency_status:
-      enum:
-      - Active
-      - Inactive
-      nullable: true
-      type: string
-    incoming_phone_number_toll_free_voice_receive_mode:
-      enum:
-      - voice
-      - fax
-      nullable: true
-      type: string
-    incoming_phone_number_voice_receive_mode:
-      enum:
-      - voice
-      - fax
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    iso_country_code:
-      nullable: true
-      type: string
-    message_direction:
-      enum:
-      - inbound
-      - outbound-api
-      - outbound-call
-      - outbound-reply
-      nullable: true
-      type: string
-    message_feedback_outcome:
-      enum:
-      - confirmed
-      - unconfirmed
-      nullable: true
-      type: string
-    message_status:
-      enum:
-      - queued
-      - sending
-      - sent
-      - failed
-      - delivered
-      - undelivered
-      - receiving
-      - received
-      - accepted
-      - scheduled
-      - read
-      - partially_delivered
-      nullable: true
-      type: string
-    object:
-      nullable: true
-      type: object
-    participant_status:
-      enum:
-      - queued
-      - connecting
-      - ringing
-      - connected
-      - complete
-      - failed
-      nullable: true
-      type: string
-    phone_number:
-      nullable: true
-      type: string
-    phone_number_capabilities:
-      nullable: true
-      properties:
-        fax:
-          type: boolean
-        mms:
-          type: boolean
-        sms:
-          type: boolean
-        voice:
-          type: boolean
-      type: object
-    recording_add_on_result_status:
-      enum:
-      - canceled
-      - completed
-      - deleted
-      - failed
-      - in-progress
-      - init
-      - processing
-      - queued
-      nullable: true
-      type: string
-    recording_source:
-      enum:
-      - DialVerb
-      - Conference
-      - OutboundAPI
-      - Trunking
-      - RecordVerb
-      - StartCallRecordingAPI
-      - StartConferenceRecordingAPI
-      nullable: true
-      type: string
-    recording_status:
-      enum:
-      - in-progress
-      - paused
-      - stopped
-      - processing
-      - completed
-      - absent
-      nullable: true
-      type: string
-    recording_transcription_status:
-      enum:
-      - in-progress
-      - completed
-      - failed
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_AD:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AD[0-9a-fA-F]{32}$
-      type: string
-    sid_AL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AL[0-9a-fA-F]{32}$
-      type: string
-    sid_AP:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AP[0-9a-fA-F]{32}$
-      type: string
-    sid_BU:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BU[0-9a-fA-F]{32}$
-      type: string
-    sid_BY:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BY[0-9a-fA-F]{32}$
-      type: string
-    sid_CA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CA[0-9a-fA-F]{32}$
-      type: string
-    sid_CF:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CF[0-9a-fA-F]{32}$
-      type: string
-    sid_CL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CL[0-9a-fA-F]{32}$
-      type: string
-    sid_CN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CN[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    sid_FS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FS[0-9a-fA-F]{32}$
-      type: string
-    sid_GP:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^GP[0-9a-fA-F]{32}$
-      type: string
-    sid_IP:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IP[0-9a-fA-F]{32}$
-      type: string
-    sid_ME:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ME[0-9a-fA-F]{32}$
-      type: string
-    sid_MG:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MG[0-9a-fA-F]{32}$
-      type: string
-    sid_MM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^(SM|MM)[0-9a-fA-F]{32}$
-      type: string
-    sid_NO:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^NO[0-9a-fA-F]{32}$
-      type: string
-    sid_PK:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^PK[0-9a-fA-F]{32}$
-      type: string
-    sid_PN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^PN[0-9a-fA-F]{32}$
-      type: string
-    sid_QU:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^QU[0-9a-fA-F]{32}$
-      type: string
-    sid_RE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RE[0-9a-fA-F]{32}$
-      type: string
-    sid_RI:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RI[0-9a-fA-F]{32}$
-      type: string
-    sid_SC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^SC[0-9a-fA-F]{32}$
-      type: string
-    sid_SD:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^SD[0-9a-fA-F]{32}$
-      type: string
-    sid_SK:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^SK[0-9a-fA-F]{32}$
-      type: string
-    sid_TK:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^TK[0-9a-fA-F]{32}$
-      type: string
-    sid_TR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^TR[0-9a-fA-F]{32}$
-      type: string
-    sid_UT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UT[0-9a-fA-F]{32}$
-      type: string
-    sid_XB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^XB[0-9a-fA-F]{32}$
-      type: string
-    sid_XE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^XE[0-9a-fA-F]{32}$
-      type: string
-    sid_XF:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^XF[0-9a-fA-F]{32}$
-      type: string
-    sid_XH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^XH[0-9a-fA-F]{32}$
-      type: string
-    sid_XR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^XR[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    transcription_status:
-      enum:
-      - in-progress
-      - completed
-      - failed
-      nullable: true
-      type: string
-    uri:
-      format: uri
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
-    usage_record_all_time_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_record_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_record_daily_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_record_last_month_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_record_monthly_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_record_this_month_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_record_today_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_record_yearly_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_record_yesterday_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
-    usage_trigger_recurring:
-      enum:
-      - daily
-      - monthly
-      - yearly
-      - alltime
-      nullable: true
-      type: string
-    usage_trigger_trigger_field:
-      enum:
-      - count
-      - usage
-      - price
-      nullable: true
-      type: string
-    usage_trigger_usage_category:
-      enum:
-      - agent-conference
-      - answering-machine-detection
-      - authy-authentications
-      - authy-calls-outbound
-      - authy-monthly-fees
-      - authy-phone-intelligence
-      - authy-phone-verifications
-      - authy-sms-outbound
-      - call-progess-events
-      - calleridlookups
-      - calls
-      - calls-client
-      - calls-globalconference
-      - calls-inbound
-      - calls-inbound-local
-      - calls-inbound-mobile
-      - calls-inbound-tollfree
-      - calls-outbound
-      - calls-pay-verb-transactions
-      - calls-recordings
-      - calls-sip
-      - calls-sip-inbound
-      - calls-sip-outbound
-      - carrier-lookups
-      - conversations
-      - conversations-api-requests
-      - conversations-conversation-events
-      - conversations-endpoint-connectivity
-      - conversations-events
-      - conversations-participant-events
-      - conversations-participants
-      - cps
-      - fraud-lookups
-      - group-rooms
-      - group-rooms-data-track
-      - group-rooms-encrypted-media-recorded
-      - group-rooms-media-downloaded
-      - group-rooms-media-recorded
-      - group-rooms-media-routed
-      - group-rooms-media-stored
-      - group-rooms-participant-minutes
-      - group-rooms-recorded-minutes
-      - imp-v1-usage
-      - lookups
-      - marketplace
-      - marketplace-algorithmia-named-entity-recognition
-      - marketplace-cadence-transcription
-      - marketplace-cadence-translation
-      - marketplace-capio-speech-to-text
-      - marketplace-convriza-ababa
-      - marketplace-deepgram-phrase-detector
-      - marketplace-digital-segment-business-info
-      - marketplace-facebook-offline-conversions
-      - marketplace-google-speech-to-text
-      - marketplace-ibm-watson-message-insights
-      - marketplace-ibm-watson-message-sentiment
-      - marketplace-ibm-watson-recording-analysis
-      - marketplace-ibm-watson-tone-analyzer
-      - marketplace-icehook-systems-scout
-      - marketplace-infogroup-dataaxle-bizinfo
-      - marketplace-keen-io-contact-center-analytics
-      - marketplace-marchex-cleancall
-      - marketplace-marchex-sentiment-analysis-for-sms
-      - marketplace-marketplace-nextcaller-social-id
-      - marketplace-mobile-commons-opt-out-classifier
-      - marketplace-nexiwave-voicemail-to-text
-      - marketplace-nextcaller-advanced-caller-identification
-      - marketplace-nomorobo-spam-score
-      - marketplace-payfone-tcpa-compliance
-      - marketplace-remeeting-automatic-speech-recognition
-      - marketplace-tcpa-defense-solutions-blacklist-feed
-      - marketplace-telo-opencnam
-      - marketplace-truecnam-true-spam
-      - marketplace-twilio-caller-name-lookup-us
-      - marketplace-twilio-carrier-information-lookup
-      - marketplace-voicebase-pci
-      - marketplace-voicebase-transcription
-      - marketplace-voicebase-transcription-custom-vocabulary
-      - marketplace-whitepages-pro-caller-identification
-      - marketplace-whitepages-pro-phone-intelligence
-      - marketplace-whitepages-pro-phone-reputation
-      - marketplace-wolfarm-spoken-results
-      - marketplace-wolfram-short-answer
-      - marketplace-ytica-contact-center-reporting-analytics
-      - mediastorage
-      - mms
-      - mms-inbound
-      - mms-inbound-longcode
-      - mms-inbound-shortcode
-      - mms-messages-carrierfees
-      - mms-outbound
-      - mms-outbound-longcode
-      - mms-outbound-shortcode
-      - monitor-reads
-      - monitor-storage
-      - monitor-writes
-      - notify
-      - notify-actions-attempts
-      - notify-channels
-      - number-format-lookups
-      - pchat
-      - pchat-users
-      - peer-to-peer-rooms-participant-minutes
-      - pfax
-      - pfax-minutes
-      - pfax-minutes-inbound
-      - pfax-minutes-outbound
-      - pfax-pages
-      - phonenumbers
-      - phonenumbers-cps
-      - phonenumbers-emergency
-      - phonenumbers-local
-      - phonenumbers-mobile
-      - phonenumbers-setups
-      - phonenumbers-tollfree
-      - premiumsupport
-      - proxy
-      - proxy-active-sessions
-      - pstnconnectivity
-      - pv
-      - pv-composition-media-downloaded
-      - pv-composition-media-encrypted
-      - pv-composition-media-stored
-      - pv-composition-minutes
-      - pv-recording-compositions
-      - pv-room-participants
-      - pv-room-participants-au1
-      - pv-room-participants-br1
-      - pv-room-participants-ie1
-      - pv-room-participants-jp1
-      - pv-room-participants-sg1
-      - pv-room-participants-us1
-      - pv-room-participants-us2
-      - pv-rooms
-      - pv-sip-endpoint-registrations
-      - recordings
-      - recordingstorage
-      - rooms-group-bandwidth
-      - rooms-group-minutes
-      - rooms-peer-to-peer-minutes
-      - shortcodes
-      - shortcodes-customerowned
-      - shortcodes-mms-enablement
-      - shortcodes-mps
-      - shortcodes-random
-      - shortcodes-uk
-      - shortcodes-vanity
-      - small-group-rooms
-      - small-group-rooms-data-track
-      - small-group-rooms-participant-minutes
-      - sms
-      - sms-inbound
-      - sms-inbound-longcode
-      - sms-inbound-shortcode
-      - sms-messages-carrierfees
-      - sms-messages-features
-      - sms-messages-features-senderid
-      - sms-outbound
-      - sms-outbound-content-inspection
-      - sms-outbound-longcode
-      - sms-outbound-shortcode
-      - speech-recognition
-      - studio-engagements
-      - sync
-      - sync-actions
-      - sync-endpoint-hours
-      - sync-endpoint-hours-above-daily-cap
-      - taskrouter-tasks
-      - totalprice
-      - transcriptions
-      - trunking-cps
-      - trunking-emergency-calls
-      - trunking-origination
-      - trunking-origination-local
-      - trunking-origination-mobile
-      - trunking-origination-tollfree
-      - trunking-recordings
-      - trunking-secure
-      - trunking-termination
-      - turnmegabytes
-      - turnmegabytes-australia
-      - turnmegabytes-brasil
-      - turnmegabytes-germany
-      - turnmegabytes-india
-      - turnmegabytes-ireland
-      - turnmegabytes-japan
-      - turnmegabytes-singapore
-      - turnmegabytes-useast
-      - turnmegabytes-uswest
-      - twilio-interconnect
-      - verify-push
-      - video-recordings
-      - voice-insights
-      - voice-insights-client-insights-on-demand-minute
-      - voice-insights-ptsn-insights-on-demand-minute
-      - voice-insights-sip-interface-insights-on-demand-minute
-      - voice-insights-sip-trunking-insights-on-demand-minute
-      - wireless
-      - wireless-orders
-      - wireless-orders-artwork
-      - wireless-orders-bulk
-      - wireless-orders-esim
-      - wireless-orders-starter
-      - wireless-usage
-      - wireless-usage-commands
-      - wireless-usage-commands-africa
-      - wireless-usage-commands-asia
-      - wireless-usage-commands-centralandsouthamerica
-      - wireless-usage-commands-europe
-      - wireless-usage-commands-home
-      - wireless-usage-commands-northamerica
-      - wireless-usage-commands-oceania
-      - wireless-usage-commands-roaming
-      - wireless-usage-data
-      - wireless-usage-data-africa
-      - wireless-usage-data-asia
-      - wireless-usage-data-centralandsouthamerica
-      - wireless-usage-data-custom-additionalmb
-      - wireless-usage-data-custom-first5mb
-      - wireless-usage-data-domestic-roaming
-      - wireless-usage-data-europe
-      - wireless-usage-data-individual-additionalgb
-      - wireless-usage-data-individual-firstgb
-      - wireless-usage-data-international-roaming-canada
-      - wireless-usage-data-international-roaming-india
-      - wireless-usage-data-international-roaming-mexico
-      - wireless-usage-data-northamerica
-      - wireless-usage-data-oceania
-      - wireless-usage-data-pooled
-      - wireless-usage-data-pooled-downlink
-      - wireless-usage-data-pooled-uplink
-      - wireless-usage-mrc
-      - wireless-usage-mrc-custom
-      - wireless-usage-mrc-individual
-      - wireless-usage-mrc-pooled
-      - wireless-usage-mrc-suspended
-      - wireless-usage-sms
-      - wireless-usage-voice
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_autopilot_v1.yaml
+++ b/spec/yaml/twilio_autopilot_v1.yaml
@@ -3,410 +3,802 @@ components:
     autopilot.v1.assistant:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         callback_events:
-          $ref: '#/components/schemas/string'
+          description: Reserved
+          nullable: true
+          type: string
         callback_url:
-          $ref: '#/components/schemas/url'
+          description: Reserved
+          format: uri
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         development_stage:
-          $ref: '#/components/schemas/string'
+          description: A string describing the state of the assistant.
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         latest_model_build_sid:
-          $ref: '#/components/schemas/sid_UG'
+          description: Reserved
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UG[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of the URLs of the Assistant's related resources
+          nullable: true
+          type: object
         log_queries:
-          $ref: '#/components/schemas/boolean'
+          description: Whether queries should be logged and kept after training
+          nullable: true
+          type: boolean
         needs_model_build:
-          $ref: '#/components/schemas/boolean'
+          description: Whether model needs to be rebuilt
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Assistant resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.defaults:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         data:
-          $ref: '#/components/schemas/object'
+          description: The JSON string that describes the default task links
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Defaults resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.dialogue:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         data:
-          $ref: '#/components/schemas/object'
+          description: The JSON string that describes the dialogue session object
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_UK'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UK[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Dialogue resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.field_type:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of the URLs of related resources
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_UB'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UB[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the FieldType resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.field_type.field_value:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the FieldType
+            associated with the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         field_type_sid:
-          $ref: '#/components/schemas/sid_UB'
+          description: The SID of the Field Type associated with the Field Value
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UB[0-9a-fA-F]{32}$
+          type: string
         language:
-          $ref: '#/components/schemas/string'
+          description: The ISO language-country tag that identifies the language of
+            the value
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_UC'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UC[0-9a-fA-F]{32}$
+          type: string
         synonym_of:
-          $ref: '#/components/schemas/sid_UC'
+          description: The word for which the field value is a synonym of
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UC[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the FieldValue resource
+          format: uri
+          nullable: true
+          type: string
         value:
-          $ref: '#/components/schemas/string'
+          description: The Field Value data
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.model_build:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         build_duration:
-          $ref: '#/components/schemas/integer'
+          description: The time in seconds it took to build the model
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/integer'
+          description: More information about why the model build failed, if `status`
+            is `failed`
+          nullable: true
+          type: integer
         sid:
-          $ref: '#/components/schemas/sid_UG'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UG[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/model_build_status'
+          description: The status of the model build process
+          enum:
+          - enqueued
+          - building
+          - completed
+          - failed
+          - canceled
+          nullable: true
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the ModelBuild resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.query:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         dialogue_sid:
-          $ref: '#/components/schemas/sid_UK'
+          description: The SID of the [Dialogue](https://www.twilio.com/docs/autopilot/api/dialogue).
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UK[0-9a-fA-F]{32}$
+          type: string
         language:
-          $ref: '#/components/schemas/string'
+          description: The ISO language-country string that specifies the language
+            used by the Query
+          nullable: true
+          type: string
         model_build_sid:
-          $ref: '#/components/schemas/sid_UG'
+          description: The SID of the [Model Build](https://www.twilio.com/docs/autopilot/api/model-build)
+            queried
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UG[0-9a-fA-F]{32}$
+          type: string
         query:
-          $ref: '#/components/schemas/string'
+          description: The end-user's natural language input
+          nullable: true
+          type: string
         results:
-          $ref: '#/components/schemas/object'
+          description: The natural language analysis results that include the Task
+            recognized and a list of identified Fields
+          nullable: true
+          type: object
         sample_sid:
-          $ref: '#/components/schemas/sid_UF'
+          description: The SID of an optional reference to the Sample created from
+            the query
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UF[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_UH'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UH[0-9a-fA-F]{32}$
+          type: string
         source_channel:
-          $ref: '#/components/schemas/string'
+          description: The communication channel from where the end-user input came
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/string'
+          description: The status of the Query
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Query resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.style_sheet:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         data:
-          $ref: '#/components/schemas/object'
+          description: The JSON string that describes the style sheet object
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the StyleSheet resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.task:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         actions_url:
-          $ref: '#/components/schemas/url'
+          description: The URL from which the Assistant can fetch actions
+          format: uri
+          nullable: true
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of the URLs of related resources
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_UD'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UD[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Task resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.task.field:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the Task associated
+            with the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         field_type:
-          $ref: '#/components/schemas/string'
+          description: The Field Type of the field
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_UE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UE[0-9a-fA-F]{32}$
+          type: string
         task_sid:
-          $ref: '#/components/schemas/sid_UD'
+          description: The SID of the [Task](https://www.twilio.com/docs/autopilot/api/task)
+            resource associated with this Field
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UD[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Field resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.task.sample:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the Task associated
+            with the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         language:
-          $ref: '#/components/schemas/string'
+          description: An ISO language-country string that specifies the language
+            used for the sample
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_UF'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UF[0-9a-fA-F]{32}$
+          type: string
         source_channel:
-          $ref: '#/components/schemas/string'
+          description: The communication channel from which the sample was captured
+          nullable: true
+          type: string
         tagged_text:
-          $ref: '#/components/schemas/string'
+          description: The text example of how end users might express the task
+          nullable: true
+          type: string
         task_sid:
-          $ref: '#/components/schemas/sid_UD'
+          description: The SID of the Task associated with the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UD[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Sample resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.task.task_actions:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the Task associated
+            with the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         data:
-          $ref: '#/components/schemas/object'
+          description: The JSON string that specifies the actions that instruct the
+            Assistant on how to perform the task
+          nullable: true
+          type: object
         task_sid:
-          $ref: '#/components/schemas/sid_UD'
+          description: The SID of the Task associated with the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UD[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the TaskActions resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.task.task_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the Task associated
+            with the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         fields_count:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Fields associated with the Task
+          nullable: true
+          type: integer
         samples_count:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Samples associated with the Task
+          nullable: true
+          type: integer
         task_sid:
-          $ref: '#/components/schemas/sid_UD'
+          description: The SID of the Task for which the statistics were collected
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UD[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the TaskStatistics resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.assistant.webhook:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assistant_sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The SID of the Assistant that is the parent of the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         events:
-          $ref: '#/components/schemas/string'
+          description: The list of space-separated events that this Webhook is subscribed
+            to.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_UM'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UM[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Webhook resource
+          format: uri
+          nullable: true
+          type: string
         webhook_method:
-          $ref: '#/components/schemas/string'
+          description: The method used when calling the webhook's URL.
+          nullable: true
+          type: string
         webhook_url:
-          $ref: '#/components/schemas/url'
+          description: The URL associated with this Webhook.
+          format: uri
+          nullable: true
+          type: string
       type: object
     autopilot.v1.restore_assistant:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         callback_events:
-          $ref: '#/components/schemas/string'
+          description: Reserved
+          nullable: true
+          type: string
         callback_url:
-          $ref: '#/components/schemas/url'
+          description: Reserved
+          format: uri
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         development_stage:
-          $ref: '#/components/schemas/string'
+          description: A string describing the state of the assistant.
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         latest_model_build_sid:
-          $ref: '#/components/schemas/sid_UG'
+          description: Reserved
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UG[0-9a-fA-F]{32}$
+          type: string
         log_queries:
-          $ref: '#/components/schemas/boolean'
+          description: Whether queries should be logged and kept after training
+          nullable: true
+          type: boolean
         needs_model_build:
-          $ref: '#/components/schemas/boolean'
+          description: Whether model needs to be rebuilt
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_UA'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^UA[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
       type: object
-    boolean:
-      nullable: true
-      type: boolean
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    model_build_status:
-      enum:
-      - enqueued
-      - building
-      - completed
-      - failed
-      - canceled
-      nullable: true
-      type: string
-    object:
-      nullable: true
-      type: object
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_UA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UA[0-9a-fA-F]{32}$
-      type: string
-    sid_UB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UB[0-9a-fA-F]{32}$
-      type: string
-    sid_UC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UC[0-9a-fA-F]{32}$
-      type: string
-    sid_UD:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UD[0-9a-fA-F]{32}$
-      type: string
-    sid_UE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UE[0-9a-fA-F]{32}$
-      type: string
-    sid_UF:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UF[0-9a-fA-F]{32}$
-      type: string
-    sid_UG:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UG[0-9a-fA-F]{32}$
-      type: string
-    sid_UH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UH[0-9a-fA-F]{32}$
-      type: string
-    sid_UK:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UK[0-9a-fA-F]{32}$
-      type: string
-    sid_UM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^UM[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_bulkexports_v1.yaml
+++ b/spec/yaml/twilio_bulkexports_v1.yaml
@@ -1,114 +1,179 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
     bulkexports.v1.export:
       properties:
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs.
+          nullable: true
+          type: object
         resource_type:
-          $ref: '#/components/schemas/string'
+          description: "The type of communication \u2013 Messages, Calls, Conferences,\
+            \ and Participants"
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     bulkexports.v1.export.day:
       properties:
         create_date:
-          $ref: '#/components/schemas/string'
+          description: The date when resource is created
+          nullable: true
+          type: string
         day:
-          $ref: '#/components/schemas/string'
+          description: The date of the data in the file
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly name specified when creating the job
+          nullable: true
+          type: string
         resource_type:
-          $ref: '#/components/schemas/string'
+          description: "The type of communication \u2013 Messages, Calls, Conferences,\
+            \ and Participants"
+          nullable: true
+          type: string
         size:
-          $ref: '#/components/schemas/integer'
+          description: Size of the file in bytes
+          nullable: true
+          type: integer
       type: object
     bulkexports.v1.export.day-instance:
       properties:
         redirect_to:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     bulkexports.v1.export.export_custom_job:
       properties:
         details:
-          $ref: '#/components/schemas/object'
+          description: The details of a job state which is an object that contains
+            a status string, a day count integer, and list of days in the job
+          nullable: true
+          type: object
         email:
-          $ref: '#/components/schemas/string'
+          description: The optional email to send the completion notification to
+          nullable: true
+          type: string
         end_day:
-          $ref: '#/components/schemas/string'
+          description: The end day for the custom export specified as a string in
+            the format of yyyy-MM-dd. This will be the last day exported. For instance,
+            to export a single day, choose the same day for start and end day. To
+            export the first 4 days of July, you would set the start date to 2020-07-01
+            and the end date to 2020-07-04. The end date must be the UTC day before
+            yesterday.
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly name specified when creating the job
+          nullable: true
+          type: string
         job_sid:
-          $ref: '#/components/schemas/sid_JS'
+          description: The unique job_sid returned when the custom export was created.
+            This can be used to look up the status of the job.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^JS[0-9a-fA-F]{32}$
+          type: string
         resource_type:
-          $ref: '#/components/schemas/string'
+          description: "The type of communication \u2013 Messages, Calls, Conferences,\
+            \ and Participants"
+          nullable: true
+          type: string
         start_day:
-          $ref: '#/components/schemas/string'
+          description: The start day for the custom export specified as a string in
+            the format of yyyy-MM-dd
+          nullable: true
+          type: string
         webhook_method:
-          $ref: '#/components/schemas/string'
+          description: This is the method used to call the webhook
+          nullable: true
+          type: string
         webhook_url:
-          $ref: '#/components/schemas/string'
+          description: The optional webhook url called on completion
+          nullable: true
+          type: string
       type: object
     bulkexports.v1.export.job:
       properties:
         details:
-          $ref: '#/components/schemas/object'
+          description: This is a list of the completed, pending, or errored dates
+            within the export time range, with one entry for each status with more
+            than one day in that status
+          nullable: true
+          type: object
         email:
-          $ref: '#/components/schemas/string'
+          description: The optional email to send the completion notification to
+          nullable: true
+          type: string
         end_day:
-          $ref: '#/components/schemas/string'
+          description: The end time for the export specified when creating the job
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly name specified when creating the job
+          nullable: true
+          type: string
         job_sid:
-          $ref: '#/components/schemas/sid_JS'
+          description: The job_sid returned when the export was created
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^JS[0-9a-fA-F]{32}$
+          type: string
         resource_type:
-          $ref: '#/components/schemas/string'
+          description: "The type of communication \u2013 Messages, Calls, Conferences,\
+            \ and Participants"
+          nullable: true
+          type: string
         start_day:
-          $ref: '#/components/schemas/string'
+          description: The start time for the export specified when creating the job
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         webhook_method:
-          $ref: '#/components/schemas/string'
+          description: This is the method used to call the webhook
+          nullable: true
+          type: string
         webhook_url:
-          $ref: '#/components/schemas/string'
+          description: The optional webhook url called on completion
+          nullable: true
+          type: string
       type: object
     bulkexports.v1.export_configuration:
       properties:
         enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether files are automatically generated
+          nullable: true
+          type: boolean
         resource_type:
-          $ref: '#/components/schemas/string'
+          description: "The type of communication \u2013 Messages, Calls, Conferences,\
+            \ and Participants"
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
         webhook_method:
-          $ref: '#/components/schemas/string'
+          description: Whether to GET or POST to the webhook url
+          nullable: true
+          type: string
         webhook_url:
-          $ref: '#/components/schemas/url'
+          description: URL targeted at export
+          format: uri
+          nullable: true
+          type: string
       type: object
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    sid_JS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^JS[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_chat_v1.yaml
+++ b/spec/yaml/twilio_chat_v1.yaml
@@ -1,356 +1,639 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    channel_channel_type:
-      enum:
-      - public
-      - private
-      nullable: true
-      type: string
     chat.v1.credential:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sandbox:
-          $ref: '#/components/schemas/string'
+          description: '[APN only] Whether to send the credential to sandbox APNs'
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/credential_push_service'
+          description: The type of push-notification service the credential is for
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Credential resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v1.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         consumption_report_interval:
-          $ref: '#/components/schemas/integer'
+          description: DEPRECATED
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         default_channel_creator_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The channel role assigned to a channel creator when they join
+            a new channel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_channel_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The channel role assigned to users when they are added to a
+            channel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_service_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The service role assigned to users when they are added to the
+            service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         limits:
-          $ref: '#/components/schemas/object'
+          description: An object that describes the limits of the service instance
+          nullable: true
+          type: object
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The absolute URLs of the Service's Channels, Roles, and Users
+          nullable: true
+          type: object
         notifications:
-          $ref: '#/components/schemas/object'
+          description: The notification configuration for the Service instance
+          nullable: true
+          type: object
         post_webhook_url:
-          $ref: '#/components/schemas/string'
+          description: The URL for post-event webhooks
+          nullable: true
+          type: string
         pre_webhook_url:
-          $ref: '#/components/schemas/string'
+          description: The webhook URL for pre-event webhooks
+          nullable: true
+          type: string
         reachability_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Reachability Indicator feature is enabled for this
+            Service instance
+          nullable: true
+          type: boolean
         read_status_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Message Consumption Horizon feature is enabled
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         typing_indicator_timeout:
-          $ref: '#/components/schemas/integer'
+          description: How long in seconds to wait before assuming the user is no
+            longer typing
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Service resource
+          format: uri
+          nullable: true
+          type: string
         webhook_filters:
-          $ref: '#/components/schemas/string_list'
+          description: The list of WebHook events that are enabled for this Service
+            instance
+          items:
+            type: string
+          nullable: true
+          type: array
         webhook_method:
-          $ref: '#/components/schemas/string'
+          description: The HTTP method  to use for both PRE and POST webhooks
+          nullable: true
+          type: string
         webhooks:
-          $ref: '#/components/schemas/object'
+          description: An object that contains information about the webhooks configured
+            for this service
+          nullable: true
+          type: object
       type: object
     chat.v1.service.channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string that stores application-specific data
+          nullable: true
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the User that created the channel
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URLs to access the Members, Messages , Invites and,
+            if it exists, the last Message for the Channel
+          nullable: true
+          type: object
         members_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of Members in the Channel
+          nullable: true
+          type: integer
         messages_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of Messages in the Channel
+          nullable: true
+          type: integer
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/channel_channel_type'
+          description: 'The visibility of the channel. Can be: `public` or `private`'
+          enum:
+          - public
+          - private
+          nullable: true
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Channel resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v1.service.channel.invite:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel the new resource belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the User that created the invite
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of the Role assigned to the member
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Invite resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v1.service.channel.member:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Channel for the member
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         last_consumed_message_index:
-          $ref: '#/components/schemas/integer'
+          description: The index of the last Message that the Member has read within
+            the Channel
+          nullable: true
+          type: integer
         last_consumption_timestamp:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 based timestamp string that represents the date-time
+            of the last Message read event for the Member within the Channel
+          format: date-time
+          nullable: true
+          type: string
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of the Role assigned to the member
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Member resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v1.service.channel.message:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string that stores application-specific data
+          nullable: true
+          type: string
         body:
-          $ref: '#/components/schemas/string'
+          description: The content of the message
+          nullable: true
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Channel the Message resource belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         from:
-          $ref: '#/components/schemas/string'
+          description: The identity of the message's author
+          nullable: true
+          type: string
         index:
-          $ref: '#/components/schemas/integer'
+          description: The index of the message within the Channel
+          nullable: true
+          type: integer
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IM'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IM[0-9a-fA-F]{32}$
+          type: string
         to:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel that the message was sent to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Message resource
+          format: uri
+          nullable: true
+          type: string
         was_edited:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the message has been edited since  it was created
+          nullable: true
+          type: boolean
       type: object
     chat.v1.service.role:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         permissions:
-          $ref: '#/components/schemas/string_list'
+          description: An array of the permissions the role has been granted
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/role_role_type'
+          description: The type of role
+          enum:
+          - channel
+          - deployment
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Role resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v1.service.user:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string that stores application-specific data
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         is_notifiable:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the User has a potentially valid Push Notification
+            registration for the Service instance
+          nullable: true
+          type: boolean
         is_online:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the User is actively connected to the Service instance
+            and online
+          nullable: true
+          type: boolean
         joined_channels_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of Channels this User is a Member of
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The absolute URLs of the Channel and Binding resources related
+            to the user
+          nullable: true
+          type: object
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of the assigned to the user
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_US'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the User resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v1.service.user.user_channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel the resource belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         last_consumed_message_index:
-          $ref: '#/components/schemas/integer'
+          description: The index of the last Message in the Channel the Member has
+            read
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URLs to access the Members, Messages , Invites and,
+            if it exists, the last Message for the Channel
+          nullable: true
+          type: object
         member_sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: The SID of the User as a Member in the Channel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/user_channel_channel_status'
+          description: The status of the User on the Channel
+          enum:
+          - joined
+          - invited
+          - not_participating
+          nullable: true
+          type: string
         unread_messages_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of unread Messages in the Channel for the User
+          nullable: true
+          type: integer
       type: object
-    credential_push_service:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    role_role_type:
-      enum:
-      - channel
-      - deployment
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_CH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CH[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    sid_IM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IM[0-9a-fA-F]{32}$
-      type: string
-    sid_IN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IN[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_MB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MB[0-9a-fA-F]{32}$
-      type: string
-    sid_RL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RL[0-9a-fA-F]{32}$
-      type: string
-    sid_US:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^US[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
-    user_channel_channel_status:
-      enum:
-      - joined
-      - invited
-      - not_participating
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_chat_v2.yaml
+++ b/spec/yaml/twilio_chat_v2.yaml
@@ -1,481 +1,894 @@
 components:
   schemas:
-    binding_binding_type:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    boolean:
-      nullable: true
-      type: boolean
-    channel_channel_type:
-      enum:
-      - public
-      - private
-      nullable: true
-      type: string
     chat.v2.credential:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sandbox:
-          $ref: '#/components/schemas/string'
+          description: '[APN only] Whether to send the credential to sandbox APNs'
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/credential_push_service'
+          description: The type of push-notification service the credential is for
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Credential resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v2.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         consumption_report_interval:
-          $ref: '#/components/schemas/integer'
+          description: DEPRECATED
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         default_channel_creator_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The channel role assigned to a channel creator when they join
+            a new channel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_channel_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The channel role assigned to users when they are added to a
+            channel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_service_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The service role assigned to users when they are added to the
+            service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         limits:
-          $ref: '#/components/schemas/object'
+          description: An object that describes the limits of the service instance
+          nullable: true
+          type: object
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The absolute URLs of the Service's Channels, Roles, and Users
+          nullable: true
+          type: object
         media:
-          $ref: '#/components/schemas/object'
+          description: The properties of the media that the service supports
+          nullable: true
+          type: object
         notifications:
-          $ref: '#/components/schemas/object'
+          description: The notification configuration for the Service instance
+          nullable: true
+          type: object
         post_webhook_retry_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of times calls to the `post_webhook_url` will be
+            retried
+          nullable: true
+          type: integer
         post_webhook_url:
-          $ref: '#/components/schemas/string'
+          description: The URL for post-event webhooks
+          nullable: true
+          type: string
         pre_webhook_retry_count:
-          $ref: '#/components/schemas/integer'
+          description: Count of times webhook will be retried in case of timeout or
+            429/503/504 HTTP responses
+          nullable: true
+          type: integer
         pre_webhook_url:
-          $ref: '#/components/schemas/string'
+          description: The webhook URL for pre-event webhooks
+          nullable: true
+          type: string
         reachability_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Reachability Indicator feature is enabled for this
+            Service instance
+          nullable: true
+          type: boolean
         read_status_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Message Consumption Horizon feature is enabled
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         typing_indicator_timeout:
-          $ref: '#/components/schemas/integer'
+          description: How long in seconds to wait before assuming the user is no
+            longer typing
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Service resource
+          format: uri
+          nullable: true
+          type: string
         webhook_filters:
-          $ref: '#/components/schemas/string_list'
+          description: The list of webhook events that are enabled for this Service
+            instance
+          items:
+            type: string
+          nullable: true
+          type: array
         webhook_method:
-          $ref: '#/components/schemas/string'
+          description: The HTTP method  to use for both PRE and POST webhooks
+          nullable: true
+          type: string
       type: object
     chat.v2.service.binding:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         binding_type:
-          $ref: '#/components/schemas/binding_binding_type'
+          description: The push technology to use for the binding
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Credential for the binding
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         endpoint:
-          $ref: '#/components/schemas/string'
+          description: The unique endpoint identifier for the Binding
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The absolute URLs of the Binding's User
+          nullable: true
+          type: object
         message_types:
-          $ref: '#/components/schemas/string_list'
+          description: The Programmable Chat message types the binding is subscribed
+            to
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the Binding resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Binding resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v2.service.channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string that stores application-specific data
+          nullable: true
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the User that created the channel
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URLs to access the Members, Messages , Invites and,
+            if it exists, the last Message for the Channel
+          nullable: true
+          type: object
         members_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of Members in the Channel
+          nullable: true
+          type: integer
         messages_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of Messages that have been passed in the Channel
+          nullable: true
+          type: integer
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/channel_channel_type'
+          description: 'The visibility of the channel. Can be: `public` or `private`'
+          enum:
+          - public
+          - private
+          nullable: true
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Channel resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v2.service.channel.channel_webhook:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel the Channel Webhook resource belongs
+            to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         configuration:
-          $ref: '#/components/schemas/object'
+          description: The JSON string that describes the configuration object for
+            the channel webhook
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the Channel Webhook resource is
+            associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WH'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WH[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: The type of webhook
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Channel Webhook resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v2.service.channel.invite:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel the new resource belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the User that created the invite
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of the Role assigned to the member
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Invite resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v2.service.channel.member:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string that stores application-specific data
+          nullable: true
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel for the member
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         last_consumed_message_index:
-          $ref: '#/components/schemas/integer'
+          description: The index of the last Message that the Member has read within
+            the Channel
+          nullable: true
+          type: integer
         last_consumption_timestamp:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 based timestamp string that represents the datetime
+            of the last Message read event for the Member within the Channel
+          format: date-time
+          nullable: true
+          type: string
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of the Role assigned to the member
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Member resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v2.service.channel.message:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string that stores application-specific data
+          nullable: true
+          type: string
         body:
-          $ref: '#/components/schemas/string'
+          description: The content of the message
+          nullable: true
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel the Message resource belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         from:
-          $ref: '#/components/schemas/string'
+          description: The Identity of the message's author
+          nullable: true
+          type: string
         index:
-          $ref: '#/components/schemas/integer'
+          description: The index of the message within the Channel
+          nullable: true
+          type: integer
         last_updated_by:
-          $ref: '#/components/schemas/string'
+          description: The Identity of the User who last updated the Message
+          nullable: true
+          type: string
         media:
-          $ref: '#/components/schemas/object'
+          description: A Media object that describes the Message's media if attached;
+            otherwise, null
+          nullable: true
+          type: object
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IM'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IM[0-9a-fA-F]{32}$
+          type: string
         to:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel that the message was sent to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: The Message type
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Message resource
+          format: uri
+          nullable: true
+          type: string
         was_edited:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the message has been edited since  it was created
+          nullable: true
+          type: boolean
       type: object
     chat.v2.service.role:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         permissions:
-          $ref: '#/components/schemas/string_list'
+          description: An array of the permissions the role has been granted
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/role_role_type'
+          description: The type of role
+          enum:
+          - channel
+          - deployment
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Role resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v2.service.user:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string that stores application-specific data
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         is_notifiable:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the User has a potentially valid Push Notification
+            registration for the Service instance
+          nullable: true
+          type: boolean
         is_online:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the User is actively connected to the Service instance
+            and online
+          nullable: true
+          type: boolean
         joined_channels_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of Channels the User is a Member of
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The absolute URLs of the Channel and Binding resources related
+            to the user
+          nullable: true
+          type: object
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of the Role assigned to the user
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_US'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the User resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     chat.v2.service.user.user_binding:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         binding_type:
-          $ref: '#/components/schemas/user_binding_binding_type'
+          description: The push technology to use for the binding
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Credential for the binding
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         endpoint:
-          $ref: '#/components/schemas/string'
+          description: The unique endpoint identifier for the User Binding
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         message_types:
-          $ref: '#/components/schemas/string_list'
+          description: The Programmable Chat message types the binding is subscribed
+            to
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the User Binding resource
+          format: uri
+          nullable: true
+          type: string
         user_sid:
-          $ref: '#/components/schemas/sid_US'
+          description: The SID of the User with the binding
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
       type: object
     chat.v2.service.user.user_channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The SID of the Channel the resource belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         last_consumed_message_index:
-          $ref: '#/components/schemas/integer'
+          description: The index of the last Message in the Channel the Member has
+            read
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URLs to access the Members, Messages , Invites and,
+            if it exists, the last Message for the Channel
+          nullable: true
+          type: object
         member_sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: The SID of the User as a Member in the Channel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         notification_level:
-          $ref: '#/components/schemas/user_channel_notification_level'
+          description: The push notification level of the User for the Channel
+          enum:
+          - default
+          - muted
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/user_channel_channel_status'
+          description: The status of the User on the Channel
+          enum:
+          - joined
+          - invited
+          - not_participating
+          nullable: true
+          type: string
         unread_messages_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of unread Messages in the Channel for the User
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         user_sid:
-          $ref: '#/components/schemas/sid_US'
+          description: The SID of the User the User Channel belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
       type: object
-    credential_push_service:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    role_role_type:
-      enum:
-      - channel
-      - deployment
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_BS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BS[0-9a-fA-F]{32}$
-      type: string
-    sid_CH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CH[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    sid_IM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IM[0-9a-fA-F]{32}$
-      type: string
-    sid_IN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IN[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_MB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MB[0-9a-fA-F]{32}$
-      type: string
-    sid_RL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RL[0-9a-fA-F]{32}$
-      type: string
-    sid_US:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^US[0-9a-fA-F]{32}$
-      type: string
-    sid_WH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WH[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
-    user_binding_binding_type:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    user_channel_channel_status:
-      enum:
-      - joined
-      - invited
-      - not_participating
-      nullable: true
-      type: string
-    user_channel_notification_level:
-      enum:
-      - default
-      - muted
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_conversations_v1.yaml
+++ b/spec/yaml/twilio_conversations_v1.yaml
@@ -1,681 +1,1334 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    configuration_webhook_method:
-      enum:
-      - GET
-      - POST
-      nullable: true
-      type: string
-    configuration_webhook_target:
-      enum:
-      - webhook
-      - flex
-      nullable: true
-      type: string
-    conversation_message_receipt_delivery_status:
-      enum:
-      - read
-      - failed
-      - delivered
-      - undelivered
-      - sent
-      nullable: true
-      type: string
-    conversation_state:
-      enum:
-      - inactive
-      - active
-      - closed
-      nullable: true
-      type: string
     conversations.v1.configuration:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account responsible for this configuration.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         default_chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the default Conversation Service that every new
+            conversation is associated with.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         default_closed_timer:
-          $ref: '#/components/schemas/string'
+          description: Default ISO8601 duration when conversation will be switched
+            to `closed` state.
+          nullable: true
+          type: string
         default_inactive_timer:
-          $ref: '#/components/schemas/string'
+          description: Default ISO8601 duration when conversation will be switched
+            to `inactive` state.
+          nullable: true
+          type: string
         default_messaging_service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The SID of the default Messaging Service that every new conversation
+            is associated with.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URLs to access the webhook and default service configurations.
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this global configuration.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.configuration.configuration_webhook:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this conversation.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         filters:
-          $ref: '#/components/schemas/string_list'
+          description: The list of webhook event triggers that are enabled for this
+            Service.
+          items:
+            type: string
+          nullable: true
+          type: array
         method:
-          $ref: '#/components/schemas/configuration_webhook_method'
+          description: The HTTP method to be used when sending a webhook request.
+          enum:
+          - GET
+          - POST
+          nullable: true
+          type: string
         post_webhook_url:
-          $ref: '#/components/schemas/string'
+          description: The absolute url the post-event webhook request should be sent
+            to.
+          nullable: true
+          type: string
         pre_webhook_url:
-          $ref: '#/components/schemas/string'
+          description: The absolute url the pre-event webhook request should be sent
+            to.
+          nullable: true
+          type: string
         target:
-          $ref: '#/components/schemas/configuration_webhook_target'
+          description: The routing target of the webhook.
+          enum:
+          - webhook
+          - flex
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this webhook.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.conversation:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this conversation.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: An optional string metadata field you can use to store any
+            data you wish.
+          nullable: true
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The unique ID of the Conversation Service this conversation
+            belongs to.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The human-readable name of this conversation.
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URLs to access the participants, messages and webhooks
+            of this conversation.
+          nullable: true
+          type: object
         messaging_service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The unique ID of the Messaging Service this conversation belongs
+            to.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         state:
-          $ref: '#/components/schemas/conversation_state'
+          description: Current state of this conversation.
+          enum:
+          - inactive
+          - active
+          - closed
+          nullable: true
+          type: string
         timers:
-          $ref: '#/components/schemas/object'
+          description: Timer date values for this conversation.
+          nullable: true
+          type: object
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this conversation.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.conversation.conversation_message:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this message.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: A string metadata field you can use to store any data you wish.
+          nullable: true
+          type: string
         author:
-          $ref: '#/components/schemas/string'
+          description: The channel specific identifier of the message's author.
+          nullable: true
+          type: string
         body:
-          $ref: '#/components/schemas/string'
+          description: The content of the message.
+          nullable: true
+          type: string
         conversation_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Conversation for this message.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         delivery:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the summary of delivery statuses for
+            the message to non-chat participants.
+          nullable: true
+          type: object
         index:
-          $ref: '#/components/schemas/integer'
+          description: The index of the message within the Conversation.
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URL to access the receipts of this message.
+          nullable: true
+          type: object
         media:
-          $ref: '#/components/schemas/object_list'
+          description: An array of objects that describe the Message's media if attached,
+            otherwise, null.
+          items:
+            type: object
+          nullable: true
+          type: array
         participant_sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: The unique ID of messages's author participant.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IM'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IM[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute API URL for this message.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.conversation.conversation_message.conversation_message_receipt:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this participant.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_message_sid:
-          $ref: '#/components/schemas/sid'
+          description: A messaging channel-specific identifier for the message delivered
+            to participant
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         conversation_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Conversation for this message.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/integer'
+          description: The message [delivery error code](https://www.twilio.com/docs/sms/api/message-resource#delivery-related-errors)
+            for a `failed` status
+          nullable: true
+          type: integer
         message_sid:
-          $ref: '#/components/schemas/sid_IM'
+          description: The SID of the message the delivery receipt belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IM[0-9a-fA-F]{32}$
+          type: string
         participant_sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: The unique ID of the participant the delivery receipt belongs
+            to.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_DY'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DY[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/conversation_message_receipt_delivery_status'
+          description: The message delivery status
+          enum:
+          - read
+          - failed
+          - delivered
+          - undelivered
+          - sent
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this delivery receipt.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.conversation.conversation_participant:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this participant.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: An optional string metadata field you can use to store any
+            data you wish.
+          nullable: true
+          type: string
         conversation_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Conversation for this participant.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: A unique string identifier for the conversation participant
+            as Conversation User.
+          nullable: true
+          type: string
         last_read_message_index:
-          $ref: '#/components/schemas/integer'
+          description: "Index of last \u201Cread\u201D message in the Conversation\
+            \ for the Participant."
+          nullable: true
+          type: integer
         last_read_timestamp:
-          $ref: '#/components/schemas/string'
+          description: "Timestamp of last \u201Cread\u201D message in the Conversation\
+            \ for the Participant."
+          nullable: true
+          type: string
         messaging_binding:
-          $ref: '#/components/schemas/object'
+          description: Information about how this participant exchanges messages with
+            the conversation.
+          nullable: true
+          type: object
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of a conversation-level Role to assign to the participant
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this participant.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.conversation.conversation_scoped_webhook:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this conversation.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         configuration:
-          $ref: '#/components/schemas/object'
+          description: The configuration of this webhook.
+          nullable: true
+          type: object
         conversation_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Conversation for this webhook.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WH'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WH[0-9a-fA-F]{32}$
+          type: string
         target:
-          $ref: '#/components/schemas/string'
+          description: The target of this webhook.
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this webhook.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.credential:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this credential.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The human-readable name of this credential.
+          nullable: true
+          type: string
         sandbox:
-          $ref: '#/components/schemas/string'
+          description: '[APN only] Whether to send the credential to sandbox APNs.'
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/credential_push_type'
+          description: The type of push-notification service the credential is for.
+          enum:
+          - apn
+          - gcm
+          - fcm
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this credential.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.role:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         permissions:
-          $ref: '#/components/schemas/string_list'
+          description: An array of the permissions the role has been granted
+          items:
+            type: string
+          nullable: true
+          type: array
         sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/role_role_type'
+          description: The type of role
+          enum:
+          - conversation
+          - service
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this user role.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this service.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The human-readable name of this service.
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URLs to access the conversations, users, roles, bindings
+            and configuration of this service.
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this service.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_binding:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this binding.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         binding_type:
-          $ref: '#/components/schemas/service_binding_binding_type'
+          description: The push technology to use for the binding.
+          enum:
+          - apn
+          - gcm
+          - fcm
+          nullable: true
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Credential for the binding.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         endpoint:
-          $ref: '#/components/schemas/string'
+          description: The unique endpoint identifier for the Binding.
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The identity of Conversation User associated with this binding.
+          nullable: true
+          type: string
         message_types:
-          $ref: '#/components/schemas/string_list'
+          description: The Conversation message types the binding is subscribed to.
+          items:
+            type: string
+          nullable: true
+          type: array
         sid:
-          $ref: '#/components/schemas/sid_BS'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this binding.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_configuration:
       properties:
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         default_chat_service_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The service role assigned to users when they are added to the
+            service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_conversation_creator_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The role assigned to a conversation creator user when they
+            join a new conversation
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_conversation_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The role assigned to users when they are added to a conversation
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URL to access the push notifications configuration
+            of this service.
+          nullable: true
+          type: object
         reachability_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Reachability Indicator feature is enabled for this
+            Conversations Service
+          nullable: true
+          type: boolean
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this service configuration.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_configuration.service_notification:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this configuration.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         added_to_conversation:
-          $ref: '#/components/schemas/object'
+          description: The Push Notification configuration for being added to a Conversation.
+          nullable: true
+          type: object
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the Configuration
+            applies to.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         log_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Weather the notification logging is enabled.
+          nullable: true
+          type: boolean
         new_message:
-          $ref: '#/components/schemas/object'
+          description: The Push Notification configuration for New Messages.
+          nullable: true
+          type: object
         removed_from_conversation:
-          $ref: '#/components/schemas/object'
+          description: The Push Notification configuration for being removed from
+            a Conversation.
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this configuration.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_conversation:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this conversation.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: An optional string metadata field you can use to store any
+            data you wish.
+          nullable: true
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The unique ID of the Conversation Service this conversation
+            belongs to.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The human-readable name of this conversation.
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URLs to access the participants, messages and webhooks
+            of this conversation.
+          nullable: true
+          type: object
         messaging_service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The unique ID of the Messaging Service this conversation belongs
+            to.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         state:
-          $ref: '#/components/schemas/service_conversation_state'
+          description: Current state of this conversation.
+          enum:
+          - inactive
+          - active
+          - closed
+          nullable: true
+          type: string
         timers:
-          $ref: '#/components/schemas/object'
+          description: Timer date values for this conversation.
+          nullable: true
+          type: object
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this conversation.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_conversation.service_conversation_message:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this message.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: A string metadata field you can use to store any data you wish.
+          nullable: true
+          type: string
         author:
-          $ref: '#/components/schemas/string'
+          description: The channel specific identifier of the message's author.
+          nullable: true
+          type: string
         body:
-          $ref: '#/components/schemas/string'
+          description: The content of the message.
+          nullable: true
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         conversation_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Conversation for this message.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         delivery:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the summary of delivery statuses for
+            the message to non-chat participants.
+          nullable: true
+          type: object
         index:
-          $ref: '#/components/schemas/integer'
+          description: The index of the message within the Conversation.
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Absolute URL to access the receipts of this message.
+          nullable: true
+          type: object
         media:
-          $ref: '#/components/schemas/object_list'
+          description: An array of objects that describe the Message's media if attached,
+            otherwise, null.
+          items:
+            type: object
+          nullable: true
+          type: array
         participant_sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: The unique ID of messages's author participant.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IM'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IM[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this message.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_conversation.service_conversation_message.service_conversation_message_receipt:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this participant.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_message_sid:
-          $ref: '#/components/schemas/sid'
+          description: A messaging channel-specific identifier for the message delivered
+            to participant
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         conversation_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Conversation for this message.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/integer'
+          description: The message [delivery error code](https://www.twilio.com/docs/sms/api/message-resource#delivery-related-errors)
+            for a `failed` status
+          nullable: true
+          type: integer
         message_sid:
-          $ref: '#/components/schemas/sid_IM'
+          description: The SID of the message the delivery receipt belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IM[0-9a-fA-F]{32}$
+          type: string
         participant_sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: The unique ID of the participant the delivery receipt belongs
+            to.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_DY'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DY[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/service_conversation_message_receipt_delivery_status'
+          description: The message delivery status
+          enum:
+          - read
+          - failed
+          - delivered
+          - undelivered
+          - sent
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this delivery receipt.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_conversation.service_conversation_participant:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this participant.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: An optional string metadata field you can use to store any
+            data you wish.
+          nullable: true
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         conversation_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Conversation for this participant.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: A unique string identifier for the conversation participant
+            as Conversation User.
+          nullable: true
+          type: string
         last_read_message_index:
-          $ref: '#/components/schemas/integer'
+          description: "Index of last \u201Cread\u201D message in the Conversation\
+            \ for the Participant."
+          nullable: true
+          type: integer
         last_read_timestamp:
-          $ref: '#/components/schemas/string'
+          description: "Timestamp of last \u201Cread\u201D message in the Conversation\
+            \ for the Participant."
+          nullable: true
+          type: string
         messaging_binding:
-          $ref: '#/components/schemas/object'
+          description: Information about how this participant exchanges messages with
+            the conversation.
+          nullable: true
+          type: object
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of a conversation-level Role to assign to the participant
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MB'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this participant.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_conversation.service_conversation_scoped_webhook:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The unique ID of the Account responsible for this conversation.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         configuration:
-          $ref: '#/components/schemas/object'
+          description: The configuration of this webhook.
+          nullable: true
+          type: object
         conversation_sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique ID of the Conversation for this webhook.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that this resource was last updated.
+          format: date-time
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WH'
+          description: A 34 character string that uniquely identifies this resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WH[0-9a-fA-F]{32}$
+          type: string
         target:
-          $ref: '#/components/schemas/string'
+          description: The target of this webhook.
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this webhook.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_role:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         permissions:
-          $ref: '#/components/schemas/string_list'
+          description: An array of the permissions the role has been granted
+          items:
+            type: string
+          nullable: true
+          type: array
         sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/service_role_role_type'
+          description: The type of role
+          enum:
+          - conversation
+          - service
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this user role.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.service.service_user:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON Object string that stores application-specific data
+          nullable: true
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         is_notifiable:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the User has a potentially valid Push Notification
+            registration for this Conversations Service
+          nullable: true
+          type: boolean
         is_online:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the User is actively connected to this Conversations
+            Service and online
+          nullable: true
+          type: boolean
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of a service-level Role assigned to the user
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_US'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this user.
+          format: uri
+          nullable: true
+          type: string
       type: object
     conversations.v1.user:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON Object string that stores application-specific data
+          nullable: true
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Conversation Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         is_notifiable:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the User has a potentially valid Push Notification
+            registration for this Conversations Service
+          nullable: true
+          type: boolean
         is_online:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the User is actively connected to this Conversations
+            Service and online
+          nullable: true
+          type: boolean
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          description: The SID of a service-level Role assigned to the user
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_US'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: An absolute URL for this user.
+          format: uri
+          nullable: true
+          type: string
       type: object
-    credential_push_type:
-      enum:
-      - apn
-      - gcm
-      - fcm
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    role_role_type:
-      enum:
-      - conversation
-      - service
-      nullable: true
-      type: string
-    service_binding_binding_type:
-      enum:
-      - apn
-      - gcm
-      - fcm
-      nullable: true
-      type: string
-    service_conversation_message_receipt_delivery_status:
-      enum:
-      - read
-      - failed
-      - delivered
-      - undelivered
-      - sent
-      nullable: true
-      type: string
-    service_conversation_state:
-      enum:
-      - inactive
-      - active
-      - closed
-      nullable: true
-      type: string
-    service_role_role_type:
-      enum:
-      - conversation
-      - service
-      nullable: true
-      type: string
-    sid:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_BS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BS[0-9a-fA-F]{32}$
-      type: string
-    sid_CH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CH[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    sid_DY:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^DY[0-9a-fA-F]{32}$
-      type: string
-    sid_IM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IM[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_MB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MB[0-9a-fA-F]{32}$
-      type: string
-    sid_MG:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MG[0-9a-fA-F]{32}$
-      type: string
-    sid_RL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RL[0-9a-fA-F]{32}$
-      type: string
-    sid_US:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^US[0-9a-fA-F]{32}$
-      type: string
-    sid_WH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WH[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_events_v1.yaml
+++ b/spec/yaml/twilio_events_v1.yaml
@@ -1,163 +1,232 @@
 components:
   schemas:
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
     events.v1.event_type:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Event Type was created.
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Event Type was updated.
+          format: date-time
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: Event Type description.
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         schema_id:
-          $ref: '#/components/schemas/string'
+          description: The Schema identifier for this Event Type.
+          nullable: true
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: The Event Type identifier.
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     events.v1.schema:
       properties:
         id:
-          $ref: '#/components/schemas/string'
+          description: Schema Identifier.
+          nullable: true
+          type: string
         last_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that the last schema version was created.
+          format: date-time
+          nullable: true
+          type: string
         last_version:
-          $ref: '#/components/schemas/integer'
+          description: Last schema version.
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs.
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     events.v1.schema.version:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date the schema version was created.
+          format: date-time
+          nullable: true
+          type: string
         id:
-          $ref: '#/components/schemas/string'
+          description: The unique identifier of the schema.
+          nullable: true
+          type: string
         raw:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         schema_version:
-          $ref: '#/components/schemas/integer'
+          description: The version of this schema.
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     events.v1.sink:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Sink was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Sink was updated
+          format: date-time
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: Sink Description
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs.
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_DG'
+          description: A string that uniquely identifies this Sink.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DG[0-9a-fA-F]{32}$
+          type: string
         sink_configuration:
-          $ref: '#/components/schemas/object'
+          description: JSON Sink configuration.
+          nullable: true
+          type: object
         sink_type:
-          $ref: '#/components/schemas/sink_sink_type'
+          description: Sink type.
+          enum:
+          - kinesis
+          - webhook
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/sink_status'
+          description: The Status of this Sink
+          enum:
+          - initialized
+          - validating
+          - active
+          - failed
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     events.v1.sink.sink_test:
       properties:
         result:
-          $ref: '#/components/schemas/string'
+          description: Feedback indicating whether the test event was generated.
+          nullable: true
+          type: string
       type: object
     events.v1.sink.sink_validate:
       properties:
         result:
-          $ref: '#/components/schemas/string'
+          description: Feedback indicating whether the given Sink was validated.
+          nullable: true
+          type: string
       type: object
     events.v1.subscription:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: Account SID.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Subscription was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Subscription was updated
+          format: date-time
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: Subscription description
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs.
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_DF'
+          description: A string that uniquely identifies this Subscription.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DF[0-9a-fA-F]{32}$
+          type: string
         sink_sid:
-          $ref: '#/components/schemas/sid_DG'
+          description: Sink SID.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DG[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     events.v1.subscription.subscribed_event:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: Account SID.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         subscription_sid:
-          $ref: '#/components/schemas/sid_DF'
+          description: Subscription SID.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DF[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: Type of event being subscribed to.
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
         version:
-          $ref: '#/components/schemas/integer'
+          description: The schema version that the subscription should use.
+          nullable: true
+          type: integer
       type: object
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_DF:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^DF[0-9a-fA-F]{32}$
-      type: string
-    sid_DG:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^DG[0-9a-fA-F]{32}$
-      type: string
-    sink_sink_type:
-      enum:
-      - kinesis
-      - webhook
-      nullable: true
-      type: string
-    sink_status:
-      enum:
-      - initialized
-      - validating
-      - active
-      - failed
-      nullable: true
-      type: string
-    string:
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_fax_v1.yaml
+++ b/spec/yaml/twilio_fax_v1.yaml
@@ -1,129 +1,157 @@
 components:
   schemas:
-    currency:
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    decimal:
-      nullable: true
-      type: number
     fax.v1.fax:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to transmit the fax
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 formatted date and time in GMT when the resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 formatted date and time in GMT when the resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         direction:
-          $ref: '#/components/schemas/fax_direction'
+          description: The direction of the fax
+          enum:
+          - inbound
+          - outbound
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/integer'
+          description: The time it took to transmit the fax
+          nullable: true
+          type: integer
         from:
-          $ref: '#/components/schemas/string'
+          description: The number the fax was sent from
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the fax's related resources
+          nullable: true
+          type: object
         media_sid:
-          $ref: '#/components/schemas/sid_ME'
+          description: The SID of the FaxMedia resource that is associated with the
+            Fax
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ME[0-9a-fA-F]{32}$
+          type: string
         media_url:
-          $ref: '#/components/schemas/string'
+          description: The Twilio-hosted URL that can be used to download fax media
+          nullable: true
+          type: string
         num_pages:
-          $ref: '#/components/schemas/integer'
+          description: The number of pages contained in the fax document
+          nullable: true
+          type: integer
         price:
-          $ref: '#/components/schemas/decimal'
+          description: The fax transmission price
+          nullable: true
+          type: number
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The ISO 4217 currency used for billing
+          nullable: true
+          type: string
         quality:
-          $ref: '#/components/schemas/fax_quality'
+          description: The quality of the fax
+          enum:
+          - standard
+          - fine
+          - superfine
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_FX'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FX[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/fax_status'
+          description: The status of the fax
+          enum:
+          - queued
+          - processing
+          - sending
+          - delivered
+          - receiving
+          - received
+          - no-answer
+          - busy
+          - failed
+          - canceled
+          nullable: true
+          type: string
         to:
-          $ref: '#/components/schemas/string'
+          description: The phone number that received the fax
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the fax resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     fax.v1.fax.fax_media:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         content_type:
-          $ref: '#/components/schemas/string'
+          description: The content type of the stored fax media
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         fax_sid:
-          $ref: '#/components/schemas/sid_FX'
+          description: The SID of the fax the FaxMedia resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FX[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ME'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ME[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the FaxMedia resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    fax_direction:
-      enum:
-      - inbound
-      - outbound
-      nullable: true
-      type: string
-    fax_quality:
-      enum:
-      - standard
-      - fine
-      - superfine
-      nullable: true
-      type: string
-    fax_status:
-      enum:
-      - queued
-      - processing
-      - sending
-      - delivered
-      - receiving
-      - received
-      - no-answer
-      - busy
-      - failed
-      - canceled
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_FX:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FX[0-9a-fA-F]{32}$
-      type: string
-    sid_ME:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ME[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_flex_v1.yaml
+++ b/spec/yaml/twilio_flex_v1.yaml
@@ -1,271 +1,395 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    configuration_status:
-      enum:
-      - ok
-      - inprogress
-      - notstarted
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
     flex.v1.channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource and owns this
+            Workflow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Flex chat channel
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Flex chat channel
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         flex_flow_sid:
-          $ref: '#/components/schemas/sid_FO'
+          description: The SID of the Flex Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FO[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         task_sid:
-          $ref: '#/components/schemas/sid_WT'
+          description: The SID of the TaskRouter Task
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WT[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Flex chat channel resource
+          format: uri
+          nullable: true
+          type: string
         user_sid:
-          $ref: '#/components/schemas/sid_US'
+          description: The SID of the chat user
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
       type: object
     flex.v1.configuration:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/object'
+          description: An object that contains application-specific data
+          nullable: true
+          type: object
         call_recording_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether call recording is enabled
+          nullable: true
+          type: boolean
         call_recording_webhook_url:
-          $ref: '#/components/schemas/url'
+          description: The call recording webhook URL
+          format: uri
+          nullable: true
+          type: string
         chat_service_instance_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the chat service this user belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         crm_attributes:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the CRM attributes
+          nullable: true
+          type: object
         crm_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The CRM Callback URL
+          format: uri
+          nullable: true
+          type: string
         crm_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether CRM is present for Flex
+          nullable: true
+          type: boolean
         crm_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The CRM Fallback URL
+          format: uri
+          nullable: true
+          type: string
         crm_type:
-          $ref: '#/components/schemas/string'
+          description: The CRM Type
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Configuration resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Configuration resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         flex_service_instance_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Flex service instance
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         integrations:
-          $ref: '#/components/schemas/object_list'
+          description: A list of objects that contain the configurations for the Integrations
+            supported in this configuration
+          items:
+            type: object
+          nullable: true
+          type: array
         markdown:
-          $ref: '#/components/schemas/object'
+          description: Configurable parameters for Markdown
+          nullable: true
+          type: object
         messaging_service_instance_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The SID of the Messaging service instance
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         notifications:
-          $ref: '#/components/schemas/object'
+          description: Configurable parameters for Notifications
+          nullable: true
+          type: object
         outbound_call_flows:
-          $ref: '#/components/schemas/object'
+          description: The list of outbound call flows
+          nullable: true
+          type: object
         plugin_service_attributes:
-          $ref: '#/components/schemas/object'
+          description: The plugin service attributes
+          nullable: true
+          type: object
         plugin_service_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the plugin service enabled
+          nullable: true
+          type: boolean
         public_attributes:
-          $ref: '#/components/schemas/object'
+          description: The list of public attributes
+          nullable: true
+          type: object
         queue_stats_configuration:
-          $ref: '#/components/schemas/object'
+          description: Configurable parameters for Queues Statistics
+          nullable: true
+          type: object
         runtime_domain:
-          $ref: '#/components/schemas/url'
+          description: The URL where the Flex instance is hosted
+          format: uri
+          nullable: true
+          type: string
         serverless_service_sids:
-          $ref: '#/components/schemas/sid_ZS_list'
+          description: The list of serverless service SIDs
+          items:
+            maxLength: 34
+            minLength: 34
+            pattern: ^ZS[0-9a-fA-F]{32}$
+            type: string
+          nullable: true
+          type: array
         service_version:
-          $ref: '#/components/schemas/string'
+          description: The Flex Service version
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/configuration_status'
+          description: The status of the Flex onboarding
+          enum:
+          - ok
+          - inprogress
+          - notstarted
+          nullable: true
+          type: string
         taskrouter_offline_activity_sid:
-          $ref: '#/components/schemas/sid_WA'
+          description: The TaskRouter SID of the offline activity
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WA[0-9a-fA-F]{32}$
+          type: string
         taskrouter_skills:
-          $ref: '#/components/schemas/object_list'
+          description: The Skill description for TaskRouter workers
+          items:
+            type: object
+          nullable: true
+          type: array
         taskrouter_target_taskqueue_sid:
-          $ref: '#/components/schemas/sid_WQ'
+          description: The SID of the TaskRouter Target TaskQueue
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WQ[0-9a-fA-F]{32}$
+          type: string
         taskrouter_target_workflow_sid:
-          $ref: '#/components/schemas/sid_WW'
+          description: The SID of the TaskRouter target Workflow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WW[0-9a-fA-F]{32}$
+          type: string
         taskrouter_taskqueues:
-          $ref: '#/components/schemas/object_list'
+          description: The list of TaskRouter TaskQueues
+          items:
+            type: object
+          nullable: true
+          type: array
         taskrouter_worker_attributes:
-          $ref: '#/components/schemas/object'
+          description: The TaskRouter Worker attributes
+          nullable: true
+          type: object
         taskrouter_worker_channels:
-          $ref: '#/components/schemas/object'
+          description: The TaskRouter default channel capacities and availability
+            for workers
+          nullable: true
+          type: object
         taskrouter_workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the TaskRouter Workspace
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
         ui_attributes:
-          $ref: '#/components/schemas/object'
+          description: The object that describes Flex UI characteristics and settings
+          nullable: true
+          type: object
         ui_dependencies:
-          $ref: '#/components/schemas/object'
+          description: The object that defines the NPM packages and versions to be
+            used in Hosted Flex
+          nullable: true
+          type: object
         ui_language:
-          $ref: '#/components/schemas/string'
+          description: The primary language of the Flex UI
+          nullable: true
+          type: string
         ui_version:
-          $ref: '#/components/schemas/string'
+          description: The Pinned UI version
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Configuration resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     flex.v1.flex_flow:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_type:
-          $ref: '#/components/schemas/flex_flow_channel_type'
+          description: The channel type
+          enum:
+          - web
+          - sms
+          - facebook
+          - whatsapp
+          - line
+          - custom
+          nullable: true
+          type: string
         chat_service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the chat service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         contact_identity:
-          $ref: '#/components/schemas/string'
+          description: The channel contact's Identity
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Flex Flow is enabled
+          nullable: true
+          type: boolean
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         integration:
-          $ref: '#/components/schemas/object'
+          description: An object that contains specific parameters for the integration
+          nullable: true
+          type: object
         integration_type:
-          $ref: '#/components/schemas/flex_flow_integration_type'
+          description: The integration type
+          enum:
+          - studio
+          - external
+          - task
+          nullable: true
+          type: string
         janitor_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Remove active Proxy sessions if the corresponding Task is deleted.
+          nullable: true
+          type: boolean
         long_lived:
-          $ref: '#/components/schemas/boolean'
+          description: Re-use this chat channel for future interactions with a contact
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_FO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FO[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Flex Flow resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     flex.v1.web_channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource and owns this
+            Workflow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         flex_flow_sid:
-          $ref: '#/components/schemas/sid_FO'
+          description: The SID of the Flex Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FO[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CH'
+          description: The unique string that identifies the WebChannel resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the WebChannel resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    flex_flow_channel_type:
-      enum:
-      - web
-      - sms
-      - facebook
-      - whatsapp
-      - line
-      - custom
-      nullable: true
-      type: string
-    flex_flow_integration_type:
-      enum:
-      - studio
-      - external
-      - task
-      nullable: true
-      type: string
-    object:
-      nullable: true
-      type: object
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_CH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CH[0-9a-fA-F]{32}$
-      type: string
-    sid_FO:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FO[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_MG:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MG[0-9a-fA-F]{32}$
-      type: string
-    sid_US:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^US[0-9a-fA-F]{32}$
-      type: string
-    sid_WA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WA[0-9a-fA-F]{32}$
-      type: string
-    sid_WQ:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WQ[0-9a-fA-F]{32}$
-      type: string
-    sid_WS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WS[0-9a-fA-F]{32}$
-      type: string
-    sid_WT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WT[0-9a-fA-F]{32}$
-      type: string
-    sid_WW:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WW[0-9a-fA-F]{32}$
-      type: string
-    sid_ZS_list:
-      items:
-        maxLength: 34
-        minLength: 34
-        pattern: ^ZS[0-9a-fA-F]{32}$
-        type: string
-      nullable: true
-      type: array
-    string:
-      nullable: true
-      type: string
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_insights_v1.yaml
+++ b/spec/yaml/twilio_insights_v1.yaml
@@ -1,434 +1,456 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    event_level:
-      enum:
-      - UNKNOWN
-      - DEBUG
-      - INFO
-      - WARNING
-      - ERROR
-      nullable: true
-      type: string
-    event_twilio_edge:
-      enum:
-      - unknown_edge
-      - carrier_edge
-      - sip_edge
-      - sdk_edge
-      - client_edge
-      nullable: true
-      type: string
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
     insights.v1.call:
       properties:
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_CA'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     insights.v1.call.event:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         carrier_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         client_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         edge:
-          $ref: '#/components/schemas/event_twilio_edge'
+          enum:
+          - unknown_edge
+          - carrier_edge
+          - sip_edge
+          - sdk_edge
+          - client_edge
+          nullable: true
+          type: string
         group:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         level:
-          $ref: '#/components/schemas/event_level'
+          enum:
+          - UNKNOWN
+          - DEBUG
+          - INFO
+          - WARNING
+          - ERROR
+          nullable: true
+          type: string
         name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         sdk_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         sip_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         timestamp:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
       type: object
     insights.v1.call.metric:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         carrier_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         client_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         direction:
-          $ref: '#/components/schemas/metric_stream_direction'
+          enum:
+          - unknown
+          - inbound
+          - outbound
+          - both
+          nullable: true
+          type: string
         edge:
-          $ref: '#/components/schemas/metric_twilio_edge'
+          enum:
+          - unknown_edge
+          - carrier_edge
+          - sip_edge
+          - sdk_edge
+          - client_edge
+          nullable: true
+          type: string
         sdk_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         sip_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         timestamp:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
       type: object
     insights.v1.call.summary:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         call_sid:
-          $ref: '#/components/schemas/sid_CA'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CA[0-9a-fA-F]{32}$
+          type: string
         call_state:
-          $ref: '#/components/schemas/summary_call_state'
+          enum:
+          - ringing
+          - completed
+          - busy
+          - fail
+          - noanswer
+          - canceled
+          - answered
+          - undialed
+          nullable: true
+          type: string
         call_type:
-          $ref: '#/components/schemas/summary_call_type'
+          enum:
+          - carrier
+          - sip
+          - trunking
+          - client
+          nullable: true
+          type: string
         carrier_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         client_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         connect_duration:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         created_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         end_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         from:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         processing_state:
-          $ref: '#/components/schemas/summary_processing_state'
+          enum:
+          - complete
+          - partial
+          nullable: true
+          type: string
         properties:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         sdk_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         sip_edge:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         start_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         tags:
-          $ref: '#/components/schemas/string_list'
+          items:
+            type: string
+          nullable: true
+          type: array
         to:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         trust:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     insights.v1.video_room_summary:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         codecs:
-          $ref: '#/components/schemas/video_room_summary_codec_list'
+          items:
+            enum:
+            - VP8
+            - H264
+            - VP9
+            type: string
+          nullable: true
+          type: array
         concurrent_participants:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         create_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         created_method:
-          $ref: '#/components/schemas/video_room_summary_created_method'
+          enum:
+          - sdk
+          - ad_hoc
+          - api
+          nullable: true
+          type: string
         duration_sec:
-          $ref: '#/components/schemas/long'
+          nullable: true
+          type: integer
         edge_location:
-          $ref: '#/components/schemas/video_room_summary_edge_location'
+          enum:
+          - ashburn
+          - dublin
+          - frankfurt
+          - singapore
+          - sydney
+          - sao_paulo
+          - roaming
+          - umatilla
+          - tokyo
+          nullable: true
+          type: string
         end_reason:
-          $ref: '#/components/schemas/video_room_summary_end_reason'
+          enum:
+          - room_ended_via_api
+          - timeout
+          nullable: true
+          type: string
         end_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         max_concurrent_participants:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         max_participants:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         media_region:
-          $ref: '#/components/schemas/video_room_summary_twilio_realm'
+          enum:
+          - us1
+          - us2
+          - au1
+          - br1
+          - ie1
+          - jp1
+          - sg1
+          - in1
+          - de1
+          - gll
+          nullable: true
+          type: string
         processing_state:
-          $ref: '#/components/schemas/video_room_summary_processing_state'
+          enum:
+          - complete
+          - in_progress
+          nullable: true
+          type: string
         recording_enabled:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         room_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         room_status:
-          $ref: '#/components/schemas/video_room_summary_room_status'
+          enum:
+          - in_progress
+          - completed
+          nullable: true
+          type: string
         room_type:
-          $ref: '#/components/schemas/video_room_summary_room_type'
+          enum:
+          - go
+          - peer_to_peer
+          - group
+          - group_small
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         total_participant_duration_sec:
-          $ref: '#/components/schemas/long'
+          nullable: true
+          type: integer
         total_recording_duration_sec:
-          $ref: '#/components/schemas/long'
+          nullable: true
+          type: integer
         unique_participant_identities:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         unique_participants:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     insights.v1.video_room_summary.video_participant_summary:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         codecs:
-          $ref: '#/components/schemas/video_participant_summary_codec_list'
+          items:
+            enum:
+            - VP8
+            - H264
+            - VP9
+            type: string
+          nullable: true
+          type: array
         duration_sec:
-          $ref: '#/components/schemas/long'
+          nullable: true
+          type: integer
         edge_location:
-          $ref: '#/components/schemas/video_participant_summary_edge_location'
+          enum:
+          - ashburn
+          - dublin
+          - frankfurt
+          - singapore
+          - sydney
+          - sao_paulo
+          - roaming
+          - umatilla
+          - tokyo
+          nullable: true
+          type: string
         end_reason:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         error_code_url:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         join_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         leave_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         media_region:
-          $ref: '#/components/schemas/video_participant_summary_twilio_realm'
+          enum:
+          - us1
+          - us2
+          - au1
+          - br1
+          - ie1
+          - jp1
+          - sg1
+          - in1
+          - de1
+          - gll
+          nullable: true
+          type: string
         participant_identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         participant_sid:
-          $ref: '#/components/schemas/sid_PA'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PA[0-9a-fA-F]{32}$
+          type: string
         properties:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         publisher_info:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/video_participant_summary_room_status'
+          enum:
+          - in_progress
+          - completed
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
-    integer:
-      nullable: true
-      type: integer
-    long:
-      nullable: true
-      type: integer
-    metric_stream_direction:
-      enum:
-      - unknown
-      - inbound
-      - outbound
-      - both
-      nullable: true
-      type: string
-    metric_twilio_edge:
-      enum:
-      - unknown_edge
-      - carrier_edge
-      - sip_edge
-      - sdk_edge
-      - client_edge
-      nullable: true
-      type: string
-    object:
-      nullable: true
-      type: object
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_CA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CA[0-9a-fA-F]{32}$
-      type: string
-    sid_PA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^PA[0-9a-fA-F]{32}$
-      type: string
-    sid_RM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RM[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    summary_call_state:
-      enum:
-      - ringing
-      - completed
-      - busy
-      - fail
-      - noanswer
-      - canceled
-      - answered
-      - undialed
-      nullable: true
-      type: string
-    summary_call_type:
-      enum:
-      - carrier
-      - sip
-      - trunking
-      - client
-      nullable: true
-      type: string
-    summary_processing_state:
-      enum:
-      - complete
-      - partial
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
-    video_participant_summary_codec_list:
-      items:
-        enum:
-        - VP8
-        - H264
-        - VP9
-        type: string
-      nullable: true
-      type: array
-    video_participant_summary_edge_location:
-      enum:
-      - ashburn
-      - dublin
-      - frankfurt
-      - singapore
-      - sydney
-      - sao_paulo
-      - roaming
-      - umatilla
-      - tokyo
-      nullable: true
-      type: string
-    video_participant_summary_room_status:
-      enum:
-      - in_progress
-      - completed
-      nullable: true
-      type: string
-    video_participant_summary_twilio_realm:
-      enum:
-      - us1
-      - us2
-      - au1
-      - br1
-      - ie1
-      - jp1
-      - sg1
-      - in1
-      - de1
-      - gll
-      nullable: true
-      type: string
-    video_room_summary_codec_list:
-      items:
-        enum:
-        - VP8
-        - H264
-        - VP9
-        type: string
-      nullable: true
-      type: array
-    video_room_summary_created_method:
-      enum:
-      - sdk
-      - ad_hoc
-      - api
-      nullable: true
-      type: string
-    video_room_summary_edge_location:
-      enum:
-      - ashburn
-      - dublin
-      - frankfurt
-      - singapore
-      - sydney
-      - sao_paulo
-      - roaming
-      - umatilla
-      - tokyo
-      nullable: true
-      type: string
-    video_room_summary_end_reason:
-      enum:
-      - room_ended_via_api
-      - timeout
-      nullable: true
-      type: string
-    video_room_summary_processing_state:
-      enum:
-      - complete
-      - in_progress
-      nullable: true
-      type: string
-    video_room_summary_room_status:
-      enum:
-      - in_progress
-      - completed
-      nullable: true
-      type: string
-    video_room_summary_room_type:
-      enum:
-      - go
-      - peer_to_peer
-      - group
-      - group_small
-      nullable: true
-      type: string
-    video_room_summary_twilio_realm:
-      enum:
-      - us1
-      - us2
-      - au1
-      - br1
-      - ie1
-      - jp1
-      - sg1
-      - in1
-      - de1
-      - gll
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_ip_messaging_v1.yaml
+++ b/spec/yaml/twilio_ip_messaging_v1.yaml
@@ -1,356 +1,507 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    channel_channel_type:
-      enum:
-      - public
-      - private
-      nullable: true
-      type: string
-    credential_push_service:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
     ip_messaging.v1.credential:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         sandbox:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/credential_push_service'
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v1.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         consumption_report_interval:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         default_channel_creator_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_channel_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_service_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         limits:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         notifications:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         post_webhook_url:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         pre_webhook_url:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         reachability_enabled:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         read_status_enabled:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         typing_indicator_timeout:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         webhook_filters:
-          $ref: '#/components/schemas/string_list'
+          items:
+            type: string
+          nullable: true
+          type: array
         webhook_method:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         webhooks:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
       type: object
     ip_messaging.v1.service.channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         members_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         messages_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/channel_channel_type'
+          enum:
+          - public
+          - private
+          nullable: true
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v1.service.channel.invite:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IN'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v1.service.channel.member:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         last_consumed_message_index:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         last_consumption_timestamp:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MB'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v1.service.channel.message:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         body:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         from:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         index:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IM'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IM[0-9a-fA-F]{32}$
+          type: string
         to:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         was_edited:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
       type: object
     ip_messaging.v1.service.role:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         permissions:
-          $ref: '#/components/schemas/string_list'
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/role_role_type'
+          enum:
+          - channel
+          - deployment
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v1.service.user:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         is_notifiable:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         is_online:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         joined_channels_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_US'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v1.service.user.user_channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         last_consumed_message_index:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         member_sid:
-          $ref: '#/components/schemas/sid_MB'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/user_channel_channel_status'
+          enum:
+          - joined
+          - invited
+          - not_participating
+          nullable: true
+          type: string
         unread_messages_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
       type: object
-    object:
-      nullable: true
-      type: object
-    role_role_type:
-      enum:
-      - channel
-      - deployment
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_CH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CH[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    sid_IM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IM[0-9a-fA-F]{32}$
-      type: string
-    sid_IN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IN[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_MB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MB[0-9a-fA-F]{32}$
-      type: string
-    sid_RL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RL[0-9a-fA-F]{32}$
-      type: string
-    sid_US:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^US[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
-    user_channel_channel_status:
-      enum:
-      - joined
-      - invited
-      - not_participating
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_ip_messaging_v2.yaml
+++ b/spec/yaml/twilio_ip_messaging_v2.yaml
@@ -1,481 +1,709 @@
 components:
   schemas:
-    binding_binding_type:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    boolean:
-      nullable: true
-      type: boolean
-    channel_channel_type:
-      enum:
-      - public
-      - private
-      nullable: true
-      type: string
-    credential_push_service:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
     ip_messaging.v2.credential:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         sandbox:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/credential_push_service'
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         consumption_report_interval:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         default_channel_creator_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_channel_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         default_service_role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         limits:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         media:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         notifications:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         post_webhook_retry_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         post_webhook_url:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         pre_webhook_retry_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         pre_webhook_url:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         reachability_enabled:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         read_status_enabled:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         typing_indicator_timeout:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         webhook_filters:
-          $ref: '#/components/schemas/string_list'
+          items:
+            type: string
+          nullable: true
+          type: array
         webhook_method:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service.binding:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         binding_type:
-          $ref: '#/components/schemas/binding_binding_type'
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         endpoint:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         message_types:
-          $ref: '#/components/schemas/string_list'
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service.channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         members_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         messages_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/channel_channel_type'
+          enum:
+          - public
+          - private
+          nullable: true
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service.channel.channel_webhook:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         configuration:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WH[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service.channel.invite:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IN'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service.channel.member:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         last_consumed_message_index:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         last_consumption_timestamp:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MB'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service.channel.message:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         body:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         from:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         index:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         last_updated_by:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         media:
-          $ref: '#/components/schemas/object'
+          nullable: true
+          type: object
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IM'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IM[0-9a-fA-F]{32}$
+          type: string
         to:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         was_edited:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
       type: object
     ip_messaging.v2.service.role:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         permissions:
-          $ref: '#/components/schemas/string_list'
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/role_role_type'
+          enum:
+          - channel
+          - deployment
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service.user:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         is_notifiable:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         is_online:
-          $ref: '#/components/schemas/boolean'
+          nullable: true
+          type: boolean
         joined_channels_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         role_sid:
-          $ref: '#/components/schemas/sid_RL'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RL[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_US'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     ip_messaging.v2.service.user.user_binding:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         binding_type:
-          $ref: '#/components/schemas/user_binding_binding_type'
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         endpoint:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         message_types:
-          $ref: '#/components/schemas/string_list'
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         user_sid:
-          $ref: '#/components/schemas/sid_US'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
       type: object
     ip_messaging.v2.service.user.user_channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_sid:
-          $ref: '#/components/schemas/sid_CH'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CH[0-9a-fA-F]{32}$
+          type: string
         last_consumed_message_index:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         member_sid:
-          $ref: '#/components/schemas/sid_MB'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MB[0-9a-fA-F]{32}$
+          type: string
         notification_level:
-          $ref: '#/components/schemas/user_channel_notification_level'
+          enum:
+          - default
+          - muted
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/user_channel_channel_status'
+          enum:
+          - joined
+          - invited
+          - not_participating
+          nullable: true
+          type: string
         unread_messages_count:
-          $ref: '#/components/schemas/integer'
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
         user_sid:
-          $ref: '#/components/schemas/sid_US'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
       type: object
-    object:
-      nullable: true
-      type: object
-    role_role_type:
-      enum:
-      - channel
-      - deployment
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_BS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BS[0-9a-fA-F]{32}$
-      type: string
-    sid_CH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CH[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    sid_IM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IM[0-9a-fA-F]{32}$
-      type: string
-    sid_IN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IN[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_MB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MB[0-9a-fA-F]{32}$
-      type: string
-    sid_RL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RL[0-9a-fA-F]{32}$
-      type: string
-    sid_US:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^US[0-9a-fA-F]{32}$
-      type: string
-    sid_WH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WH[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
-    user_binding_binding_type:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    user_channel_channel_status:
-      enum:
-      - joined
-      - invited
-      - not_participating
-      nullable: true
-      type: string
-    user_channel_notification_level:
-      enum:
-      - default
-      - muted
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_lookups_v1.yaml
+++ b/spec/yaml/twilio_lookups_v1.yaml
@@ -3,33 +3,35 @@ components:
     lookups.v1.phone_number:
       properties:
         add_ons:
-          $ref: '#/components/schemas/object'
+          description: A JSON string with the results of the Add-ons you specified
+          nullable: true
+          type: object
         caller_name:
-          $ref: '#/components/schemas/object'
+          description: The name of the phone number's owner
+          nullable: true
+          type: object
         carrier:
-          $ref: '#/components/schemas/object'
+          description: The telecom company that provides the phone number
+          nullable: true
+          type: object
         country_code:
-          $ref: '#/components/schemas/string'
+          description: The ISO country code for the phone number
+          nullable: true
+          type: string
         national_format:
-          $ref: '#/components/schemas/string'
+          description: The phone number, in national format
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    object:
-      nullable: true
-      type: object
-    phone_number:
-      nullable: true
-      type: string
-    string:
-      nullable: true
-      type: string
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_messaging_v1.yaml
+++ b/spec/yaml/twilio_messaging_v1.yaml
@@ -1,231 +1,356 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    brand_registrations_status:
-      enum:
-      - IN_PROGRESS
-      - VERIFIED
-      - FAILED
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
     messaging.v1.brand_registrations:
       properties:
         a2p_profile_bundle_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: A2P Messaging Profile Bundle BundleSid
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         customer_profile_bundle_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: A2P Messaging Profile Bundle BundleSid
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         failure_reason:
-          $ref: '#/components/schemas/string'
+          description: A reason why brand registration has failed
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BN'
+          description: A2P BrandRegistration Sid
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BN[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/brand_registrations_status'
+          description: Brand Registration status
+          enum:
+          - IN_PROGRESS
+          - VERIFIED
+          - FAILED
+          nullable: true
+          type: string
         tcr_id:
-          $ref: '#/components/schemas/string'
+          description: Campaign Registry (TCR) Brand ID
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Brand Registration
+          format: uri
+          nullable: true
+          type: string
       type: object
     messaging.v1.deactivation:
       properties:
         redirect_to:
-          $ref: '#/components/schemas/url'
+          description: Redirect url to the list of deactivated numbers.
+          format: uri
+          nullable: true
+          type: string
       type: object
     messaging.v1.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         area_code_geomatch:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to enable Area Code Geomatch on the Service Instance
+          nullable: true
+          type: boolean
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         fallback_to_long_code:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to enable Fallback to Long Code for messages sent through
+            the Service instance
+          nullable: true
+          type: boolean
         fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call using fallback_method if an error occurs
+            while retrieving or executing the TwiML from the Inbound Request URL
+          format: uri
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         inbound_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call inbound_request_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         inbound_request_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call using inbound_method when a message is received
+            by any phone number or short code in the Service
+          format: uri
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The absolute URLs of related resources
+          nullable: true
+          type: object
         mms_converter:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to enable the MMS Converter for messages sent through
+            the Service instance
+          nullable: true
+          type: boolean
         scan_message_content:
-          $ref: '#/components/schemas/service_scan_message_content'
+          description: Reserved
+          enum:
+          - inherit
+          - enable
+          - disable
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         smart_encoding:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to enable Encoding for messages sent through the Service
+            instance
+          nullable: true
+          type: boolean
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL we call to pass status updates about message delivery
+          format: uri
+          nullable: true
+          type: string
         sticky_sender:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to enable Sticky Sender on the Service instance
+          nullable: true
+          type: boolean
         synchronous_validation:
-          $ref: '#/components/schemas/boolean'
+          description: Reserved
+          nullable: true
+          type: boolean
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Service resource
+          format: uri
+          nullable: true
+          type: string
         validity_period:
-          $ref: '#/components/schemas/integer'
+          description: How long, in seconds, messages sent from the Service are valid
+          nullable: true
+          type: integer
       type: object
     messaging.v1.service.alpha_sender:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         alpha_sender:
-          $ref: '#/components/schemas/string'
+          description: The Alphanumeric Sender ID string
+          nullable: true
+          type: string
         capabilities:
-          $ref: '#/components/schemas/string_list'
+          description: An array of values that describe whether the number can receive
+            calls or messages
+          items:
+            type: string
+          nullable: true
+          type: array
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AI'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AI[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the AlphaSender resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     messaging.v1.service.phone_number:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         capabilities:
-          $ref: '#/components/schemas/string_list'
+          description: An array of values that describe whether the number can receive
+            calls or messages
+          items:
+            type: string
+          nullable: true
+          type: array
         country_code:
-          $ref: '#/components/schemas/string'
+          description: The 2-character ISO Country Code of the number
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the PhoneNumber resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     messaging.v1.service.short_code:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         capabilities:
-          $ref: '#/components/schemas/string_list'
+          description: An array of values that describe whether the number can receive
+            calls or messages
+          items:
+            type: string
+          nullable: true
+          type: array
         country_code:
-          $ref: '#/components/schemas/string'
+          description: The 2-character ISO Country Code of the number
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         short_code:
-          $ref: '#/components/schemas/string'
+          description: The E.164 format of the short code
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_SC'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SC[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the ShortCode resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    phone_number:
-      nullable: true
-      type: string
-    service_scan_message_content:
-      enum:
-      - inherit
-      - enable
-      - disable
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_AI:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AI[0-9a-fA-F]{32}$
-      type: string
-    sid_BN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BN[0-9a-fA-F]{32}$
-      type: string
-    sid_BU:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BU[0-9a-fA-F]{32}$
-      type: string
-    sid_MG:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MG[0-9a-fA-F]{32}$
-      type: string
-    sid_PN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^PN[0-9a-fA-F]{32}$
-      type: string
-    sid_SC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^SC[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_monitor_v1.yaml
+++ b/spec/yaml/twilio_monitor_v1.yaml
@@ -1,171 +1,275 @@
 components:
   schemas:
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
     monitor.v1.alert:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         alert_text:
-          $ref: '#/components/schemas/string'
+          description: The text of the alert
+          nullable: true
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used when the alert was generated
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_generated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date and time when the alert was generated specified in
+            ISO 8601 format
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/string'
+          description: The error code for the condition that generated the alert
+          nullable: true
+          type: string
         log_level:
-          $ref: '#/components/schemas/string'
+          description: The log level
+          nullable: true
+          type: string
         more_info:
-          $ref: '#/components/schemas/string'
+          description: The URL of the page in our Error Dictionary with more information
+            about the error condition
+          nullable: true
+          type: string
         request_method:
-          $ref: '#/components/schemas/http_method'
+          description: The method used by the request that generated the alert
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         request_url:
-          $ref: '#/components/schemas/uri'
+          description: The URL of the request that generated the alert
+          format: uri
+          nullable: true
+          type: string
         resource_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the resource for which the alert was generated
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the service or resource that generated the alert
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_NO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NO[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Alert resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     monitor.v1.alert-instance:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         alert_text:
-          $ref: '#/components/schemas/string'
+          description: The text of the alert
+          nullable: true
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used when the alert was generated
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_generated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date and time when the alert was generated specified in
+            ISO 8601 format
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         error_code:
-          $ref: '#/components/schemas/string'
+          description: The error code for the condition that generated the alert
+          nullable: true
+          type: string
         log_level:
-          $ref: '#/components/schemas/string'
+          description: The log level
+          nullable: true
+          type: string
         more_info:
-          $ref: '#/components/schemas/string'
+          description: The URL of the page in our Error Dictionary with more information
+            about the error condition
+          nullable: true
+          type: string
         request_headers:
-          $ref: '#/components/schemas/string'
+          description: The request headers of the request that generated the alert
+          nullable: true
+          type: string
         request_method:
-          $ref: '#/components/schemas/http_method'
+          description: The method used by the request that generated the alert
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         request_url:
-          $ref: '#/components/schemas/uri'
+          description: The URL of the request that generated the alert
+          format: uri
+          nullable: true
+          type: string
         request_variables:
-          $ref: '#/components/schemas/string'
+          description: The variables passed in the request that generated the alert
+          nullable: true
+          type: string
         resource_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the resource for which the alert was generated
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         response_body:
-          $ref: '#/components/schemas/string'
+          description: The response body of the request that generated the alert
+          nullable: true
+          type: string
         response_headers:
-          $ref: '#/components/schemas/string'
+          description: The response headers of the request that generated the alert
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the service or resource that generated the alert
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_NO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NO[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Alert resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     monitor.v1.event:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         actor_sid:
-          $ref: '#/components/schemas/sid_US'
+          description: The SID of the actor that caused the event, if available
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^US[0-9a-fA-F]{32}$
+          type: string
         actor_type:
-          $ref: '#/components/schemas/string'
+          description: The type of actor that caused the event
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A description of the event
+          nullable: true
+          type: string
         event_data:
-          $ref: '#/components/schemas/object'
+          description: A JSON string that represents an object with additional data
+            about the event
+          nullable: true
+          type: object
         event_date:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the event was recorded
+          format: date-time
+          nullable: true
+          type: string
         event_type:
-          $ref: '#/components/schemas/string'
+          description: The event's type
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The absolute URLs of related resources
+          nullable: true
+          type: object
         resource_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the resource that was affected
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         resource_type:
-          $ref: '#/components/schemas/string'
+          description: The type of resource that was affected
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AE[0-9a-fA-F]{32}$
+          type: string
         source:
-          $ref: '#/components/schemas/string'
+          description: The originating system or interface that caused the event
+          nullable: true
+          type: string
         source_ip_address:
-          $ref: '#/components/schemas/string'
+          description: The IP address of the source
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource that was affected
+          format: uri
+          nullable: true
+          type: string
       type: object
-    object:
-      nullable: true
-      type: object
-    sid:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_AE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AE[0-9a-fA-F]{32}$
-      type: string
-    sid_NO:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^NO[0-9a-fA-F]{32}$
-      type: string
-    sid_US:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^US[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    uri:
-      format: uri
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_notify_v1.yaml
+++ b/spec/yaml/twilio_notify_v1.yaml
@@ -1,218 +1,343 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    credential_push_service:
-      enum:
-      - gcm
-      - apn
-      - fcm
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    notification_priority:
-      enum:
-      - high
-      - low
-      nullable: true
-      type: string
     notify.v1.credential:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sandbox:
-          $ref: '#/components/schemas/string'
+          description: '[APN only] Whether to send the credential to sandbox APNs'
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/credential_push_service'
+          description: The Credential type, one of `gcm`, `fcm`, or `apn`
+          enum:
+          - gcm
+          - apn
+          - fcm
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Credential resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     notify.v1.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         alexa_skill_id:
-          $ref: '#/components/schemas/string'
+          description: Deprecated
+          nullable: true
+          type: string
         apn_credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Credential to use for APN Bindings
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         default_alexa_notification_protocol_version:
-          $ref: '#/components/schemas/string'
+          description: Deprecated
+          nullable: true
+          type: string
         default_apn_notification_protocol_version:
-          $ref: '#/components/schemas/string'
+          description: The protocol version to use for sending APNS notifications
+          nullable: true
+          type: string
         default_fcm_notification_protocol_version:
-          $ref: '#/components/schemas/string'
+          description: The protocol version to use for sending FCM notifications
+          nullable: true
+          type: string
         default_gcm_notification_protocol_version:
-          $ref: '#/components/schemas/string'
+          description: The protocol version to use for sending GCM notifications
+          nullable: true
+          type: string
         delivery_callback_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Enable delivery callbacks
+          nullable: true
+          type: boolean
         delivery_callback_url:
-          $ref: '#/components/schemas/string'
+          description: Webhook URL
+          nullable: true
+          type: string
         facebook_messenger_page_id:
-          $ref: '#/components/schemas/string'
+          description: Deprecated
+          nullable: true
+          type: string
         fcm_credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Credential to use for FCM Bindings
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         gcm_credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Credential to use for GCM Bindings
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the resources related to the service
+          nullable: true
+          type: object
         log_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to log notifications
+          nullable: true
+          type: boolean
         messaging_service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The SID of the Messaging Service to use for SMS Bindings
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Service resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     notify.v1.service.binding:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         address:
-          $ref: '#/components/schemas/string'
+          description: The channel-specific address
+          nullable: true
+          type: string
         binding_type:
-          $ref: '#/components/schemas/string'
+          description: The type of the Binding
+          nullable: true
+          type: string
         credential_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Credential resource to be used to send notifications
+            to this Binding
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         endpoint:
-          $ref: '#/components/schemas/string'
+          description: Deprecated
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The `identity` value that identifies the new resource's User
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         notification_protocol_version:
-          $ref: '#/components/schemas/string'
+          description: The protocol version to use to send the notification
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BS[0-9a-fA-F]{32}$
+          type: string
         tags:
-          $ref: '#/components/schemas/string_list'
+          description: The list of tags associated with this Binding
+          items:
+            type: string
+          nullable: true
+          type: array
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Binding resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     notify.v1.service.notification:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         action:
-          $ref: '#/components/schemas/string'
+          description: The actions to display for the notification
+          nullable: true
+          type: string
         alexa:
-          $ref: '#/components/schemas/object'
+          description: Deprecated
+          nullable: true
+          type: object
         apn:
-          $ref: '#/components/schemas/object'
+          description: The APNS-specific payload that overrides corresponding attributes
+            in a generic payload for APNS Bindings
+          nullable: true
+          type: object
         body:
-          $ref: '#/components/schemas/string'
+          description: The notification body text
+          nullable: true
+          type: string
         data:
-          $ref: '#/components/schemas/object'
+          description: The custom key-value pairs of the notification's payload
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         facebook_messenger:
-          $ref: '#/components/schemas/object'
+          description: Deprecated
+          nullable: true
+          type: object
         fcm:
-          $ref: '#/components/schemas/object'
+          description: The FCM-specific payload that overrides corresponding attributes
+            in generic payload for FCM Bindings
+          nullable: true
+          type: object
         gcm:
-          $ref: '#/components/schemas/object'
+          description: The GCM-specific payload that overrides corresponding attributes
+            in generic payload for GCM Bindings
+          nullable: true
+          type: object
         identities:
-          $ref: '#/components/schemas/string_list'
+          description: The list of identity values of the Users to notify
+          items:
+            type: string
+          nullable: true
+          type: array
         priority:
-          $ref: '#/components/schemas/notification_priority'
+          description: The priority of the notification
+          enum:
+          - high
+          - low
+          nullable: true
+          type: string
         segments:
-          $ref: '#/components/schemas/string_list'
+          description: The list of Segments to notify
+          items:
+            type: string
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_NO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NO[0-9a-fA-F]{32}$
+          type: string
         sms:
-          $ref: '#/components/schemas/object'
+          description: The SMS-specific payload that overrides corresponding attributes
+            in generic payload for SMS Bindings
+          nullable: true
+          type: object
         sound:
-          $ref: '#/components/schemas/string'
+          description: The name of the sound to be played for the notification
+          nullable: true
+          type: string
         tags:
-          $ref: '#/components/schemas/string_list'
+          description: The tags that select the Bindings to notify
+          items:
+            type: string
+          nullable: true
+          type: array
         title:
-          $ref: '#/components/schemas/string'
+          description: The notification title
+          nullable: true
+          type: string
         ttl:
-          $ref: '#/components/schemas/integer'
+          description: How long, in seconds, the notification is valid
+          nullable: true
+          type: integer
       type: object
-    object:
-      nullable: true
-      type: object
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_BS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BS[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_MG:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MG[0-9a-fA-F]{32}$
-      type: string
-    sid_NO:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^NO[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_numbers_v2.yaml
+++ b/spec/yaml/twilio_numbers_v2.yaml
@@ -1,268 +1,383 @@
 components:
   schemas:
-    bundle_status:
-      enum:
-      - draft
-      - pending-review
-      - in-review
-      - twilio-rejected
-      - twilio-approved
-      - provisionally-approved
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    end_user_type:
-      enum:
-      - individual
-      - business
-      nullable: true
-      type: string
-    evaluation_status:
-      enum:
-      - compliant
-      - noncompliant
-      nullable: true
-      type: string
     numbers.v2.regulatory_compliance:
       properties: {}
       type: object
     numbers.v2.regulatory_compliance.bundle:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         email:
-          $ref: '#/components/schemas/string'
+          description: The email address
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Assigned Items of the Bundle resource
+          nullable: true
+          type: object
         regulation_sid:
-          $ref: '#/components/schemas/sid_RN'
+          description: The unique string of a regulation.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RN[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/bundle_status'
+          description: The verification status of the Bundle resource
+          enum:
+          - draft
+          - pending-review
+          - in-review
+          - twilio-rejected
+          - twilio-approved
+          - provisionally-approved
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL we call to inform your application of status changes.
+          format: uri
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Bundle resource
+          format: uri
+          nullable: true
+          type: string
         valid_until:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource will be
+            valid until.
+          format: date-time
+          nullable: true
+          type: string
       type: object
     numbers.v2.regulatory_compliance.bundle.evaluation:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         bundle_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         regulation_sid:
-          $ref: '#/components/schemas/sid_RN'
+          description: The unique string of a regulation
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RN[0-9a-fA-F]{32}$
+          type: string
         results:
-          $ref: '#/components/schemas/object_list'
+          description: The results of the Evaluation resource
+          items:
+            type: object
+          nullable: true
+          type: array
         sid:
-          $ref: '#/components/schemas/sid_EL'
+          description: The unique string that identifies the Evaluation resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^EL[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/evaluation_status'
+          description: The compliance status of the Evaluation resource
+          enum:
+          - compliant
+          - noncompliant
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     numbers.v2.regulatory_compliance.bundle.item_assignment:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         bundle_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the Bundle resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         object_sid:
-          $ref: '#/components/schemas/sid'
+          description: The sid of an object bag
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BV'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BV[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Identity resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     numbers.v2.regulatory_compliance.end_user:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/object'
+          description: The set of parameters that compose the End Users resource
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IT[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/end_user_type'
+          description: The type of end user of the Bundle resource
+          enum:
+          - individual
+          - business
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the End User resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     numbers.v2.regulatory_compliance.end_user_type:
       properties:
         fields:
-          $ref: '#/components/schemas/object_list'
+          description: The required information for creating an End-User.
+          items:
+            type: object
+          nullable: true
+          type: array
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human-readable description of the End-User Type resource
+          nullable: true
+          type: string
         machine_name:
-          $ref: '#/components/schemas/string'
+          description: A machine-readable description of the End-User Type resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_OY'
+          description: The unique string that identifies the End-User Type resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^OY[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the End-User Type resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     numbers.v2.regulatory_compliance.regulation:
       properties:
         end_user_type:
-          $ref: '#/components/schemas/regulation_end_user_type'
+          description: The type of End User of the Regulation resource
+          enum:
+          - individual
+          - business
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human-readable description of the Regulation resource
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/string'
+          description: The ISO country code of the phone number's country
+          nullable: true
+          type: string
         number_type:
-          $ref: '#/components/schemas/string'
+          description: The type of phone number restricted by the regulatory requirement
+          nullable: true
+          type: string
         requirements:
-          $ref: '#/components/schemas/object'
+          description: The sid of a regulation object that dictates requirements
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_RN'
+          description: The unique string that identifies the Regulation resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Regulation resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     numbers.v2.regulatory_compliance.supporting_document:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/object'
+          description: The set of parameters that compose the Supporting Documents
+            resource
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         mime_type:
-          $ref: '#/components/schemas/string'
+          description: The image type of the file
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RD'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RD[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/supporting_document_status'
+          description: The verification status of the Supporting Document resource
+          enum:
+          - draft
+          - pending-review
+          - rejected
+          - approved
+          - expired
+          - provisionally-approved
+          nullable: true
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: The type of the Supporting Document
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Supporting Document resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     numbers.v2.regulatory_compliance.supporting_document_type:
       properties:
         fields:
-          $ref: '#/components/schemas/object_list'
+          description: The required information for creating a Supporting Document
+          items:
+            type: object
+          nullable: true
+          type: array
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human-readable description of the Supporting Document Type
+            resource
+          nullable: true
+          type: string
         machine_name:
-          $ref: '#/components/schemas/string'
+          description: The machine-readable description of the Supporting Document
+            Type resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_OY'
+          description: The unique string that identifies the Supporting Document Type
+            resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^OY[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Supporting Document Type resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    object:
-      nullable: true
-      type: object
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    regulation_end_user_type:
-      enum:
-      - individual
-      - business
-      nullable: true
-      type: string
-    sid:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_BU:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BU[0-9a-fA-F]{32}$
-      type: string
-    sid_BV:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BV[0-9a-fA-F]{32}$
-      type: string
-    sid_EL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^EL[0-9a-fA-F]{32}$
-      type: string
-    sid_IT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IT[0-9a-fA-F]{32}$
-      type: string
-    sid_OY:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^OY[0-9a-fA-F]{32}$
-      type: string
-    sid_RD:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RD[0-9a-fA-F]{32}$
-      type: string
-    sid_RN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RN[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    supporting_document_status:
-      enum:
-      - draft
-      - pending-review
-      - rejected
-      - approved
-      - expired
-      - provisionally-approved
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_pricing_v1.yaml
+++ b/spec/yaml/twilio_pricing_v1.yaml
@@ -1,231 +1,280 @@
 components:
   schemas:
-    currency:
-      nullable: true
-      type: string
-    inbound_call_price:
-      nullable: true
-      properties:
-        base_price:
-          type: number
-        current_price:
-          type: number
-        number_type:
-          type: string
-      type: object
-    inbound_call_price_list:
-      items:
-        properties:
-          base_price:
-            type: number
-          current_price:
-            type: number
-          number_type:
-            type: string
-        type: object
-      nullable: true
-      type: array
-    inbound_sms_price_list:
-      items:
-        properties:
-          base_price:
-            type: number
-          current_price:
-            type: number
-          number_type:
-            type: string
-        type: object
-      nullable: true
-      type: array
-    iso_country_code:
-      nullable: true
-      type: string
-    outbound_call_price:
-      nullable: true
-      properties:
-        base_price:
-          type: number
-        current_price:
-          type: number
-      type: object
-    outbound_prefix_price_list:
-      items:
-        properties:
-          base_price:
-            type: number
-          current_price:
-            type: number
-          friendly_name:
-            type: string
-          prefixes:
-            items:
-              type: string
-            type: array
-        type: object
-      nullable: true
-      type: array
-    outbound_sms_price_list:
-      items:
-        properties:
-          carrier:
-            type: string
-          mcc:
-            type: string
-          mnc:
-            type: string
-          prices:
-            items:
-              properties:
-                base_price:
-                  type: number
-                current_price:
-                  type: number
-                number_type:
-                  type: string
-              type: object
-            type: array
-        type: object
-      nullable: true
-      type: array
-    phone_number_e164:
-      nullable: true
-      type: string
-    phone_number_price_list:
-      items:
-        properties:
-          base_price:
-            type: number
-          current_price:
-            type: number
-          number_type:
-            type: string
-        type: object
-      nullable: true
-      type: array
     pricing.v1.messaging:
       properties:
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.messaging.messaging_country:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.messaging.messaging_country-instance:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         inbound_sms_prices:
-          $ref: '#/components/schemas/inbound_sms_price_list'
+          description: The list of InboundPrice records
+          items:
+            properties:
+              base_price:
+                type: number
+              current_price:
+                type: number
+              number_type:
+                type: string
+            type: object
+          nullable: true
+          type: array
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         outbound_sms_prices:
-          $ref: '#/components/schemas/outbound_sms_price_list'
+          description: The list of OutboundSMSPrice records
+          items:
+            properties:
+              carrier:
+                type: string
+              mcc:
+                type: string
+              mnc:
+                type: string
+              prices:
+                items:
+                  properties:
+                    base_price:
+                      type: number
+                    current_price:
+                      type: number
+                    number_type:
+                      type: string
+                  type: object
+                type: array
+            type: object
+          nullable: true
+          type: array
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which prices are measured, in ISO 4127 format
+            (e.g. usd, eur, jpy)
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.phone_number:
       properties:
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.phone_number.phone_number_country:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: 'The ISO country code '
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.phone_number.phone_number_country-instance:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: 'The ISO country code '
+          nullable: true
+          type: string
         phone_number_prices:
-          $ref: '#/components/schemas/phone_number_price_list'
+          description: The list of PhoneNumberPrices records
+          items:
+            properties:
+              base_price:
+                type: number
+              current_price:
+                type: number
+              number_type:
+                type: string
+            type: object
+          nullable: true
+          type: array
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which prices are measured, in ISO 4127 format
+            (e.g. usd, eur, jpy)
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.voice:
       properties:
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         name:
-          $ref: '#/components/schemas/string'
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.voice.voice_country:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.voice.voice_country-instance:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         inbound_call_prices:
-          $ref: '#/components/schemas/inbound_call_price_list'
+          description: The list of InboundCallPrice records
+          items:
+            properties:
+              base_price:
+                type: number
+              current_price:
+                type: number
+              number_type:
+                type: string
+            type: object
+          nullable: true
+          type: array
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         outbound_prefix_prices:
-          $ref: '#/components/schemas/outbound_prefix_price_list'
+          description: The list of OutboundPrefixPrice records
+          items:
+            properties:
+              base_price:
+                type: number
+              current_price:
+                type: number
+              friendly_name:
+                type: string
+              prefixes:
+                items:
+                  type: string
+                type: array
+            type: object
+          nullable: true
+          type: array
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which prices are measured, in ISO 4127 format
+            (e.g. usd, eur, jpy)
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v1.voice.voice_number:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         inbound_call_price:
-          $ref: '#/components/schemas/inbound_call_price'
+          description: The InboundCallPrice record
+          nullable: true
+          properties:
+            base_price:
+              type: number
+            current_price:
+              type: number
+            number_type:
+              type: string
+          type: object
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         number:
-          $ref: '#/components/schemas/phone_number_e164'
+          description: The phone number
+          nullable: true
+          type: string
         outbound_call_price:
-          $ref: '#/components/schemas/outbound_call_price'
+          description: The OutboundCallPrice record
+          nullable: true
+          properties:
+            base_price:
+              type: number
+            current_price:
+              type: number
+          type: object
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which prices are measured, in ISO 4127 format
+            (e.g. usd, eur, jpy)
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    string:
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_pricing_v2.yaml
+++ b/spec/yaml/twilio_pricing_v2.yaml
@@ -1,132 +1,147 @@
 components:
   schemas:
-    currency:
-      nullable: true
-      type: string
-    inbound_call_price:
-      nullable: true
-      properties:
-        base_price:
-          type: number
-        current_price:
-          type: number
-        number_type:
-          type: string
-      type: object
-    inbound_call_price_list:
-      items:
-        properties:
-          base_price:
-            type: number
-          current_price:
-            type: number
-          number_type:
-            type: string
-        type: object
-      nullable: true
-      type: array
-    iso_country_code:
-      nullable: true
-      type: string
-    outbound_call_price_with_origin_list:
-      items:
-        properties:
-          base_price:
-            type: number
-          current_price:
-            type: number
-          origination_prefixes:
-            items:
-              type: string
-            type: array
-        type: object
-      nullable: true
-      type: array
-    outbound_prefix_price_with_origin_list:
-      items:
-        properties:
-          base_price:
-            type: number
-          current_price:
-            type: number
-          destination_prefixes:
-            items:
-              type: string
-            type: array
-          friendly_name:
-            type: string
-          origination_prefixes:
-            items:
-              type: string
-            type: array
-        type: object
-      nullable: true
-      type: array
-    phone_number_e164:
-      nullable: true
-      type: string
     pricing.v2.voice:
       properties:
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the related Countries and Numbers resources
+          nullable: true
+          type: object
         name:
-          $ref: '#/components/schemas/string'
+          description: The resource name
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v2.voice.voice_country:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v2.voice.voice_country-instance:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         inbound_call_prices:
-          $ref: '#/components/schemas/inbound_call_price_list'
+          description: The list of InboundCallPrice records
+          items:
+            properties:
+              base_price:
+                type: number
+              current_price:
+                type: number
+              number_type:
+                type: string
+            type: object
+          nullable: true
+          type: array
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         outbound_prefix_prices:
-          $ref: '#/components/schemas/outbound_prefix_price_with_origin_list'
+          description: The list of OutboundPrefixPriceWithOrigin records
+          items:
+            properties:
+              base_price:
+                type: number
+              current_price:
+                type: number
+              destination_prefixes:
+                items:
+                  type: string
+                type: array
+              friendly_name:
+                type: string
+              origination_prefixes:
+                items:
+                  type: string
+                type: array
+            type: object
+          nullable: true
+          type: array
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which prices are measured, in ISO 4127 format
+            (e.g. usd, eur, jpy)
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     pricing.v2.voice.voice_number:
       properties:
         country:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         destination_number:
-          $ref: '#/components/schemas/phone_number_e164'
+          description: The destination phone number, in E.164 format
+          nullable: true
+          type: string
         inbound_call_price:
-          $ref: '#/components/schemas/inbound_call_price'
+          description: The InboundCallPrice record
+          nullable: true
+          properties:
+            base_price:
+              type: number
+            current_price:
+              type: number
+            number_type:
+              type: string
+          type: object
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         origination_number:
-          $ref: '#/components/schemas/phone_number_e164'
+          description: The origination phone number, in E.164 format
+          nullable: true
+          type: string
         outbound_call_prices:
-          $ref: '#/components/schemas/outbound_call_price_with_origin_list'
+          description: The list of OutboundCallPriceWithOrigin records
+          items:
+            properties:
+              base_price:
+                type: number
+              current_price:
+                type: number
+              origination_prefixes:
+                items:
+                  type: string
+                type: array
+            type: object
+          nullable: true
+          type: array
         price_unit:
-          $ref: '#/components/schemas/currency'
+          description: The currency in which prices are measured, in ISO 4127 format
+            (e.g. usd, eur, jpy)
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    string:
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_proxy_v1.yaml
+++ b/spec/yaml/twilio_proxy_v1.yaml
@@ -1,417 +1,723 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    interaction_resource_status:
-      enum:
-      - accepted
-      - answered
-      - busy
-      - canceled
-      - completed
-      - deleted
-      - delivered
-      - delivery-unknown
-      - failed
-      - in-progress
-      - initiated
-      - no-answer
-      - queued
-      - received
-      - receiving
-      - ringing
-      - scheduled
-      - sending
-      - sent
-      - undelivered
-      - unknown
-      nullable: true
-      type: string
-    interaction_type:
-      enum:
-      - message
-      - voice
-      - unknown
-      nullable: true
-      type: string
-    message_interaction_resource_status:
-      enum:
-      - accepted
-      - answered
-      - busy
-      - canceled
-      - completed
-      - deleted
-      - delivered
-      - delivery-unknown
-      - failed
-      - in-progress
-      - initiated
-      - no-answer
-      - queued
-      - received
-      - receiving
-      - ringing
-      - scheduled
-      - sending
-      - sent
-      - undelivered
-      - unknown
-      nullable: true
-      type: string
-    message_interaction_type:
-      enum:
-      - message
-      - voice
-      - unknown
-      nullable: true
-      type: string
-    phone_number:
-      nullable: true
-      type: string
-    phone_number_capabilities:
-      nullable: true
-      properties:
-        fax:
-          type: boolean
-        mms:
-          type: boolean
-        sms:
-          type: boolean
-        voice:
-          type: boolean
-      type: object
     proxy.v1.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the interaction status changes
+          format: uri
+          nullable: true
+          type: string
         chat_instance_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Chat Service Instance
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         default_ttl:
-          $ref: '#/components/schemas/integer'
+          description: Default TTL for a Session, in seconds
+          nullable: true
+          type: integer
         geo_match_level:
-          $ref: '#/components/schemas/service_geo_match_level'
+          description: Where a proxy number must be located relative to the participant
+            identifier
+          enum:
+          - area-code
+          - overlay
+          - radius
+          - country
+          nullable: true
+          type: string
         intercept_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call on each interaction
+          format: uri
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of resources related to the Service
+          nullable: true
+          type: object
         number_selection_behavior:
-          $ref: '#/components/schemas/service_number_selection_behavior'
+          description: The preference for Proxy Number selection for the Service instance
+          enum:
+          - avoid-sticky
+          - prefer-sticky
+          nullable: true
+          type: string
         out_of_session_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an inbound call or SMS action occurs on
+            a closed or non-existent Session
+          format: uri
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_KS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KS[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Service resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     proxy.v1.service.phone_number:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: The capabilities of the phone number
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         in_use:
-          $ref: '#/components/schemas/integer'
+          description: The number of open session assigned to the number.
+          nullable: true
+          type: integer
         is_reserved:
-          $ref: '#/components/schemas/boolean'
+          description: Reserve the phone number for manual assignment to participants
+            only
+          nullable: true
+          type: boolean
         iso_country:
-          $ref: '#/components/schemas/string'
+          description: The ISO Country Code
+          nullable: true
+          type: string
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_KS'
+          description: The SID of the PhoneNumber resource's parent Service resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the PhoneNumber resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     proxy.v1.service.session:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         closed_reason:
-          $ref: '#/components/schemas/string'
+          description: The reason the Session ended
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_ended:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date when the Session ended
+          format: date-time
+          nullable: true
+          type: string
         date_expiry:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date when the Session should expire
+          format: date-time
+          nullable: true
+          type: string
         date_last_interaction:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date when the Session last had an interaction
+          format: date-time
+          nullable: true
+          type: string
         date_started:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date when the Session started
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of resources related to the Session
+          nullable: true
+          type: object
         mode:
-          $ref: '#/components/schemas/session_mode'
+          description: The Mode of the Session
+          enum:
+          - message-only
+          - voice-only
+          - voice-and-message
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_KS'
+          description: The SID of the resource's parent Service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_KC'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KC[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/session_status'
+          description: The status of the Session
+          enum:
+          - open
+          - in-progress
+          - closed
+          - failed
+          - unknown
+          nullable: true
+          type: string
         ttl:
-          $ref: '#/components/schemas/integer'
+          description: When the session will expire
+          nullable: true
+          type: integer
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Session resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     proxy.v1.service.session.interaction:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         data:
-          $ref: '#/components/schemas/string'
+          description: A JSON string that includes the message body of message interactions
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Interaction was
+            created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         inbound_participant_sid:
-          $ref: '#/components/schemas/sid_KP'
+          description: The SID of the inbound Participant resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KP[0-9a-fA-F]{32}$
+          type: string
         inbound_resource_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the inbound resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         inbound_resource_status:
-          $ref: '#/components/schemas/interaction_resource_status'
+          description: The inbound resource status of the Interaction
+          enum:
+          - accepted
+          - answered
+          - busy
+          - canceled
+          - completed
+          - deleted
+          - delivered
+          - delivery-unknown
+          - failed
+          - in-progress
+          - initiated
+          - no-answer
+          - queued
+          - received
+          - receiving
+          - ringing
+          - scheduled
+          - sending
+          - sent
+          - undelivered
+          - unknown
+          nullable: true
+          type: string
         inbound_resource_type:
-          $ref: '#/components/schemas/string'
+          description: The inbound resource type
+          nullable: true
+          type: string
         inbound_resource_url:
-          $ref: '#/components/schemas/url'
+          description: The URL of the Twilio inbound resource
+          format: uri
+          nullable: true
+          type: string
         outbound_participant_sid:
-          $ref: '#/components/schemas/sid_KP'
+          description: The SID of the outbound Participant
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KP[0-9a-fA-F]{32}$
+          type: string
         outbound_resource_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the outbound resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         outbound_resource_status:
-          $ref: '#/components/schemas/interaction_resource_status'
+          description: The outbound resource status of the Interaction
+          enum:
+          - accepted
+          - answered
+          - busy
+          - canceled
+          - completed
+          - deleted
+          - delivered
+          - delivery-unknown
+          - failed
+          - in-progress
+          - initiated
+          - no-answer
+          - queued
+          - received
+          - receiving
+          - ringing
+          - scheduled
+          - sending
+          - sent
+          - undelivered
+          - unknown
+          nullable: true
+          type: string
         outbound_resource_type:
-          $ref: '#/components/schemas/string'
+          description: The outbound resource type
+          nullable: true
+          type: string
         outbound_resource_url:
-          $ref: '#/components/schemas/url'
+          description: The URL of the Twilio outbound resource
+          format: uri
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_KS'
+          description: The SID of the resource's parent Service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KS[0-9a-fA-F]{32}$
+          type: string
         session_sid:
-          $ref: '#/components/schemas/sid_KC'
+          description: The SID of the resource's parent Session
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KC[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_KI'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KI[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/interaction_type'
+          description: The Type of the Interaction
+          enum:
+          - message
+          - voice
+          - unknown
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Interaction resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     proxy.v1.service.session.participant:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_deleted:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date the Participant was removed
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the participant
+          nullable: true
+          type: string
         identifier:
-          $ref: '#/components/schemas/string'
+          description: The phone number of the Participant
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs to resources related the participant
+          nullable: true
+          type: object
         proxy_identifier:
-          $ref: '#/components/schemas/string'
+          description: The phone number or short code of the participant's partner
+          nullable: true
+          type: string
         proxy_identifier_sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The SID of the Proxy Identifier assigned to the Participant
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_KS'
+          description: The SID of the resource's parent Service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KS[0-9a-fA-F]{32}$
+          type: string
         session_sid:
-          $ref: '#/components/schemas/sid_KC'
+          description: The SID of the resource's parent Session
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KC[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_KP'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KP[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Participant resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     proxy.v1.service.session.participant.message_interaction:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         data:
-          $ref: '#/components/schemas/string'
+          description: A JSON string that includes the message body sent to the participant
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         inbound_participant_sid:
-          $ref: '#/components/schemas/sid_KP'
+          description: Always empty for Message Interactions
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KP[0-9a-fA-F]{32}$
+          type: string
         inbound_resource_sid:
-          $ref: '#/components/schemas/sid'
+          description: Always empty for Message Interactions
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         inbound_resource_status:
-          $ref: '#/components/schemas/message_interaction_resource_status'
+          description: Always empty for Message Interactions
+          enum:
+          - accepted
+          - answered
+          - busy
+          - canceled
+          - completed
+          - deleted
+          - delivered
+          - delivery-unknown
+          - failed
+          - in-progress
+          - initiated
+          - no-answer
+          - queued
+          - received
+          - receiving
+          - ringing
+          - scheduled
+          - sending
+          - sent
+          - undelivered
+          - unknown
+          nullable: true
+          type: string
         inbound_resource_type:
-          $ref: '#/components/schemas/string'
+          description: Always empty for Message Interactions
+          nullable: true
+          type: string
         inbound_resource_url:
-          $ref: '#/components/schemas/url'
+          description: Always empty for Message Interactions
+          format: uri
+          nullable: true
+          type: string
         outbound_participant_sid:
-          $ref: '#/components/schemas/sid_KP'
+          description: The SID of the outbound Participant resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KP[0-9a-fA-F]{32}$
+          type: string
         outbound_resource_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the outbound Message resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         outbound_resource_status:
-          $ref: '#/components/schemas/message_interaction_resource_status'
+          description: The outbound resource status
+          enum:
+          - accepted
+          - answered
+          - busy
+          - canceled
+          - completed
+          - deleted
+          - delivered
+          - delivery-unknown
+          - failed
+          - in-progress
+          - initiated
+          - no-answer
+          - queued
+          - received
+          - receiving
+          - ringing
+          - scheduled
+          - sending
+          - sent
+          - undelivered
+          - unknown
+          nullable: true
+          type: string
         outbound_resource_type:
-          $ref: '#/components/schemas/string'
+          description: The outbound resource type
+          nullable: true
+          type: string
         outbound_resource_url:
-          $ref: '#/components/schemas/url'
+          description: The URL of the Twilio message resource
+          format: uri
+          nullable: true
+          type: string
         participant_sid:
-          $ref: '#/components/schemas/sid_KP'
+          description: The SID of the Participant resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KP[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_KS'
+          description: The SID of the resource's parent Service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KS[0-9a-fA-F]{32}$
+          type: string
         session_sid:
-          $ref: '#/components/schemas/sid_KC'
+          description: The SID of the resource's parent Session
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KC[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_KI'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KI[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/message_interaction_type'
+          description: The Type of Message Interaction
+          enum:
+          - message
+          - voice
+          - unknown
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the MessageInteraction resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     proxy.v1.service.short_code:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         capabilities:
-          $ref: '#/components/schemas/phone_number_capabilities'
+          description: The capabilities of the short code
+          nullable: true
+          properties:
+            fax:
+              type: boolean
+            mms:
+              type: boolean
+            sms:
+              type: boolean
+            voice:
+              type: boolean
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         is_reserved:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the short code should be reserved for manual assignment
+            to participants only
+          nullable: true
+          type: boolean
         iso_country:
-          $ref: '#/components/schemas/string'
+          description: The ISO Country Code
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_KS'
+          description: The SID of the resource's parent Service
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^KS[0-9a-fA-F]{32}$
+          type: string
         short_code:
-          $ref: '#/components/schemas/string'
+          description: The short code's number
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_SC'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SC[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the ShortCode resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    service_geo_match_level:
-      enum:
-      - area-code
-      - overlay
-      - radius
-      - country
-      nullable: true
-      type: string
-    service_number_selection_behavior:
-      enum:
-      - avoid-sticky
-      - prefer-sticky
-      nullable: true
-      type: string
-    session_mode:
-      enum:
-      - message-only
-      - voice-only
-      - voice-and-message
-      nullable: true
-      type: string
-    session_status:
-      enum:
-      - open
-      - in-progress
-      - closed
-      - failed
-      - unknown
-      nullable: true
-      type: string
-    sid:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_KC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^KC[0-9a-fA-F]{32}$
-      type: string
-    sid_KI:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^KI[0-9a-fA-F]{32}$
-      type: string
-    sid_KP:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^KP[0-9a-fA-F]{32}$
-      type: string
-    sid_KS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^KS[0-9a-fA-F]{32}$
-      type: string
-    sid_PN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^PN[0-9a-fA-F]{32}$
-      type: string
-    sid_SC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^SC[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_serverless_v1.yaml
+++ b/spec/yaml/twilio_serverless_v1.yaml
@@ -1,377 +1,704 @@
 components:
   schemas:
-    asset_version_visibility:
-      enum:
-      - public
-      - private
-      - protected
-      nullable: true
-      type: string
-    boolean:
-      nullable: true
-      type: boolean
-    build_runtime:
-      enum:
-      - node8
-      - node10
-      - node12
-      nullable: true
-      type: string
-    build_status:
-      enum:
-      - building
-      - completed
-      - failed
-      nullable: true
-      type: string
-    build_status_status:
-      enum:
-      - building
-      - completed
-      - failed
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    function_version_visibility:
-      enum:
-      - public
-      - private
-      - protected
-      nullable: true
-      type: string
-    log_level:
-      enum:
-      - info
-      - warn
-      - error
-      nullable: true
-      type: string
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
     serverless.v1.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Service resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Service resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Service resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Service resource
+          nullable: true
+          type: string
         include_credentials:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to inject Account credentials into a function invocation
+            context
+          nullable: true
+          type: boolean
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Service's nested resources
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The unique string that identifies the Service resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         ui_editable:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Service resource's properties and subresources
+            can be edited via the UI
+          nullable: true
+          type: boolean
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: A user-defined string that uniquely identifies the Service
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Service resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.asset:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Asset resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Asset resource was
+            created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Asset resource was
+            last updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Asset resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Asset resource's nested resources
+          nullable: true
+          type: object
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Asset resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZH'
+          description: The unique string that identifies the Asset resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZH[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Asset resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.asset.asset_version:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Asset Version resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         asset_sid:
-          $ref: '#/components/schemas/sid_ZH'
+          description: The SID of the Asset resource that is the parent of the Asset
+            Version
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZH[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Asset Version resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         path:
-          $ref: '#/components/schemas/string'
+          description: The URL-friendly string by which the Asset Version can be referenced
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Asset Version resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZN'
+          description: The unique string that identifies the Asset Version resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Asset Version resource
+          format: uri
+          nullable: true
+          type: string
         visibility:
-          $ref: '#/components/schemas/asset_version_visibility'
+          description: The access control that determines how the Asset Version can
+            be accessed
+          enum:
+          - public
+          - private
+          - protected
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.build:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Build resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         asset_versions:
-          $ref: '#/components/schemas/object_list'
+          description: The list of Asset Version resource SIDs that are included in
+            the Build
+          items:
+            type: object
+          nullable: true
+          type: array
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Build resource was
+            created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Build resource was
+            last updated
+          format: date-time
+          nullable: true
+          type: string
         dependencies:
-          $ref: '#/components/schemas/object_list'
+          description: A list of objects that describe the Dependencies included in
+            the Build
+          items:
+            type: object
+          nullable: true
+          type: array
         function_versions:
-          $ref: '#/components/schemas/object_list'
+          description: The list of Function Version resource SIDs that are included
+            in the Build
+          items:
+            type: object
+          nullable: true
+          type: array
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         runtime:
-          $ref: '#/components/schemas/build_runtime'
+          description: The Runtime version that will be used to run the Build.
+          enum:
+          - node8
+          - node10
+          - node12
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Build resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZB'
+          description: The unique string that identifies the Build resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZB[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/build_status'
+          description: The status of the Build
+          enum:
+          - building
+          - completed
+          - failed
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Build resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.build.build_status:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Build resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Build resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZB'
+          description: The unique string that identifies the Build resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZB[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/build_status_status'
+          description: The status of the Build
+          enum:
+          - building
+          - completed
+          - failed
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Build Status resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.environment:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Environment resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         build_sid:
-          $ref: '#/components/schemas/sid_ZB'
+          description: The SID of the build deployed in the environment
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZB[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Environment resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Environment resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         domain_name:
-          $ref: '#/components/schemas/string'
+          description: The base domain name for all Functions and Assets deployed
+            in the Environment
+          nullable: true
+          type: string
         domain_suffix:
-          $ref: '#/components/schemas/string'
+          description: A URL-friendly name that represents the environment
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Environment resource's nested resources
+          nullable: true
+          type: object
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Environment resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZE'
+          description: The unique string that identifies the Environment resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZE[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: A user-defined string that uniquely identifies the Environment
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Environment resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.environment.deployment:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Deployment resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         build_sid:
-          $ref: '#/components/schemas/sid_ZB'
+          description: The SID of the Build for the deployment
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZB[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Deployment resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Deployment resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         environment_sid:
-          $ref: '#/components/schemas/sid_ZE'
+          description: The SID of the Environment for the Deployment
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZE[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Deployment resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZD'
+          description: The unique string that identifies the Deployment resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZD[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Deployment resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.environment.log:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Log resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         build_sid:
-          $ref: '#/components/schemas/sid_ZB'
+          description: The SID of the build that corresponds to the log
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZB[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Log resource was
+            created
+          format: date-time
+          nullable: true
+          type: string
         deployment_sid:
-          $ref: '#/components/schemas/sid_ZD'
+          description: The SID of the deployment that corresponds to the log
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZD[0-9a-fA-F]{32}$
+          type: string
         environment_sid:
-          $ref: '#/components/schemas/sid_ZE'
+          description: The SID of the environment in which the log occurred
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZE[0-9a-fA-F]{32}$
+          type: string
         function_sid:
-          $ref: '#/components/schemas/sid_ZH'
+          description: The SID of the function whose invocation produced the log
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZH[0-9a-fA-F]{32}$
+          type: string
         level:
-          $ref: '#/components/schemas/log_level'
+          description: The log level
+          enum:
+          - info
+          - warn
+          - error
+          nullable: true
+          type: string
         message:
-          $ref: '#/components/schemas/string'
+          description: The log message
+          nullable: true
+          type: string
         request_sid:
-          $ref: '#/components/schemas/sid_RQ'
+          description: The SID of the request associated with the log
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RQ[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Log resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_NO'
+          description: The unique string that identifies the Log resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NO[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Log resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.environment.variable:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Variable resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Variable resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Variable resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         environment_sid:
-          $ref: '#/components/schemas/sid_ZE'
+          description: The SID of the Environment in which the Variable exists
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZE[0-9a-fA-F]{32}$
+          type: string
         key:
-          $ref: '#/components/schemas/string'
+          description: A string by which the Variable resource can be referenced
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Variable resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZV'
+          description: The unique string that identifies the Variable resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZV[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Variable resource
+          format: uri
+          nullable: true
+          type: string
         value:
-          $ref: '#/components/schemas/string'
+          description: A string that contains the actual value of the Variable
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.function:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Function resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Function resource
+            was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Function resource
+            was last updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Function resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of nested resources of the Function resource
+          nullable: true
+          type: object
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Function resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZH'
+          description: The unique string that identifies the Function resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZH[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Function resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.function.function_version:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Function Version resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Function Version
+            resource was created
+          format: date-time
+          nullable: true
+          type: string
         function_sid:
-          $ref: '#/components/schemas/sid_ZH'
+          description: The SID of the Function resource that is the parent of the
+            Function Version resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZH[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         path:
-          $ref: '#/components/schemas/string'
+          description: The URL-friendly string by which the Function Version resource
+            can be referenced
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Function Version resource is
+            associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZN'
+          description: The unique string that identifies the Function Version resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Function Version resource
+          format: uri
+          nullable: true
+          type: string
         visibility:
-          $ref: '#/components/schemas/function_version_visibility'
+          description: The access control that determines how the Function Version
+            resource can be accessed
+          enum:
+          - public
+          - private
+          - protected
+          nullable: true
+          type: string
       type: object
     serverless.v1.service.function.function_version.function_version_content:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the Function Version resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         content:
-          $ref: '#/components/schemas/string'
+          description: The content of the Function Version resource
+          nullable: true
+          type: string
         function_sid:
-          $ref: '#/components/schemas/sid_ZH'
+          description: The SID of the Function that is the parent of the Function
+            Version
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZH[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_ZS'
+          description: The SID of the Service that the Function Version resource is
+            associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ZN'
+          description: The unique string that identifies the Function Version resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ZN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_NO:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^NO[0-9a-fA-F]{32}$
-      type: string
-    sid_RQ:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RQ[0-9a-fA-F]{32}$
-      type: string
-    sid_ZB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ZB[0-9a-fA-F]{32}$
-      type: string
-    sid_ZD:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ZD[0-9a-fA-F]{32}$
-      type: string
-    sid_ZE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ZE[0-9a-fA-F]{32}$
-      type: string
-    sid_ZH:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ZH[0-9a-fA-F]{32}$
-      type: string
-    sid_ZN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ZN[0-9a-fA-F]{32}$
-      type: string
-    sid_ZS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ZS[0-9a-fA-F]{32}$
-      type: string
-    sid_ZV:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ZV[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_studio_v1.yaml
+++ b/spec/yaml/twilio_studio_v1.yaml
@@ -1,254 +1,471 @@
 components:
   schemas:
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    engagement_status:
-      enum:
-      - active
-      - ended
-      nullable: true
-      type: string
-    execution_status:
-      enum:
-      - active
-      - ended
-      nullable: true
-      type: string
-    flow_status:
-      enum:
-      - draft
-      - published
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_FC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FC[0-9a-fA-F]{32}$
-      type: string
-    sid_FN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FN[0-9a-fA-F]{32}$
-      type: string
-    sid_FT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FT[0-9a-fA-F]{32}$
-      type: string
-    sid_FW:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FW[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
     studio.v1.flow:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Flow
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/flow_status'
+          description: The status of the Flow
+          enum:
+          - draft
+          - published
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         version:
-          $ref: '#/components/schemas/integer'
+          description: The latest version number of the Flow's definition
+          nullable: true
+          type: integer
       type: object
     studio.v1.flow.engagement:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         contact_channel_address:
-          $ref: '#/components/schemas/string'
+          description: The phone number, SIP address or Client identifier that triggered
+            this Engagement
+          nullable: true
+          type: string
         contact_sid:
-          $ref: '#/components/schemas/sid_FC'
+          description: The SID of the Contact
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the execution flow
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Engagement was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Engagement was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Engagement's nested resources
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/engagement_status'
+          description: The status of the Engagement
+          enum:
+          - active
+          - ended
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v1.flow.engagement.engagement_context:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: Account SID
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: Flow state
+          nullable: true
+          type: object
         engagement_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: Engagement SID
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: Flow SID
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v1.flow.engagement.step:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         engagement_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The SID of the Engagement
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         name:
-          $ref: '#/components/schemas/string'
+          description: The event that caused the Flow to transition to the Step
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_FT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FT[0-9a-fA-F]{32}$
+          type: string
         transitioned_from:
-          $ref: '#/components/schemas/string'
+          description: The Widget that preceded the Widget for the Step
+          nullable: true
+          type: string
         transitioned_to:
-          $ref: '#/components/schemas/string'
+          description: The Widget that will follow the Widget for the Step
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v1.flow.engagement.step.step_context:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         engagement_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The SID of the Engagement
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         step_sid:
-          $ref: '#/components/schemas/sid_FT'
+          description: Step SID
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FT[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v1.flow.execution:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         contact_channel_address:
-          $ref: '#/components/schemas/string'
+          description: The phone number, SIP address or Client identifier that triggered
+            the Execution
+          nullable: true
+          type: string
         contact_sid:
-          $ref: '#/components/schemas/sid_FC'
+          description: The SID of the Contact
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/execution_status'
+          description: The status of the Execution
+          enum:
+          - active
+          - ended
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v1.flow.execution.execution_context:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         execution_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The SID of the Execution
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v1.flow.execution.execution_step:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         execution_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The SID of the Execution
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         name:
-          $ref: '#/components/schemas/string'
+          description: The event that caused the Flow to transition to the Step
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_FT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FT[0-9a-fA-F]{32}$
+          type: string
         transitioned_from:
-          $ref: '#/components/schemas/string'
+          description: The Widget that preceded the Widget for the Step
+          nullable: true
+          type: string
         transitioned_to:
-          $ref: '#/components/schemas/string'
+          description: The Widget that will follow the Widget for the Step
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v1.flow.execution.execution_step.execution_step_context:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         execution_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The SID of the Execution
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         step_sid:
-          $ref: '#/components/schemas/sid_FT'
+          description: Step SID
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FT[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_studio_v2.yaml
+++ b/spec/yaml/twilio_studio_v2.yaml
@@ -1,232 +1,380 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    execution_status:
-      enum:
-      - active
-      - ended
-      nullable: true
-      type: string
-    flow_revision_status:
-      enum:
-      - draft
-      - published
-      nullable: true
-      type: string
-    flow_status:
-      enum:
-      - draft
-      - published
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_FN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FN[0-9a-fA-F]{32}$
-      type: string
-    sid_FT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FT[0-9a-fA-F]{32}$
-      type: string
-    sid_FW:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^FW[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
     studio.v2.flow:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         commit_message:
-          $ref: '#/components/schemas/string'
+          description: Description of change made in the revision
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         definition:
-          $ref: '#/components/schemas/object'
+          description: JSON representation of flow definition
+          nullable: true
+          type: object
         errors:
-          $ref: '#/components/schemas/object_list'
+          description: List of error in the flow definition
+          items:
+            type: object
+          nullable: true
+          type: array
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Flow
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs
+          nullable: true
+          type: object
         revision:
-          $ref: '#/components/schemas/integer'
+          description: The latest revision number of the Flow's definition
+          nullable: true
+          type: integer
         sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/flow_status'
+          description: The status of the Flow
+          enum:
+          - draft
+          - published
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         valid:
-          $ref: '#/components/schemas/boolean'
+          description: Boolean if the flow definition is valid
+          nullable: true
+          type: boolean
         warnings:
-          $ref: '#/components/schemas/object_list'
+          description: List of warnings in the flow definition
+          items:
+            type: object
+          nullable: true
+          type: array
         webhook_url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v2.flow.execution:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         contact_channel_address:
-          $ref: '#/components/schemas/string'
+          description: The phone number, SIP address or Client identifier that triggered
+            the Execution
+          nullable: true
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/execution_status'
+          description: The status of the Execution
+          enum:
+          - active
+          - ended
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v2.flow.execution.execution_context:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         execution_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The SID of the Execution
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v2.flow.execution.execution_step:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         execution_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The SID of the Execution
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         name:
-          $ref: '#/components/schemas/string'
+          description: The event that caused the Flow to transition to the Step
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_FT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FT[0-9a-fA-F]{32}$
+          type: string
         transitioned_from:
-          $ref: '#/components/schemas/string'
+          description: The Widget that preceded the Widget for the Step
+          nullable: true
+          type: string
         transitioned_to:
-          $ref: '#/components/schemas/string'
+          description: The Widget that will follow the Widget for the Step
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v2.flow.execution.execution_step.execution_step_context:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         context:
-          $ref: '#/components/schemas/object'
+          description: The current state of the flow
+          nullable: true
+          type: object
         execution_sid:
-          $ref: '#/components/schemas/sid_FN'
+          description: The SID of the Execution
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FN[0-9a-fA-F]{32}$
+          type: string
         flow_sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The SID of the Flow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         step_sid:
-          $ref: '#/components/schemas/sid_FT'
+          description: Step SID
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FT[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v2.flow.flow_revision:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         commit_message:
-          $ref: '#/components/schemas/string'
+          description: Description of change made in the revision
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         definition:
-          $ref: '#/components/schemas/object'
+          description: JSON representation of flow definition
+          nullable: true
+          type: object
         errors:
-          $ref: '#/components/schemas/object_list'
+          description: List of error in the flow definition
+          items:
+            type: object
+          nullable: true
+          type: array
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Flow
+          nullable: true
+          type: string
         revision:
-          $ref: '#/components/schemas/integer'
+          description: The latest revision number of the Flow's definition
+          nullable: true
+          type: integer
         sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/flow_revision_status'
+          description: The status of the Flow
+          enum:
+          - draft
+          - published
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         valid:
-          $ref: '#/components/schemas/boolean'
+          description: Boolean if the flow definition is valid
+          nullable: true
+          type: boolean
       type: object
     studio.v2.flow.test_user:
       properties:
         sid:
-          $ref: '#/components/schemas/sid_FW'
+          description: Unique identifier of the flow.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^FW[0-9a-fA-F]{32}$
+          type: string
         test_users:
-          $ref: '#/components/schemas/string_list'
+          description: List of test user identities that can test draft versions of
+            the flow.
+          items:
+            type: string
+          nullable: true
+          type: array
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     studio.v2.flow_validate:
       properties:
         valid:
-          $ref: '#/components/schemas/boolean'
+          description: Boolean if the flow definition is valid
+          nullable: true
+          type: boolean
       type: object
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_supersim_v1.yaml
+++ b/spec/yaml/twilio_supersim_v1.yaml
@@ -1,251 +1,369 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    command_direction:
-      enum:
-      - to_sim
-      - from_sim
-      nullable: true
-      type: string
-    command_status:
-      enum:
-      - queued
-      - sent
-      - delivered
-      - received
-      - failed
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    fleet_data_metering:
-      enum:
-      - payg
-      nullable: true
-      type: string
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    iso_country_code:
-      nullable: true
-      type: string
-    long:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_HA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^HA[0-9a-fA-F]{32}$
-      type: string
-    sid_HC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^HC[0-9a-fA-F]{32}$
-      type: string
-    sid_HF:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^HF[0-9a-fA-F]{32}$
-      type: string
-    sid_HS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^HS[0-9a-fA-F]{32}$
-      type: string
-    sid_HW:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^HW[0-9a-fA-F]{32}$
-      type: string
-    sim_status:
-      enum:
-      - new
-      - ready
-      - active
-      - inactive
-      - scheduled
-      nullable: true
-      type: string
-    string:
-      nullable: true
-      type: string
     supersim.v1.command:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         command:
-          $ref: '#/components/schemas/string'
+          description: The message body of the command sent to or from the SIM
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         direction:
-          $ref: '#/components/schemas/command_direction'
+          description: The direction of the Command
+          enum:
+          - to_sim
+          - from_sim
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_HC'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HC[0-9a-fA-F]{32}$
+          type: string
         sim_sid:
-          $ref: '#/components/schemas/sid_HS'
+          description: The SID of the SIM that this Command was sent to or from
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HS[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/command_status'
+          description: The status of the Command
+          enum:
+          - queued
+          - sent
+          - delivered
+          - received
+          - failed
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Command resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     supersim.v1.fleet:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         commands_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Defines whether SIMs in the Fleet are capable of sending and
+            receiving machine-to-machine SMS via Commands
+          nullable: true
+          type: boolean
         commands_method:
-          $ref: '#/components/schemas/http_method'
+          description: A string representing the HTTP method to use when making a
+            request to `commands_url`
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         commands_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that will receive a webhook when a Super SIM in the
+            Fleet is used to send an SMS from your device to the Commands number
+          format: uri
+          nullable: true
+          type: string
         data_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Defines whether SIMs in the Fleet are capable of using data
+            connectivity
+          nullable: true
+          type: boolean
         data_limit:
-          $ref: '#/components/schemas/integer'
+          description: The total data usage (download and upload combined) in Megabytes
+            that each Sim resource assigned to the Fleet resource can consume
+          nullable: true
+          type: integer
         data_metering:
-          $ref: '#/components/schemas/fleet_data_metering'
+          description: The model by which a SIM is metered and billed
+          enum:
+          - payg
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         network_access_profile_sid:
-          $ref: '#/components/schemas/sid_HA'
+          description: The SID of the Network Access Profile of the Fleet
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_HF'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HF[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Fleet resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     supersim.v1.network:
       properties:
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human readable identifier of this resource
+          nullable: true
+          type: string
         identifiers:
-          $ref: '#/components/schemas/object_list'
+          description: The MCC/MNCs included in the Network resource
+          items:
+            type: object
+          nullable: true
+          type: array
         iso_country:
-          $ref: '#/components/schemas/string'
+          description: The ISO country code of the Network resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_HW'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HW[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Network resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     supersim.v1.network_access_profile:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that the Network Access Profile belongs
+            to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_HA'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HA[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     supersim.v1.network_access_profile.network_access_profile_network:
       properties:
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human readable identifier of this resource
+          nullable: true
+          type: string
         identifiers:
-          $ref: '#/components/schemas/object_list'
+          description: The MCC/MNCs included in the resource
+          items:
+            type: object
+          nullable: true
+          type: array
         iso_country:
-          $ref: '#/components/schemas/string'
+          description: The ISO country code of the Network resource
+          nullable: true
+          type: string
         network_access_profile_sid:
-          $ref: '#/components/schemas/sid_HA'
+          description: The unique string that identifies the Network Access Profile
+            resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_HW'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HW[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     supersim.v1.sim:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that the Super SIM belongs to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         fleet_sid:
-          $ref: '#/components/schemas/sid_HF'
+          description: The unique ID of the Fleet configured for this SIM
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HF[0-9a-fA-F]{32}$
+          type: string
         iccid:
-          $ref: '#/components/schemas/string'
+          description: The ICCID associated with the SIM
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_HS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HS[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/sim_status'
+          description: The status of the Super SIM
+          enum:
+          - new
+          - ready
+          - active
+          - inactive
+          - scheduled
+          nullable: true
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Sim Resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     supersim.v1.usage_record:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that incurred the usage.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         data_download:
-          $ref: '#/components/schemas/long'
+          description: Total data downloaded in bytes, aggregated by the query parameters.
+          nullable: true
+          type: integer
         data_total:
-          $ref: '#/components/schemas/long'
+          description: Total of data_upload and data_download.
+          nullable: true
+          type: integer
         data_upload:
-          $ref: '#/components/schemas/long'
+          description: Total data uploaded in bytes, aggregated by the query parameters.
+          nullable: true
+          type: integer
         fleet_sid:
-          $ref: '#/components/schemas/sid_HF'
+          description: SID of the Fleet resource on which the usage occurred.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HF[0-9a-fA-F]{32}$
+          type: string
         iso_country:
-          $ref: '#/components/schemas/iso_country_code'
+          description: Alpha-2 ISO Country Code of the country the usage occurred
+            in.
+          nullable: true
+          type: string
         network_sid:
-          $ref: '#/components/schemas/sid_HW'
+          description: SID of the Network resource on which the usage occurred.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HW[0-9a-fA-F]{32}$
+          type: string
         period:
-          $ref: '#/components/schemas/object'
+          description: The time period for which the usage is reported.
+          nullable: true
+          type: object
         sim_sid:
-          $ref: '#/components/schemas/sid_HS'
+          description: SID of a Sim resource to which the UsageRecord belongs.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HS[0-9a-fA-F]{32}$
+          type: string
       type: object
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_sync_v1.yaml
+++ b/spec/yaml/twilio_sync_v1.yaml
@@ -1,315 +1,611 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_ES:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ES[0-9a-fA-F]{32}$
-      type: string
-    sid_ET:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^ET[0-9a-fA-F]{32}$
-      type: string
-    sid_IS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IS[0-9a-fA-F]{32}$
-      type: string
-    sid_MP:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MP[0-9a-fA-F]{32}$
-      type: string
-    sid_TO:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^TO[0-9a-fA-F]{32}$
-      type: string
-    sid_TZ:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^TZ[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
     sync.v1.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         acl_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether token identities in the Service must be granted access
+            to Sync objects by using the Permissions resource
+          nullable: true
+          type: boolean
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         reachability_debouncing_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether every endpoint_disconnected event occurs after a configurable
+            delay
+          nullable: true
+          type: boolean
         reachability_debouncing_window:
-          $ref: '#/components/schemas/integer'
+          description: The reachability event delay in milliseconds
+          nullable: true
+          type: integer
         reachability_webhooks_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the service instance calls webhook_url when client
+            endpoints connect to Sync
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Service resource
+          format: uri
+          nullable: true
+          type: string
         webhook_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when Sync objects are manipulated
+          format: uri
+          nullable: true
+          type: string
         webhooks_from_rest_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Service instance should call webhook_url when the
+            REST API is used to update Sync objects
+          nullable: true
+          type: boolean
       type: object
     sync.v1.service.document:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the Sync Document's creator
+          nullable: true
+          type: string
         data:
-          $ref: '#/components/schemas/object'
+          description: An arbitrary, schema-less object that the Sync Document stores
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_expires:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Sync Document expires
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of resources related to the Sync Document
+          nullable: true
+          type: object
         revision:
-          $ref: '#/components/schemas/string'
+          description: The current revision of the Sync Document, represented by a
+            string identifier
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ET'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ET[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Document resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     sync.v1.service.document.document_permission:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         document_sid:
-          $ref: '#/components/schemas/sid_ET'
+          description: The Sync Document SID
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ET[0-9a-fA-F]{32}$
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The identity of the user to whom the Sync Document Permission
+            applies
+          nullable: true
+          type: string
         manage:
-          $ref: '#/components/schemas/boolean'
+          description: Manage access
+          nullable: true
+          type: boolean
         read:
-          $ref: '#/components/schemas/boolean'
+          description: Read access
+          nullable: true
+          type: boolean
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Sync Document Permission resource
+          format: uri
+          nullable: true
+          type: string
         write:
-          $ref: '#/components/schemas/boolean'
+          description: Write access
+          nullable: true
+          type: boolean
       type: object
     sync.v1.service.sync_list:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the Sync List's creator
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_expires:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Sync List expires
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Sync List's nested resources
+          nullable: true
+          type: object
         revision:
-          $ref: '#/components/schemas/string'
+          description: The current revision of the Sync List, represented as a string
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_ES'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ES[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Sync List resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     sync.v1.service.sync_list.sync_list_item:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the List Item's creator
+          nullable: true
+          type: string
         data:
-          $ref: '#/components/schemas/object'
+          description: An arbitrary, schema-less object that the List Item stores
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_expires:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the List Item expires
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         index:
-          $ref: '#/components/schemas/integer'
+          description: The automatically generated index of the List Item
+          nullable: true
+          type: integer
         list_sid:
-          $ref: '#/components/schemas/sid_ES'
+          description: The SID of the Sync List that contains the List Item
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ES[0-9a-fA-F]{32}$
+          type: string
         revision:
-          $ref: '#/components/schemas/string'
+          description: The current revision of the item, represented as a string
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the List Item resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     sync.v1.service.sync_list.sync_list_permission:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The identity of the user to whom the Sync List Permission applies
+          nullable: true
+          type: string
         list_sid:
-          $ref: '#/components/schemas/sid_ES'
+          description: The SID of the Sync List to which the Permission applies
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^ES[0-9a-fA-F]{32}$
+          type: string
         manage:
-          $ref: '#/components/schemas/boolean'
+          description: Manage access
+          nullable: true
+          type: boolean
         read:
-          $ref: '#/components/schemas/boolean'
+          description: Read access
+          nullable: true
+          type: boolean
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Sync List Permission resource
+          format: uri
+          nullable: true
+          type: string
         write:
-          $ref: '#/components/schemas/boolean'
+          description: Write access
+          nullable: true
+          type: boolean
       type: object
     sync.v1.service.sync_map:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the Sync Map's creator
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_expires:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Sync Map expires
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Sync Map's nested resources
+          nullable: true
+          type: object
         revision:
-          $ref: '#/components/schemas/string'
+          description: The current revision of the Sync Map, represented as a string
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MP'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MP[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Sync Map resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     sync.v1.service.sync_map.sync_map_item:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The identity of the Map Item's creator
+          nullable: true
+          type: string
         data:
-          $ref: '#/components/schemas/object'
+          description: An arbitrary, schema-less object that the Map Item stores
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_expires:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Map Item expires
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         key:
-          $ref: '#/components/schemas/string'
+          description: The unique, user-defined key for the Map Item
+          nullable: true
+          type: string
         map_sid:
-          $ref: '#/components/schemas/sid_MP'
+          description: The SID of the Sync Map that contains the Map Item
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MP[0-9a-fA-F]{32}$
+          type: string
         revision:
-          $ref: '#/components/schemas/string'
+          description: The current revision of the Map Item, represented as a string
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Map Item resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     sync.v1.service.sync_map.sync_map_permission:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The identity of the user to whom the Sync Document Permission
+            applies
+          nullable: true
+          type: string
         manage:
-          $ref: '#/components/schemas/boolean'
+          description: Manage access
+          nullable: true
+          type: boolean
         map_sid:
-          $ref: '#/components/schemas/sid_MP'
+          description: Sync Map SID
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MP[0-9a-fA-F]{32}$
+          type: string
         read:
-          $ref: '#/components/schemas/boolean'
+          description: Read access
+          nullable: true
+          type: boolean
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Sync Map Permission resource
+          format: uri
+          nullable: true
+          type: string
         write:
-          $ref: '#/components/schemas/boolean'
+          description: Write access
+          nullable: true
+          type: boolean
       type: object
     sync.v1.service.sync_stream:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         created_by:
-          $ref: '#/components/schemas/string'
+          description: The Identity of the Stream's creator
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_expires:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Message Stream expires
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Stream's nested resources
+          nullable: true
+          type: object
         service_sid:
-          $ref: '#/components/schemas/sid_IS'
+          description: The SID of the Sync Service that the resource is associated
+            with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IS[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_TO'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TO[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Message Stream resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     sync.v1.service.sync_stream.stream_message:
       properties:
         data:
-          $ref: '#/components/schemas/object'
+          description: Stream Message body
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_TZ'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TZ[0-9a-fA-F]{32}$
+          type: string
       type: object
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_taskrouter_v1.yaml
+++ b/spec/yaml/twilio_taskrouter_v1.yaml
@@ -1,817 +1,1675 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    long:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    sid:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_EV:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^EV[0-9a-fA-F]{32}$
-      type: string
-    sid_TC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^TC[0-9a-fA-F]{32}$
-      type: string
-    sid_WA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WA[0-9a-fA-F]{32}$
-      type: string
-    sid_WC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WC[0-9a-fA-F]{32}$
-      type: string
-    sid_WK:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WK[0-9a-fA-F]{32}$
-      type: string
-    sid_WQ:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WQ[0-9a-fA-F]{32}$
-      type: string
-    sid_WR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WR[0-9a-fA-F]{32}$
-      type: string
-    sid_WS:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WS[0-9a-fA-F]{32}$
-      type: string
-    sid_WT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WT[0-9a-fA-F]{32}$
-      type: string
-    sid_WW:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WW[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    task_queue_task_order:
-      enum:
-      - FIFO
-      - LIFO
-      nullable: true
-      type: string
-    task_reservation_status:
-      enum:
-      - pending
-      - accepted
-      - rejected
-      - timeout
-      - canceled
-      - rescinded
-      - wrapping
-      - completed
-      nullable: true
-      type: string
-    task_status:
-      enum:
-      - pending
-      - reserved
-      - assigned
-      - canceled
-      - completed
-      - wrapping
-      nullable: true
-      type: string
     taskrouter.v1.workspace:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         default_activity_name:
-          $ref: '#/components/schemas/string'
+          description: The name of the default activity
+          nullable: true
+          type: string
         default_activity_sid:
-          $ref: '#/components/schemas/sid_WA'
+          description: The SID of the Activity that will be used when new Workers
+            are created in the Workspace
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WA[0-9a-fA-F]{32}$
+          type: string
         event_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an event occurs
+          format: uri
+          nullable: true
+          type: string
         events_filter:
-          $ref: '#/components/schemas/string'
+          description: The list of Workspace events for which to call event_callback_url
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Workspace resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         multi_task_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether multi-tasking is enabled
+          nullable: true
+          type: boolean
         prioritize_queue_order:
-          $ref: '#/components/schemas/workspace_queue_order'
+          description: The type of TaskQueue to prioritize when Workers are receiving
+            Tasks from both types of TaskQueues
+          enum:
+          - FIFO
+          - LIFO
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
         timeout_activity_name:
-          $ref: '#/components/schemas/string'
+          description: The name of the timeout activity
+          nullable: true
+          type: string
         timeout_activity_sid:
-          $ref: '#/components/schemas/sid_WA'
+          description: The SID of the Activity that will be assigned to a Worker when
+            a Task reservation times out without a response
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WA[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workspace resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     taskrouter.v1.workspace.activity:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         available:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Worker should be eligible to receive a Task when
+            it occupies the Activity
+          nullable: true
+          type: boolean
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Activity resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WA'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WA[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Activity resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Activity
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.event:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         actor_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the resource that triggered the event
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         actor_type:
-          $ref: '#/components/schemas/string'
+          description: The type of resource that triggered the event
+          nullable: true
+          type: string
         actor_url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource that triggered the event
+          format: uri
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: A description of the event
+          nullable: true
+          type: string
         event_data:
-          $ref: '#/components/schemas/object'
+          description: Data about the event
+          nullable: true
+          type: object
         event_date:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The time the event was sent
+          format: date-time
+          nullable: true
+          type: string
         event_date_ms:
-          $ref: '#/components/schemas/long'
+          description: The time the event was sent in milliseconds
+          nullable: true
+          type: integer
         event_type:
-          $ref: '#/components/schemas/string'
+          description: The identifier for the event
+          nullable: true
+          type: string
         resource_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the object the event is most relevant to
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         resource_type:
-          $ref: '#/components/schemas/string'
+          description: The type of object the event is most relevant to
+          nullable: true
+          type: string
         resource_url:
-          $ref: '#/components/schemas/url'
+          description: The URL of the resource the event is most relevant to
+          format: uri
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_EV'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^EV[0-9a-fA-F]{32}$
+          type: string
         source:
-          $ref: '#/components/schemas/string'
+          description: Where the Event originated
+          nullable: true
+          type: string
         source_ip_address:
-          $ref: '#/components/schemas/string'
+          description: The IP from which the Event originated
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Event resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Event
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.task:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         addons:
-          $ref: '#/components/schemas/string'
+          description: An object that contains the addon data for all installed addons
+          nullable: true
+          type: string
         age:
-          $ref: '#/components/schemas/integer'
+          description: The number of seconds since the Task was created
+          nullable: true
+          type: integer
         assignment_status:
-          $ref: '#/components/schemas/task_status'
+          description: The current status of the Task's assignment
+          enum:
+          - pending
+          - reserved
+          - assigned
+          - canceled
+          - completed
+          - wrapping
+          nullable: true
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string with custom attributes of the work
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         priority:
-          $ref: '#/components/schemas/integer'
+          description: Retrieve the list of all Tasks in the Workspace with the specified
+            priority
+          nullable: true
+          type: integer
         reason:
-          $ref: '#/components/schemas/string'
+          description: The reason the Task was canceled or completed
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WT[0-9a-fA-F]{32}$
+          type: string
         task_channel_sid:
-          $ref: '#/components/schemas/sid_TC'
+          description: The SID of the TaskChannel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TC[0-9a-fA-F]{32}$
+          type: string
         task_channel_unique_name:
-          $ref: '#/components/schemas/string'
+          description: The unique name of the TaskChannel
+          nullable: true
+          type: string
         task_queue_entered_date:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Task entered the
+            TaskQueue.
+          format: date-time
+          nullable: true
+          type: string
         task_queue_friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly name of the TaskQueue
+          nullable: true
+          type: string
         task_queue_sid:
-          $ref: '#/components/schemas/sid_WQ'
+          description: The SID of the TaskQueue
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WQ[0-9a-fA-F]{32}$
+          type: string
         timeout:
-          $ref: '#/components/schemas/integer'
+          description: The amount of time in seconds that the Task can live before
+            being assigned
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Task resource
+          format: uri
+          nullable: true
+          type: string
         workflow_friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly name of the Workflow that is controlling the Task
+          nullable: true
+          type: string
         workflow_sid:
-          $ref: '#/components/schemas/sid_WW'
+          description: The SID of the Workflow that is controlling the Task
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WW[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Task
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.task.task_reservation:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         reservation_status:
-          $ref: '#/components/schemas/task_reservation_status'
+          description: The current status of the reservation
+          enum:
+          - pending
+          - accepted
+          - rejected
+          - timeout
+          - canceled
+          - rescinded
+          - wrapping
+          - completed
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WR[0-9a-fA-F]{32}$
+          type: string
         task_sid:
-          $ref: '#/components/schemas/sid_WT'
+          description: The SID of the reserved Task resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WT[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the TaskReservation reservation
+          format: uri
+          nullable: true
+          type: string
         worker_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly_name of the Worker that is reserved
+          nullable: true
+          type: string
         worker_sid:
-          $ref: '#/components/schemas/sid_WK'
+          description: The SID of the reserved Worker resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WK[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that this task is contained within.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.task_channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_optimized_routing:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Task Channel will prioritize Workers that have
+            been idle
+          nullable: true
+          type: boolean
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_TC'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TC[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            Task Channel
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Task Channel resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Task Channel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.task_queue:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assignment_activity_name:
-          $ref: '#/components/schemas/string'
+          description: The name of the Activity to assign Workers when a task is assigned
+            for them
+          nullable: true
+          type: string
         assignment_activity_sid:
-          $ref: '#/components/schemas/sid_WA'
+          description: The SID of the Activity to assign Workers when a task is assigned
+            for them
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WA[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         max_reserved_workers:
-          $ref: '#/components/schemas/integer'
+          description: The maximum number of Workers to reserve
+          nullable: true
+          type: integer
         reservation_activity_name:
-          $ref: '#/components/schemas/string'
+          description: The name of the Activity to assign Workers once a task is reserved
+            for them
+          nullable: true
+          type: string
         reservation_activity_sid:
-          $ref: '#/components/schemas/sid_WA'
+          description: The SID of the Activity to assign Workers once a task is reserved
+            for them
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WQ'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WQ[0-9a-fA-F]{32}$
+          type: string
         target_workers:
-          $ref: '#/components/schemas/string'
+          description: A string describing the Worker selection criteria for any Tasks
+            that enter the TaskQueue
+          nullable: true
+          type: string
         task_order:
-          $ref: '#/components/schemas/task_queue_task_order'
+          description: How Tasks will be assigned to Workers
+          enum:
+          - FIFO
+          - LIFO
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the TaskQueue resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the TaskQueue
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.task_queue.task_queue_cumulative_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         avg_task_acceptance_time:
-          $ref: '#/components/schemas/integer'
+          description: The average time in seconds between Task creation and acceptance
+          nullable: true
+          type: integer
         end_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The end of the interval during which these statistics were
+            calculated
+          format: date-time
+          nullable: true
+          type: string
         reservations_accepted:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations accepted for Tasks in the
+            TaskQueue
+          nullable: true
+          type: integer
         reservations_canceled:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations canceled for Tasks in the
+            TaskQueue
+          nullable: true
+          type: integer
         reservations_created:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations created for Tasks in the TaskQueue
+          nullable: true
+          type: integer
         reservations_rejected:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations rejected for Tasks in the
+            TaskQueue
+          nullable: true
+          type: integer
         reservations_rescinded:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations rescinded
+          nullable: true
+          type: integer
         reservations_timed_out:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that timed out for Tasks in
+            the TaskQueue
+          nullable: true
+          type: integer
         split_by_wait_time:
-          $ref: '#/components/schemas/object'
+          description: A list of objects that describe the Tasks canceled and reservations
+            accepted above and below the specified thresholds
+          nullable: true
+          type: object
         start_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The beginning of the interval during which these statistics
+            were calculated
+          format: date-time
+          nullable: true
+          type: string
         task_queue_sid:
-          $ref: '#/components/schemas/sid_WQ'
+          description: The SID of the TaskQueue from which these statistics were calculated
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WQ[0-9a-fA-F]{32}$
+          type: string
         tasks_canceled:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks canceled in the TaskQueue
+          nullable: true
+          type: integer
         tasks_completed:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks completed in the TaskQueue
+          nullable: true
+          type: integer
         tasks_deleted:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks deleted in the TaskQueue
+          nullable: true
+          type: integer
         tasks_entered:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks entered into the TaskQueue
+          nullable: true
+          type: integer
         tasks_moved:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were moved from one queue to
+            another
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the TaskQueue statistics resource
+          format: uri
+          nullable: true
+          type: string
         wait_duration_in_queue_until_accepted:
-          $ref: '#/components/schemas/object'
+          description: The relative wait duration statistics for Tasks accepted while
+            in the TaskQueue
+          nullable: true
+          type: object
         wait_duration_until_accepted:
-          $ref: '#/components/schemas/object'
+          description: The wait duration statistics for Tasks accepted while in the
+            TaskQueue
+          nullable: true
+          type: object
         wait_duration_until_canceled:
-          $ref: '#/components/schemas/object'
+          description: The wait duration statistics for Tasks canceled while in the
+            TaskQueue
+          nullable: true
+          type: object
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the TaskQueue
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.task_queue.task_queue_real_time_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         activity_statistics:
-          $ref: '#/components/schemas/object_list'
+          description: The number of current Workers by Activity
+          items:
+            type: object
+          nullable: true
+          type: array
         longest_relative_task_age_in_queue:
-          $ref: '#/components/schemas/integer'
+          description: The relative age in the TaskQueue for the longest waiting Task.
+          nullable: true
+          type: integer
         longest_relative_task_sid_in_queue:
-          $ref: '#/components/schemas/sid_WT'
+          description: The SID of the Task waiting in the TaskQueue the longest.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WT[0-9a-fA-F]{32}$
+          type: string
         longest_task_waiting_age:
-          $ref: '#/components/schemas/integer'
+          description: The age of the longest waiting Task
+          nullable: true
+          type: integer
         longest_task_waiting_sid:
-          $ref: '#/components/schemas/sid_WT'
+          description: The SID of the longest waiting Task
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WT[0-9a-fA-F]{32}$
+          type: string
         task_queue_sid:
-          $ref: '#/components/schemas/sid_WQ'
+          description: The SID of the TaskQueue from which these statistics were calculated
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WQ[0-9a-fA-F]{32}$
+          type: string
         tasks_by_priority:
-          $ref: '#/components/schemas/object'
+          description: The number of Tasks by priority
+          nullable: true
+          type: object
         tasks_by_status:
-          $ref: '#/components/schemas/object'
+          description: The number of Tasks by their current status
+          nullable: true
+          type: object
         total_available_workers:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Workers available for Tasks in the TaskQueue
+          nullable: true
+          type: integer
         total_eligible_workers:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Workers eligible for Tasks in the TaskQueue,
+            independent of their Activity state
+          nullable: true
+          type: integer
         total_tasks:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the TaskQueue statistics resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the TaskQueue
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.task_queue.task_queue_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cumulative:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the cumulative statistics for the TaskQueue
+          nullable: true
+          type: object
         realtime:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the real-time statistics for the TaskQueue
+          nullable: true
+          type: object
         task_queue_sid:
-          $ref: '#/components/schemas/sid_WQ'
+          description: The SID of the TaskQueue from which these statistics were calculated
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WQ[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the TaskQueue statistics resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the TaskQueue
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.task_queue.task_queues_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cumulative:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the cumulative statistics for the TaskQueues
+          nullable: true
+          type: object
         realtime:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the real-time statistics for the TaskQueues
+          nullable: true
+          type: object
         task_queue_sid:
-          $ref: '#/components/schemas/sid_WQ'
+          description: The SID of the TaskQueue from which these statistics were calculated
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WQ[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the TaskQueues
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.worker:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         activity_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly_name of the Worker's current Activity
+          nullable: true
+          type: string
         activity_sid:
-          $ref: '#/components/schemas/sid_WA'
+          description: The SID of the Worker's current Activity
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WA[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/string'
+          description: The JSON string that describes the Worker
+          nullable: true
+          type: string
         available:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Worker is available to perform tasks
+          nullable: true
+          type: boolean
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_status_changed:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date and time in GMT of the last change to the Worker's
+            activity
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_WK'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WK[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Worker resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Worker
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.worker.worker_channel:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assigned_tasks:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks assigned to Worker for the TaskChannel
+            type
+          nullable: true
+          type: integer
         available:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the Worker should receive Tasks of the TaskChannel
+            type
+          nullable: true
+          type: boolean
         available_capacity_percentage:
-          $ref: '#/components/schemas/integer'
+          description: The current available capacity between 0 to 100 for the TaskChannel
+          nullable: true
+          type: integer
         configured_capacity:
-          $ref: '#/components/schemas/integer'
+          description: The current configured capacity for the WorkerChannel
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WC'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WC[0-9a-fA-F]{32}$
+          type: string
         task_channel_sid:
-          $ref: '#/components/schemas/sid_TC'
+          description: The SID of the TaskChannel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TC[0-9a-fA-F]{32}$
+          type: string
         task_channel_unique_name:
-          $ref: '#/components/schemas/string'
+          description: The unique name of the TaskChannel, such as 'voice' or 'sms'
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the WorkerChannel resource
+          format: uri
+          nullable: true
+          type: string
         worker_sid:
-          $ref: '#/components/schemas/sid_WK'
+          description: The SID of the Worker that contains the WorkerChannel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WK[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the WorkerChannel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.worker.worker_instance_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cumulative:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the cumulative statistics for the Worker
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the WorkerChannel statistics resource
+          format: uri
+          nullable: true
+          type: string
         worker_sid:
-          $ref: '#/components/schemas/sid_WK'
+          description: The SID of the Worker that contains the WorkerChannel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WK[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the WorkerChannel
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.worker.worker_reservation:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         reservation_status:
-          $ref: '#/components/schemas/worker_reservation_status'
+          description: The current status of the reservation
+          enum:
+          - pending
+          - accepted
+          - rejected
+          - timeout
+          - canceled
+          - rescinded
+          - wrapping
+          - completed
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_WR'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WR[0-9a-fA-F]{32}$
+          type: string
         task_sid:
-          $ref: '#/components/schemas/sid_WT'
+          description: The SID of the reserved Task resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WT[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the WorkerReservation resource
+          format: uri
+          nullable: true
+          type: string
         worker_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly_name of the Worker that is reserved
+          nullable: true
+          type: string
         worker_sid:
-          $ref: '#/components/schemas/sid_WK'
+          description: The SID of the reserved Worker resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WK[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that this worker is contained within.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.worker.worker_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cumulative:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the cumulative statistics for the Worker
+          nullable: true
+          type: object
         realtime:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the real-time statistics for the Worker
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Worker statistics resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Worker
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.worker.workers_cumulative_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         activity_durations:
-          $ref: '#/components/schemas/object_list'
+          description: The minimum, average, maximum, and total time that Workers
+            spent in each Activity
+          items:
+            type: object
+          nullable: true
+          type: array
         end_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The end of the interval during which these statistics were
+            calculated
+          format: date-time
+          nullable: true
+          type: string
         reservations_accepted:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were accepted
+          nullable: true
+          type: integer
         reservations_canceled:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were canceled
+          nullable: true
+          type: integer
         reservations_created:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were created
+          nullable: true
+          type: integer
         reservations_rejected:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were rejected
+          nullable: true
+          type: integer
         reservations_rescinded:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were rescinded
+          nullable: true
+          type: integer
         reservations_timed_out:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were timed out
+          nullable: true
+          type: integer
         start_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The beginning of the interval during which these statistics
+            were calculated
+          format: date-time
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workers statistics resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Workers
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.worker.workers_real_time_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         activity_statistics:
-          $ref: '#/components/schemas/object_list'
+          description: The number of current Workers by Activity
+          items:
+            type: object
+          nullable: true
+          type: array
         total_workers:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Workers
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workers statistics resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Workers
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.workflow:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         assignment_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when a task managed by the Workflow is
+            assigned to a Worker
+          format: uri
+          nullable: true
+          type: string
         configuration:
-          $ref: '#/components/schemas/string'
+          description: A JSON string that contains the Workflow's configuration
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         document_content_type:
-          $ref: '#/components/schemas/string'
+          description: The MIME type of the document
+          nullable: true
+          type: string
         fallback_assignment_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when a call to the `assignment_callback_url`
+            fails
+          format: uri
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Workflow resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_WW'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WW[0-9a-fA-F]{32}$
+          type: string
         task_reservation_timeout:
-          $ref: '#/components/schemas/integer'
+          description: How long TaskRouter will wait for a confirmation response from
+            your application after it assigns a Task to a Worker
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workflow resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Workflow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.workflow.workflow_cumulative_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         avg_task_acceptance_time:
-          $ref: '#/components/schemas/integer'
+          description: The average time in seconds between Task creation and acceptance
+          nullable: true
+          type: integer
         end_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The end of the interval during which these statistics were
+            calculated
+          format: date-time
+          nullable: true
+          type: string
         reservations_accepted:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations accepted by Workers
+          nullable: true
+          type: integer
         reservations_canceled:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were canceled
+          nullable: true
+          type: integer
         reservations_created:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were created for Workers
+          nullable: true
+          type: integer
         reservations_rejected:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were rejected
+          nullable: true
+          type: integer
         reservations_rescinded:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were rescinded
+          nullable: true
+          type: integer
         reservations_timed_out:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were timed out
+          nullable: true
+          type: integer
         split_by_wait_time:
-          $ref: '#/components/schemas/object'
+          description: A list of objects that describe the Tasks canceled and reservations
+            accepted above and below the specified thresholds
+          nullable: true
+          type: object
         start_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The beginning of the interval during which these statistics
+            were calculated
+          format: date-time
+          nullable: true
+          type: string
         tasks_canceled:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were canceled
+          nullable: true
+          type: integer
         tasks_completed:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were completed
+          nullable: true
+          type: integer
         tasks_deleted:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were deleted
+          nullable: true
+          type: integer
         tasks_entered:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that entered the Workflow
+          nullable: true
+          type: integer
         tasks_moved:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were moved from one queue to
+            another
+          nullable: true
+          type: integer
         tasks_timed_out_in_workflow:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were timed out of their Workflows
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workflow statistics resource
+          format: uri
+          nullable: true
+          type: string
         wait_duration_until_accepted:
-          $ref: '#/components/schemas/object'
+          description: The wait duration statistics for Tasks that were accepted
+          nullable: true
+          type: object
         wait_duration_until_canceled:
-          $ref: '#/components/schemas/object'
+          description: The wait duration statistics for Tasks that were canceled
+          nullable: true
+          type: object
         workflow_sid:
-          $ref: '#/components/schemas/sid_WW'
+          description: Returns the list of Tasks that are being controlled by the
+            Workflow with the specified Sid value
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WW[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Workflow.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.workflow.workflow_real_time_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         longest_task_waiting_age:
-          $ref: '#/components/schemas/integer'
+          description: The age of the longest waiting Task
+          nullable: true
+          type: integer
         longest_task_waiting_sid:
-          $ref: '#/components/schemas/sid_WT'
+          description: The SID of the longest waiting Task
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WT[0-9a-fA-F]{32}$
+          type: string
         tasks_by_priority:
-          $ref: '#/components/schemas/object'
+          description: The number of Tasks by priority
+          nullable: true
+          type: object
         tasks_by_status:
-          $ref: '#/components/schemas/object'
+          description: The number of Tasks by their current status
+          nullable: true
+          type: object
         total_tasks:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workflow statistics resource
+          format: uri
+          nullable: true
+          type: string
         workflow_sid:
-          $ref: '#/components/schemas/sid_WW'
+          description: Returns the list of Tasks that are being controlled by the
+            Workflow with the specified SID value
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WW[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Workflow.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.workflow.workflow_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cumulative:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the cumulative statistics for the Workflow
+          nullable: true
+          type: object
         realtime:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the real-time statistics for the Workflow
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workflow statistics resource
+          format: uri
+          nullable: true
+          type: string
         workflow_sid:
-          $ref: '#/components/schemas/sid_WW'
+          description: Returns the list of Tasks that are being controlled by the
+            Workflow with the specified SID value
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WW[0-9a-fA-F]{32}$
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace that contains the Workflow
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.workspace_cumulative_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         avg_task_acceptance_time:
-          $ref: '#/components/schemas/integer'
+          description: The average time in seconds between Task creation and acceptance
+          nullable: true
+          type: integer
         end_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The end of the interval during which these statistics were
+            calculated
+          format: date-time
+          nullable: true
+          type: string
         reservations_accepted:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations accepted by Workers
+          nullable: true
+          type: integer
         reservations_canceled:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were canceled
+          nullable: true
+          type: integer
         reservations_created:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were created for Workers
+          nullable: true
+          type: integer
         reservations_rejected:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were rejected
+          nullable: true
+          type: integer
         reservations_rescinded:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were rescinded
+          nullable: true
+          type: integer
         reservations_timed_out:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Reservations that were timed out
+          nullable: true
+          type: integer
         split_by_wait_time:
-          $ref: '#/components/schemas/object'
+          description: A list of objects that describe the Tasks canceled and reservations
+            accepted above and below the specified thresholds
+          nullable: true
+          type: object
         start_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The beginning of the interval during which these statistics
+            were calculated
+          format: date-time
+          nullable: true
+          type: string
         tasks_canceled:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were canceled
+          nullable: true
+          type: integer
         tasks_completed:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were completed
+          nullable: true
+          type: integer
         tasks_created:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks created
+          nullable: true
+          type: integer
         tasks_deleted:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were deleted
+          nullable: true
+          type: integer
         tasks_moved:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were moved from one queue to
+            another
+          nullable: true
+          type: integer
         tasks_timed_out_in_workflow:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks that were timed out of their Workflows
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workspace statistics resource
+          format: uri
+          nullable: true
+          type: string
         wait_duration_until_accepted:
-          $ref: '#/components/schemas/object'
+          description: The wait duration statistics for Tasks that were accepted
+          nullable: true
+          type: object
         wait_duration_until_canceled:
-          $ref: '#/components/schemas/object'
+          description: The wait duration statistics for Tasks that were canceled
+          nullable: true
+          type: object
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.workspace_real_time_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         activity_statistics:
-          $ref: '#/components/schemas/object_list'
+          description: The number of current Workers by Activity
+          items:
+            type: object
+          nullable: true
+          type: array
         longest_task_waiting_age:
-          $ref: '#/components/schemas/integer'
+          description: The age of the longest waiting Task
+          nullable: true
+          type: integer
         longest_task_waiting_sid:
-          $ref: '#/components/schemas/sid_WT'
+          description: The SID of the longest waiting Task
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WT[0-9a-fA-F]{32}$
+          type: string
         tasks_by_priority:
-          $ref: '#/components/schemas/object'
+          description: The number of Tasks by priority
+          nullable: true
+          type: object
         tasks_by_status:
-          $ref: '#/components/schemas/object'
+          description: The number of Tasks by their current status
+          nullable: true
+          type: object
         total_tasks:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Tasks
+          nullable: true
+          type: integer
         total_workers:
-          $ref: '#/components/schemas/integer'
+          description: The total number of Workers in the Workspace
+          nullable: true
+          type: integer
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workspace statistics resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
     taskrouter.v1.workspace.workspace_statistics:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cumulative:
-          $ref: '#/components/schemas/object'
+          description: An object that contains the cumulative statistics for the Workspace
+          nullable: true
+          type: object
         realtime:
-          $ref: '#/components/schemas/object'
+          description: n object that contains the real-time statistics for the Workspace
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Workspace statistics resource
+          format: uri
+          nullable: true
+          type: string
         workspace_sid:
-          $ref: '#/components/schemas/sid_WS'
+          description: The SID of the Workspace
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WS[0-9a-fA-F]{32}$
+          type: string
       type: object
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
-    worker_reservation_status:
-      enum:
-      - pending
-      - accepted
-      - rejected
-      - timeout
-      - canceled
-      - rescinded
-      - wrapping
-      - completed
-      nullable: true
-      type: string
-    workspace_queue_order:
-      enum:
-      - FIFO
-      - LIFO
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_trunking_v1.yaml
+++ b/spec/yaml/twilio_trunking_v1.yaml
@@ -1,277 +1,445 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    phone_number:
-      nullable: true
-      type: string
-    phone_number_address_requirement:
-      enum:
-      - none
-      - any
-      - local
-      - foreign
-      nullable: true
-      type: string
-    recording_recording_mode:
-      enum:
-      - do-not-record
-      - record-from-ringing
-      - record-from-answer
-      - record-from-ringing-dual
-      - record-from-answer-dual
-      nullable: true
-      type: string
-    recording_recording_trim:
-      enum:
-      - trim-silence
-      - do-not-trim
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_AL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AL[0-9a-fA-F]{32}$
-      type: string
-    sid_AP:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AP[0-9a-fA-F]{32}$
-      type: string
-    sid_CL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CL[0-9a-fA-F]{32}$
-      type: string
-    sid_OU:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^OU[0-9a-fA-F]{32}$
-      type: string
-    sid_PN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^PN[0-9a-fA-F]{32}$
-      type: string
-    sid_TK:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^TK[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    string_map:
-      nullable: true
-      type: object
-    trunk_transfer_setting:
-      enum:
-      - disable-all
-      - enable-all
-      - sip-only
-      nullable: true
-      type: string
     trunking.v1.trunk:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         auth_type:
-          $ref: '#/components/schemas/string'
+          description: The types of authentication mapped to the domain
+          nullable: true
+          type: string
         auth_type_set:
-          $ref: '#/components/schemas/string_list'
+          description: Reserved
+          items:
+            type: string
+          nullable: true
+          type: array
         cnam_lookup_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether Caller ID Name (CNAM) lookup is enabled for the trunk
+          nullable: true
+          type: boolean
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         disaster_recovery_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call the disaster_recovery_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         disaster_recovery_url:
-          $ref: '#/components/schemas/url'
+          description: The HTTP URL that we call if an error occurs while sending
+            SIP traffic towards your configured Origination URL
+          format: uri
+          nullable: true
+          type: string
         domain_name:
-          $ref: '#/components/schemas/string'
+          description: The unique address you reserve on Twilio to which you route
+            your SIP traffic
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         recording:
-          $ref: '#/components/schemas/object'
+          description: The recording settings for the trunk
+          nullable: true
+          type: object
         secure:
-          $ref: '#/components/schemas/boolean'
+          description: Whether Secure Trunking is enabled for the trunk
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         transfer_mode:
-          $ref: '#/components/schemas/trunk_transfer_setting'
+          description: The call transfer settings for the trunk
+          enum:
+          - disable-all
+          - enable-all
+          - sip-only
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trunking.v1.trunk.credential_list:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CL[0-9a-fA-F]{32}$
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk the credential list in associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trunking.v1.trunk.ip_access_control_list:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_AL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AL[0-9a-fA-F]{32}$
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trunking.v1.trunk.origination_url:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the URL is enabled
+          nullable: true
+          type: boolean
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         priority:
-          $ref: '#/components/schemas/integer'
+          description: The relative importance of the URI
+          nullable: true
+          type: integer
         sid:
-          $ref: '#/components/schemas/sid_OU'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^OU[0-9a-fA-F]{32}$
+          type: string
         sip_url:
-          $ref: '#/components/schemas/url'
+          description: The SIP address you want Twilio to route your Origination calls
+            to
+          format: uri
+          nullable: true
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk that owns the Origination URL
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         weight:
-          $ref: '#/components/schemas/integer'
+          description: The value that determines the relative load the URI should
+            receive compared to others with the same priority
+          nullable: true
+          type: integer
       type: object
     trunking.v1.trunk.phone_number:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         address_requirements:
-          $ref: '#/components/schemas/phone_number_address_requirement'
+          description: Whether the phone number requires an Address registered with
+            Twilio
+          enum:
+          - none
+          - any
+          - local
+          - foreign
+          nullable: true
+          type: string
         api_version:
-          $ref: '#/components/schemas/string'
+          description: The API version used to start a new TwiML session
+          nullable: true
+          type: string
         beta:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the phone number is new to the Twilio platform
+          nullable: true
+          type: boolean
         capabilities:
-          $ref: '#/components/schemas/string_map'
+          description: Indicate if a phone can receive calls or messages
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         phone_number:
-          $ref: '#/components/schemas/phone_number'
+          description: The phone number in E.164 format
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PN'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PN[0-9a-fA-F]{32}$
+          type: string
         sms_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles SMS messages sent to
+            the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call when an error occurs while retrieving
+            or executing the TwiML
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with sms_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives an incoming
+            SMS message
+          format: uri
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         trunk_sid:
-          $ref: '#/components/schemas/sid_TK'
+          description: The SID of the Trunk that handles calls to the phone number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^TK[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         voice_application_sid:
-          $ref: '#/components/schemas/sid_AP'
+          description: The SID of the application that handles calls to the phone
+            number
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AP[0-9a-fA-F]{32}$
+          type: string
         voice_caller_id_lookup:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to lookup the caller's name
+          nullable: true
+          type: boolean
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method that we use to call voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs in TwiML
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with the voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the phone number receives a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     trunking.v1.trunk.recording:
       properties:
         mode:
-          $ref: '#/components/schemas/recording_recording_mode'
+          description: The recording mode for the trunk.
+          enum:
+          - do-not-record
+          - record-from-ringing
+          - record-from-answer
+          - record-from-ringing-dual
+          - record-from-answer-dual
+          nullable: true
+          type: string
         trim:
-          $ref: '#/components/schemas/recording_recording_trim'
+          description: The recording trim setting for the trunk.
+          enum:
+          - trim-silence
+          - do-not-trim
+          nullable: true
+          type: string
       type: object
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_trusthub_v1.yaml
+++ b/spec/yaml/twilio_trusthub_v1.yaml
@@ -1,362 +1,617 @@
 components:
   schemas:
-    customer_profile_evaluation_status:
-      enum:
-      - compliant
-      - noncompliant
-      nullable: true
-      type: string
-    customer_profile_status:
-      enum:
-      - draft
-      - pending-review
-      - in-review
-      - twilio-rejected
-      - twilio-approved
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    object:
-      nullable: true
-      type: object
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    sid:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_BU:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BU[0-9a-fA-F]{32}$
-      type: string
-    sid_BV:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BV[0-9a-fA-F]{32}$
-      type: string
-    sid_EL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^EL[0-9a-fA-F]{32}$
-      type: string
-    sid_IT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IT[0-9a-fA-F]{32}$
-      type: string
-    sid_OY:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^OY[0-9a-fA-F]{32}$
-      type: string
-    sid_RA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RA[0-9a-fA-F]{32}$
-      type: string
-    sid_RD:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RD[0-9a-fA-F]{32}$
-      type: string
-    sid_RN:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RN[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    supporting_document_status:
-      enum:
-      - draft
-      - pending-review
-      - rejected
-      - approved
-      - expired
-      - provisionally-approved
-      nullable: true
-      type: string
-    trust_product_evaluation_status:
-      enum:
-      - compliant
-      - noncompliant
-      nullable: true
-      type: string
-    trust_product_status:
-      enum:
-      - draft
-      - pending-review
-      - in-review
-      - twilio-rejected
-      - twilio-approved
-      nullable: true
-      type: string
     trusthub.v1.customer_profile:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         email:
-          $ref: '#/components/schemas/string'
+          description: The email address
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Assigned Items of the Customer-Profile resource
+          nullable: true
+          type: object
         policy_sid:
-          $ref: '#/components/schemas/sid_RN'
+          description: The unique string of a policy.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RN[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/customer_profile_status'
+          description: The verification status of the Customer-Profile resource
+          enum:
+          - draft
+          - pending-review
+          - in-review
+          - twilio-rejected
+          - twilio-approved
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL we call to inform your application of status changes.
+          format: uri
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Customer-Profile resource
+          format: uri
+          nullable: true
+          type: string
         valid_until:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource will be
+            valid until.
+          format: date-time
+          nullable: true
+          type: string
       type: object
     trusthub.v1.customer_profile.customer_profile_channel_endpoint_assignment:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_endpoint_sid:
-          $ref: '#/components/schemas/sid'
+          description: The sid of an channel endpoint
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         channel_endpoint_type:
-          $ref: '#/components/schemas/string'
+          description: The type of channel endpoint
+          nullable: true
+          type: string
         customer_profile_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the CustomerProfile resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RA'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RA[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Identity resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.customer_profile.customer_profile_entity_assignment:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         customer_profile_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the CustomerProfile resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         object_sid:
-          $ref: '#/components/schemas/sid'
+          description: The sid of an object bag
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BV'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BV[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Identity resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.customer_profile.customer_profile_evaluation:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         customer_profile_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         policy_sid:
-          $ref: '#/components/schemas/sid_RN'
+          description: The unique string of a policy
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RN[0-9a-fA-F]{32}$
+          type: string
         results:
-          $ref: '#/components/schemas/object_list'
+          description: The results of the Evaluation resource
+          items:
+            type: object
+          nullable: true
+          type: array
         sid:
-          $ref: '#/components/schemas/sid_EL'
+          description: The unique string that identifies the Evaluation resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^EL[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/customer_profile_evaluation_status'
+          description: The compliance status of the Evaluation resource
+          enum:
+          - compliant
+          - noncompliant
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.end_user:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/object'
+          description: The set of parameters that compose the End Users resource
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IT[0-9a-fA-F]{32}$
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: The type of end user of the Bundle resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the End User resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.end_user_type:
       properties:
         fields:
-          $ref: '#/components/schemas/object_list'
+          description: The required information for creating an End-User.
+          items:
+            type: object
+          nullable: true
+          type: array
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human-readable description of the End-User Type resource
+          nullable: true
+          type: string
         machine_name:
-          $ref: '#/components/schemas/string'
+          description: A machine-readable description of the End-User Type resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_OY'
+          description: The unique string that identifies the End-User Type resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^OY[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the End-User Type resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.policies:
       properties:
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human-readable description of the Policy resource
+          nullable: true
+          type: string
         requirements:
-          $ref: '#/components/schemas/object'
+          description: The sid of a Policy object that dictates requirements
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_RN'
+          description: The unique string that identifies the Policy resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RN[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Policy resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.supporting_document:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         attributes:
-          $ref: '#/components/schemas/object'
+          description: The set of parameters that compose the Supporting Documents
+            resource
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         mime_type:
-          $ref: '#/components/schemas/string'
+          description: The image type of the file
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RD'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RD[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/supporting_document_status'
+          description: The verification status of the Supporting Document resource
+          enum:
+          - draft
+          - pending-review
+          - rejected
+          - approved
+          - expired
+          - provisionally-approved
+          nullable: true
+          type: string
         type:
-          $ref: '#/components/schemas/string'
+          description: The type of the Supporting Document
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Supporting Document resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.supporting_document_type:
       properties:
         fields:
-          $ref: '#/components/schemas/object_list'
+          description: The required information for creating a Supporting Document
+          items:
+            type: object
+          nullable: true
+          type: array
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human-readable description of the Supporting Document Type
+            resource
+          nullable: true
+          type: string
         machine_name:
-          $ref: '#/components/schemas/string'
+          description: The machine-readable description of the Supporting Document
+            Type resource
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_OY'
+          description: The unique string that identifies the Supporting Document Type
+            resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^OY[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Supporting Document Type resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.trust_product:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         email:
-          $ref: '#/components/schemas/string'
+          description: The email address
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of the Assigned Items of the Customer-Profile resource
+          nullable: true
+          type: object
         policy_sid:
-          $ref: '#/components/schemas/sid_RN'
+          description: The unique string of a policy.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RN[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/trust_product_status'
+          description: The verification status of the Customer-Profile resource
+          enum:
+          - draft
+          - pending-review
+          - in-review
+          - twilio-rejected
+          - twilio-approved
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL we call to inform your application of status changes.
+          format: uri
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Customer-Profile resource
+          format: uri
+          nullable: true
+          type: string
         valid_until:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource will be
+            valid until.
+          format: date-time
+          nullable: true
+          type: string
       type: object
     trusthub.v1.trust_product.trust_product_channel_endpoint_assignment:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel_endpoint_sid:
-          $ref: '#/components/schemas/sid'
+          description: The sid of an channel endpoint
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         channel_endpoint_type:
-          $ref: '#/components/schemas/string'
+          description: The type of channel endpoint
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RA'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RA[0-9a-fA-F]{32}$
+          type: string
         trust_product_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the CustomerProfile resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Identity resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.trust_product.trust_product_entity_assignment:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         object_sid:
-          $ref: '#/components/schemas/sid'
+          description: The sid of an object bag
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BV'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BV[0-9a-fA-F]{32}$
+          type: string
         trust_product_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the TrustProduct resource.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Identity resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     trusthub.v1.trust_product.trust_product_evaluation:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          format: date-time
+          nullable: true
+          type: string
         policy_sid:
-          $ref: '#/components/schemas/sid_RN'
+          description: The unique string of a policy
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RN[0-9a-fA-F]{32}$
+          type: string
         results:
-          $ref: '#/components/schemas/object_list'
+          description: The results of the Evaluation resource
+          items:
+            type: object
+          nullable: true
+          type: array
         sid:
-          $ref: '#/components/schemas/sid_EL'
+          description: The unique string that identifies the Evaluation resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^EL[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/trust_product_evaluation_status'
+          description: The compliance status of the Evaluation resource
+          enum:
+          - compliant
+          - noncompliant
+          nullable: true
+          type: string
         trust_product_sid:
-          $ref: '#/components/schemas/sid_BU'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BU[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_verify_v2.yaml
+++ b/spec/yaml/twilio_verify_v2.yaml
@@ -1,472 +1,748 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    challenge_challenge_reasons:
-      enum:
-      - none
-      - not_needed
-      - not_requested
-      nullable: true
-      type: string
-    challenge_challenge_statuses:
-      enum:
-      - pending
-      - expired
-      - approved
-      - denied
-      nullable: true
-      type: string
-    challenge_factor_types:
-      enum:
-      - push
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    factor_factor_statuses:
-      enum:
-      - unverified
-      - verified
-      nullable: true
-      type: string
-    factor_factor_types:
-      enum:
-      - push
-      nullable: true
-      type: string
-    form_form_types:
-      enum:
-      - form-push
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    object_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_BL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BL[0-9a-fA-F]{32}$
-      type: string
-    sid_MG:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MG[0-9a-fA-F]{32}$
-      type: string
-    sid_RK:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RK[0-9a-fA-F]{32}$
-      type: string
-    sid_VA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^VA[0-9a-fA-F]{32}$
-      type: string
-    sid_VE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^VE[0-9a-fA-F]{32}$
-      type: string
-    sid_VL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^VL[0-9a-fA-F]{32}$
-      type: string
-    sid_YC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^YC[0-9a-fA-F]{32}$
-      type: string
-    sid_YE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^YE[0-9a-fA-F]{32}$
-      type: string
-    sid_YF:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^YF[0-9a-fA-F]{32}$
-      type: string
-    sid_YW:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^YW[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
-    verification_attempt_channels:
-      enum:
-      - sms
-      - call
-      - email
-      nullable: true
-      type: string
-    verification_attempt_conversion_status:
-      enum:
-      - converted
-      - unconverted
-      nullable: true
-      type: string
-    verification_channel:
-      enum:
-      - sms
-      - call
-      - email
-      nullable: true
-      type: string
-    verification_check_channel:
-      enum:
-      - sms
-      - call
-      - email
-      nullable: true
-      type: string
     verify.v2.form:
       properties:
         form_meta:
-          $ref: '#/components/schemas/object'
+          description: Additional information for the available forms for this type.
+          nullable: true
+          type: object
         form_type:
-          $ref: '#/components/schemas/form_form_types'
+          description: The Type of this Form
+          enum:
+          - form-push
+          nullable: true
+          type: string
         forms:
-          $ref: '#/components/schemas/object'
+          description: Object that contains the available forms for this type.
+          nullable: true
+          type: object
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL to access the forms for this type.
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.service:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         code_length:
-          $ref: '#/components/schemas/integer'
+          description: The length of the verification code
+          nullable: true
+          type: integer
         custom_code_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to allow sending verifications with a custom code.
+          nullable: true
+          type: boolean
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         do_not_share_warning_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to add a security warning at the end of an SMS.
+          nullable: true
+          type: boolean
         dtmf_input_required:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to ask the user to press a number before delivering
+            the verify code in a phone call
+          nullable: true
+          type: boolean
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the verification service
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         lookup_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to perform a lookup with each verification
+          nullable: true
+          type: boolean
         psd2_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to pass PSD2 transaction parameters when starting a
+            verification
+          nullable: true
+          type: boolean
         push:
-          $ref: '#/components/schemas/object'
+          description: The service level configuration of factor push type.
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         skip_sms_to_landlines:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to skip sending SMS verifications to landlines
+          nullable: true
+          type: boolean
         tts_name:
-          $ref: '#/components/schemas/string'
+          description: The name of an alternative text-to-speech service to use in
+            phone calls
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.service.access_token:
       properties:
         token:
-          $ref: '#/components/schemas/string'
+          description: Generated access token.
+          nullable: true
+          type: string
       type: object
     verify.v2.service.entity:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: Account Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Entity was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Entity was updated
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: Unique external identifier of the Entity
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: Nested resource URLs.
+          nullable: true
+          type: object
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: Service Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_YE'
+          description: A string that uniquely identifies this Entity.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^YE[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.service.entity.challenge:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: Account Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Challenge was created
+          format: date-time
+          nullable: true
+          type: string
         date_responded:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Challenge was responded
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Challenge was updated
+          format: date-time
+          nullable: true
+          type: string
         details:
-          $ref: '#/components/schemas/object'
+          description: Details about the Challenge.
+          nullable: true
+          type: object
         entity_sid:
-          $ref: '#/components/schemas/sid_YE'
+          description: Entity Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^YE[0-9a-fA-F]{32}$
+          type: string
         expiration_date:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date-time when this Challenge expires
+          format: date-time
+          nullable: true
+          type: string
         factor_sid:
-          $ref: '#/components/schemas/sid_YF'
+          description: Factor Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^YF[0-9a-fA-F]{32}$
+          type: string
         factor_type:
-          $ref: '#/components/schemas/challenge_factor_types'
+          description: The Factor Type of this Challenge
+          enum:
+          - push
+          nullable: true
+          type: string
         hidden_details:
-          $ref: '#/components/schemas/object'
+          description: Hidden details about the Challenge
+          nullable: true
+          type: object
         identity:
-          $ref: '#/components/schemas/string'
+          description: Unique external identifier of the Entity
+          nullable: true
+          type: string
         responded_reason:
-          $ref: '#/components/schemas/challenge_challenge_reasons'
+          description: The Reason of this Challenge `status`
+          enum:
+          - none
+          - not_needed
+          - not_requested
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: Service Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_YC'
+          description: A string that uniquely identifies this Challenge.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^YC[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/challenge_challenge_statuses'
+          description: The Status of this Challenge
+          enum:
+          - pending
+          - expired
+          - approved
+          - denied
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.service.entity.factor:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: Account Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         config:
-          $ref: '#/components/schemas/object'
+          description: Configurations for a `factor_type`.
+          nullable: true
+          type: object
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Factor was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Factor was updated
+          format: date-time
+          nullable: true
+          type: string
         entity_sid:
-          $ref: '#/components/schemas/sid_YE'
+          description: Entity Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^YE[0-9a-fA-F]{32}$
+          type: string
         factor_type:
-          $ref: '#/components/schemas/factor_factor_types'
+          description: The Type of this Factor
+          enum:
+          - push
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: A human readable description of this resource.
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: Unique external identifier of the Entity
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: Service Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_YF'
+          description: A string that uniquely identifies this Factor.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^YF[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/factor_factor_statuses'
+          description: The Status of this Factor
+          enum:
+          - unverified
+          - verified
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.service.messaging_configuration:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         country:
-          $ref: '#/components/schemas/string'
+          description: The ISO-3166-1 country code of the country or `all`.
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         messaging_service_sid:
-          $ref: '#/components/schemas/sid_MG'
+          description: The SID of the Messaging Service used for this configuration.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MG[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.service.rate_limit:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         description:
-          $ref: '#/components/schemas/string'
+          description: Description of this Rate Limit
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RK'
+          description: A string that uniquely identifies this Rate Limit.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RK[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: A unique, developer assigned name of this Rate Limit.
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.service.rate_limit.bucket:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         interval:
-          $ref: '#/components/schemas/integer'
+          description: Number of seconds that the rate limit will be enforced over.
+          nullable: true
+          type: integer
         max:
-          $ref: '#/components/schemas/integer'
+          description: Max number of requests.
+          nullable: true
+          type: integer
         rate_limit_sid:
-          $ref: '#/components/schemas/sid_RK'
+          description: Rate Limit Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RK[0-9a-fA-F]{32}$
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BL'
+          description: A string that uniquely identifies this Bucket.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BL[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The URL of this resource.
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.service.verification:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         amount:
-          $ref: '#/components/schemas/string'
+          description: The amount of the associated PSD2 compliant transaction.
+          nullable: true
+          type: string
         channel:
-          $ref: '#/components/schemas/verification_channel'
+          description: The verification method used.
+          enum:
+          - sms
+          - call
+          - email
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         lookup:
-          $ref: '#/components/schemas/object'
+          description: Information about the phone number being verified
+          nullable: true
+          type: object
         payee:
-          $ref: '#/components/schemas/string'
+          description: The payee of the associated PSD2 compliant transaction
+          nullable: true
+          type: string
         send_code_attempts:
-          $ref: '#/components/schemas/object_list'
+          description: An array of verification attempt objects.
+          items:
+            type: object
+          nullable: true
+          type: array
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_VE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VE[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/string'
+          description: The status of the verification resource
+          nullable: true
+          type: string
         to:
-          $ref: '#/components/schemas/string'
+          description: The phone number or email being verified
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Verification resource
+          format: uri
+          nullable: true
+          type: string
         valid:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the verification was successful
+          nullable: true
+          type: boolean
       type: object
     verify.v2.service.verification_check:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         amount:
-          $ref: '#/components/schemas/string'
+          description: The amount of the associated PSD2 compliant transaction.
+          nullable: true
+          type: string
         channel:
-          $ref: '#/components/schemas/verification_check_channel'
+          description: The verification method to use
+          enum:
+          - sms
+          - call
+          - email
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Verification Check
+            resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Verification Check
+            resource was last updated
+          format: date-time
+          nullable: true
+          type: string
         payee:
-          $ref: '#/components/schemas/string'
+          description: The payee of the associated PSD2 compliant transaction
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: The SID of the Service that the resource is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_VE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VE[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/string'
+          description: The status of the verification resource
+          nullable: true
+          type: string
         to:
-          $ref: '#/components/schemas/string'
+          description: The phone number or email being verified
+          nullable: true
+          type: string
         valid:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the verification was successful
+          nullable: true
+          type: boolean
       type: object
     verify.v2.service.webhook:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         event_types:
-          $ref: '#/components/schemas/string_list'
+          description: The array of events that this Webhook is subscribed to.
+          items:
+            type: string
+          nullable: true
+          type: array
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the webhook
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          description: Service Sid.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_YW'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^YW[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/webhook_status'
+          description: The webhook status
+          enum:
+          - enabled
+          - disabled
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the Webhook resource
+          format: uri
+          nullable: true
+          type: string
         webhook_method:
-          $ref: '#/components/schemas/webhook_methods'
+          description: The method used when calling the webhook's URL.
+          enum:
+          - GET
+          - POST
+          nullable: true
+          type: string
         webhook_url:
-          $ref: '#/components/schemas/url'
+          description: The URL associated with this Webhook.
+          format: uri
+          nullable: true
+          type: string
       type: object
     verify.v2.verification_attempt:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: Account Sid
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         channel:
-          $ref: '#/components/schemas/verification_attempt_channels'
+          description: Channel used for the attempt
+          enum:
+          - sms
+          - call
+          - email
+          nullable: true
+          type: string
         channel_data:
-          $ref: '#/components/schemas/object'
+          description: Object with the channel information for an attempt
+          nullable: true
+          type: object
         conversion_status:
-          $ref: '#/components/schemas/verification_attempt_conversion_status'
+          description: Status of a conversion
+          enum:
+          - converted
+          - unconverted
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Attempt was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date this Attempt was updated
+          format: date-time
+          nullable: true
+          type: string
         service_sid:
-          $ref: '#/components/schemas/sid_VA'
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VA[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_VL'
+          description: A string that uniquely identifies this Verification Attempt
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^VL[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          format: uri
+          nullable: true
+          type: string
       type: object
-    webhook_methods:
-      enum:
-      - GET
-      - POST
-      nullable: true
-      type: string
-    webhook_status:
-      enum:
-      - enabled
-      - disabled
-      nullable: true
-      type: string
   securitySchemes:
     accountSid_authToken:
       scheme: basic

--- a/spec/yaml/twilio_video_v1.yaml
+++ b/spec/yaml/twilio_video_v1.yaml
@@ -1,556 +1,865 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    composition_format:
-      enum:
-      - mp4
-      - webm
-      nullable: true
-      type: string
-    composition_hook_format:
-      enum:
-      - mp4
-      - webm
-      nullable: true
-      type: string
-    composition_status:
-      enum:
-      - enqueued
-      - processing
-      - completed
-      - deleted
-      - failed
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    long:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    recording_codec:
-      enum:
-      - VP8
-      - H264
-      - OPUS
-      - PCMU
-      nullable: true
-      type: string
-    recording_format:
-      enum:
-      - mka
-      - mkv
-      nullable: true
-      type: string
-    recording_rule_list:
-      items:
-        properties:
-          all:
-            type: boolean
-          kind:
-            type: string
-          publisher:
-            type: string
-          track:
-            type: string
-          type:
-            type: string
-        type: object
-      nullable: true
-      type: array
-    recording_status:
-      enum:
-      - processing
-      - completed
-      - deleted
-      - failed
-      nullable: true
-      type: string
-    recording_type:
-      enum:
-      - audio
-      - video
-      - data
-      nullable: true
-      type: string
-    room_participant_published_track_kind:
-      enum:
-      - audio
-      - video
-      - data
-      nullable: true
-      type: string
-    room_participant_status:
-      enum:
-      - connected
-      - disconnected
-      nullable: true
-      type: string
-    room_participant_subscribed_track_kind:
-      enum:
-      - audio
-      - video
-      - data
-      nullable: true
-      type: string
-    room_recording_codec:
-      enum:
-      - VP8
-      - H264
-      - OPUS
-      - PCMU
-      nullable: true
-      type: string
-    room_recording_format:
-      enum:
-      - mka
-      - mkv
-      nullable: true
-      type: string
-    room_recording_status:
-      enum:
-      - processing
-      - completed
-      - deleted
-      - failed
-      nullable: true
-      type: string
-    room_recording_type:
-      enum:
-      - audio
-      - video
-      - data
-      nullable: true
-      type: string
-    room_room_status:
-      enum:
-      - in-progress
-      - completed
-      - failed
-      nullable: true
-      type: string
-    room_room_type:
-      enum:
-      - go
-      - peer-to-peer
-      - group
-      - group-small
-      nullable: true
-      type: string
-    room_video_codec_list:
-      items:
-        enum:
-        - VP8
-        - H264
-        type: string
-      nullable: true
-      type: array
-    sid:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_CJ:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CJ[0-9a-fA-F]{32}$
-      type: string
-    sid_CR:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^CR[0-9a-fA-F]{32}$
-      type: string
-    sid_HK:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^HK[0-9a-fA-F]{32}$
-      type: string
-    sid_MT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^MT[0-9a-fA-F]{32}$
-      type: string
-    sid_PA:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^PA[0-9a-fA-F]{32}$
-      type: string
-    sid_RM:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RM[0-9a-fA-F]{32}$
-      type: string
-    sid_RT:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^RT[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    subscribe_rule_list:
-      items:
-        type: object
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
     video.v1.composition:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         audio_sources:
-          $ref: '#/components/schemas/string_list'
+          description: The array of track names to include in the composition
+          items:
+            type: string
+          nullable: true
+          type: array
         audio_sources_excluded:
-          $ref: '#/components/schemas/string_list'
+          description: The array of track names to exclude from the composition
+          items:
+            type: string
+          nullable: true
+          type: array
         bitrate:
-          $ref: '#/components/schemas/integer'
+          description: The average bit rate of the composition's media
+          nullable: true
+          type: integer
         date_completed:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: Date when the media processing task finished
+          format: date-time
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_deleted:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the composition generated
+            media was deleted
+          format: date-time
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/integer'
+          description: The duration of the composition's media file in seconds
+          nullable: true
+          type: integer
         format:
-          $ref: '#/components/schemas/composition_format'
+          description: The container format of the composition's media files as specified
+            in the POST request that created the Composition resource
+          enum:
+          - mp4
+          - webm
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URL of the media file associated with the composition
+          nullable: true
+          type: object
         resolution:
-          $ref: '#/components/schemas/string'
+          description: The dimensions of the video image in pixels expressed as columns
+            (width) and rows (height)
+          nullable: true
+          type: string
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          description: The SID of the Group Room that generated the audio and video
+            tracks used in the composition
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_CJ'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CJ[0-9a-fA-F]{32}$
+          type: string
         size:
-          $ref: '#/components/schemas/long'
+          description: The size of the composed media file in bytes
+          nullable: true
+          type: integer
         status:
-          $ref: '#/components/schemas/composition_status'
+          description: The status of the composition
+          enum:
+          - enqueued
+          - processing
+          - completed
+          - deleted
+          - failed
+          nullable: true
+          type: string
         trim:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to remove intervals with no media
+          nullable: true
+          type: boolean
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         video_layout:
-          $ref: '#/components/schemas/object'
+          description: An object that describes the video layout of the composition
+          nullable: true
+          type: object
       type: object
     video.v1.composition_hook:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         audio_sources:
-          $ref: '#/components/schemas/string_list'
+          description: The array of track names to include in the compositions created
+            by the composition hook
+          items:
+            type: string
+          nullable: true
+          type: array
         audio_sources_excluded:
-          $ref: '#/components/schemas/string_list'
+          description: The array of track names to exclude from the compositions created
+            by the composition hook
+          items:
+            type: string
+          nullable: true
+          type: array
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the CompositionHook is active
+          nullable: true
+          type: boolean
         format:
-          $ref: '#/components/schemas/composition_hook_format'
+          description: The container format of the media files used by the compositions
+            created by the composition hook
+          enum:
+          - mp4
+          - webm
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         resolution:
-          $ref: '#/components/schemas/string'
+          description: The dimensions of the video image in pixels expressed as columns
+            (width) and rows (height)
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_HK'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^HK[0-9a-fA-F]{32}$
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we should use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         trim:
-          $ref: '#/components/schemas/boolean'
+          description: Whether intervals with no media are clipped
+          nullable: true
+          type: boolean
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         video_layout:
-          $ref: '#/components/schemas/object'
+          description: A JSON object that describes the video layout of the Composition
+          nullable: true
+          type: object
       type: object
     video.v1.composition_settings:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         aws_credentials_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the stored Credential resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         aws_s3_url:
-          $ref: '#/components/schemas/url'
+          description: The URL of the AWS S3 bucket where the compositions are stored
+          format: uri
+          nullable: true
+          type: string
         aws_storage_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether all compositions are written to the aws_s3_url
+          nullable: true
+          type: boolean
         encryption_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether all compositions are stored in an encrypted form
+          nullable: true
+          type: boolean
         encryption_key_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Public Key resource used for encryption
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     video.v1.recording:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         codec:
-          $ref: '#/components/schemas/recording_codec'
+          description: The codec used to encode the track
+          enum:
+          - VP8
+          - H264
+          - OPUS
+          - PCMU
+          nullable: true
+          type: string
         container_format:
-          $ref: '#/components/schemas/recording_format'
+          description: The file format for the recording
+          enum:
+          - mka
+          - mkv
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/integer'
+          description: The duration of the recording in seconds
+          nullable: true
+          type: integer
         grouping_sids:
-          $ref: '#/components/schemas/object'
+          description: A list of SIDs related to the recording
+          nullable: true
+          type: object
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         offset:
-          $ref: '#/components/schemas/long'
+          description: The number of milliseconds between a point in time that is
+            common to all rooms in a group and when the source room of the recording
+            started
+          nullable: true
+          type: integer
         sid:
-          $ref: '#/components/schemas/sid_RT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RT[0-9a-fA-F]{32}$
+          type: string
         size:
-          $ref: '#/components/schemas/long'
+          description: The size of the recorded track, in bytes
+          nullable: true
+          type: integer
         source_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the recording source
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/recording_status'
+          description: The status of the recording
+          enum:
+          - processing
+          - completed
+          - deleted
+          - failed
+          nullable: true
+          type: string
         track_name:
-          $ref: '#/components/schemas/string'
+          description: The name that was given to the source track of the recording
+          nullable: true
+          type: string
         type:
-          $ref: '#/components/schemas/recording_type'
+          description: The recording's media type
+          enum:
+          - audio
+          - video
+          - data
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     video.v1.recording_settings:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         aws_credentials_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the stored Credential resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         aws_s3_url:
-          $ref: '#/components/schemas/url'
+          description: The URL of the AWS S3 bucket where the recordings are stored
+          format: uri
+          nullable: true
+          type: string
         aws_storage_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether all recordings are written to the aws_s3_url
+          nullable: true
+          type: boolean
         encryption_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether all recordings are stored in an encrypted form
+          nullable: true
+          type: boolean
         encryption_key_sid:
-          $ref: '#/components/schemas/sid_CR'
+          description: The SID of the Public Key resource used for encryption
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^CR[0-9a-fA-F]{32}$
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     video.v1.room:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/integer'
+          description: The duration of the room in seconds
+          nullable: true
+          type: integer
         enable_turn:
-          $ref: '#/components/schemas/boolean'
+          description: Enable Twilio's Network Traversal TURN service
+          nullable: true
+          type: boolean
         end_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The UTC end time of the room in UTC ISO 8601 format
+          format: date-time
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         max_concurrent_published_tracks:
-          $ref: '#/components/schemas/integer'
+          description: The maximum number of published tracks allowed in the room
+            at the same time
+          nullable: true
+          type: integer
         max_participants:
-          $ref: '#/components/schemas/integer'
+          description: The maximum number of concurrent Participants allowed in the
+            room
+          nullable: true
+          type: integer
         media_region:
-          $ref: '#/components/schemas/string'
+          description: The region for the media server in Group Rooms
+          nullable: true
+          type: string
         record_participants_on_connect:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to start recording when Participants connect
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_RM'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/room_room_status'
+          description: The status of the room
+          enum:
+          - in-progress
+          - completed
+          - failed
+          nullable: true
+          type: string
         status_callback:
-          $ref: '#/components/schemas/url'
+          description: The URL to send status information to your application
+          format: uri
+          nullable: true
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         type:
-          $ref: '#/components/schemas/room_room_type'
+          description: The type of room
+          enum:
+          - go
+          - peer-to-peer
+          - group
+          - group-small
+          nullable: true
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         video_codecs:
-          $ref: '#/components/schemas/room_video_codec_list'
+          description: An array of the video codecs that are supported when publishing
+            a track in the room
+          items:
+            enum:
+            - VP8
+            - H264
+            type: string
+          nullable: true
+          type: array
       type: object
     video.v1.room.room_participant:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/integer'
+          description: Duration of time in seconds the participant was connected
+          nullable: true
+          type: integer
         end_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The time when the participant disconnected from the room in
+            ISO 8601 format
+          format: date-time
+          nullable: true
+          type: string
         identity:
-          $ref: '#/components/schemas/string'
+          description: The string that identifies the resource's User
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          description: The SID of the participant's room
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_PA'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PA[0-9a-fA-F]{32}$
+          type: string
         start_time:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The time of participant connected to the room in ISO 8601 format
+          format: date-time
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/room_participant_status'
+          description: The status of the Participant
+          enum:
+          - connected
+          - disconnected
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     video.v1.room.room_participant.room_participant_published_track:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the track is enabled
+          nullable: true
+          type: boolean
         kind:
-          $ref: '#/components/schemas/room_participant_published_track_kind'
+          description: The track type
+          enum:
+          - audio
+          - video
+          - data
+          nullable: true
+          type: string
         name:
-          $ref: '#/components/schemas/string'
+          description: The track name
+          nullable: true
+          type: string
         participant_sid:
-          $ref: '#/components/schemas/sid_PA'
+          description: The SID of the Participant resource with the published track
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PA[0-9a-fA-F]{32}$
+          type: string
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          description: The SID of the Room resource where the track is published
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MT[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     video.v1.room.room_participant.room_participant_subscribe_rule:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         participant_sid:
-          $ref: '#/components/schemas/sid_PA'
+          description: The SID of the Participant resource for the Subscribe Rules
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PA[0-9a-fA-F]{32}$
+          type: string
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          description: The SID of the Room resource for the Subscribe Rules
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         rules:
-          $ref: '#/components/schemas/subscribe_rule_list'
+          description: A collection of Subscribe Rules that describe how to include
+            or exclude matching tracks
+          items:
+            type: object
+          nullable: true
+          type: array
       type: object
     video.v1.room.room_participant.room_participant_subscribed_track:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the track is enabled
+          nullable: true
+          type: boolean
         kind:
-          $ref: '#/components/schemas/room_participant_subscribed_track_kind'
+          description: The track type
+          enum:
+          - audio
+          - video
+          - data
+          nullable: true
+          type: string
         name:
-          $ref: '#/components/schemas/string'
+          description: The track name
+          nullable: true
+          type: string
         participant_sid:
-          $ref: '#/components/schemas/sid_PA'
+          description: The SID of the participant that subscribes to the track
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PA[0-9a-fA-F]{32}$
+          type: string
         publisher_sid:
-          $ref: '#/components/schemas/sid_PA'
+          description: The SID of the participant that publishes the track
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^PA[0-9a-fA-F]{32}$
+          type: string
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          description: The SID of the room where the track is published
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_MT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^MT[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     video.v1.room.room_recording:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         codec:
-          $ref: '#/components/schemas/room_recording_codec'
+          description: The codec used for the recording
+          enum:
+          - VP8
+          - H264
+          - OPUS
+          - PCMU
+          nullable: true
+          type: string
         container_format:
-          $ref: '#/components/schemas/room_recording_format'
+          description: The file format for the recording
+          enum:
+          - mka
+          - mkv
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         duration:
-          $ref: '#/components/schemas/integer'
+          description: The duration of the recording in seconds
+          nullable: true
+          type: integer
         grouping_sids:
-          $ref: '#/components/schemas/object'
+          description: A list of SIDs related to the Recording
+          nullable: true
+          type: object
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         offset:
-          $ref: '#/components/schemas/long'
+          description: The number of milliseconds between a point in time that is
+            common to all rooms in a group and when the source room of the recording
+            started
+          nullable: true
+          type: integer
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          description: The SID of the Room resource the recording is associated with
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_RT'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RT[0-9a-fA-F]{32}$
+          type: string
         size:
-          $ref: '#/components/schemas/long'
+          description: The size of the recorded track in bytes
+          nullable: true
+          type: integer
         source_sid:
-          $ref: '#/components/schemas/sid'
+          description: The SID of the recording source
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^[a-zA-Z]{2}[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/room_recording_status'
+          description: The status of the recording
+          enum:
+          - processing
+          - completed
+          - deleted
+          - failed
+          nullable: true
+          type: string
         track_name:
-          $ref: '#/components/schemas/string'
+          description: The name that was given to the source track of the recording
+          nullable: true
+          type: string
         type:
-          $ref: '#/components/schemas/room_recording_type'
+          description: The recording's media type
+          enum:
+          - audio
+          - video
+          - data
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     video.v1.room.room_recording_rule:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         room_sid:
-          $ref: '#/components/schemas/sid_RM'
+          description: The SID of the Room resource for the Recording Rules
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^RM[0-9a-fA-F]{32}$
+          type: string
         rules:
-          $ref: '#/components/schemas/recording_rule_list'
+          description: A collection of recording Rules that describe how to include
+            or exclude matching tracks for recording
+          items:
+            properties:
+              all:
+                type: boolean
+              kind:
+                type: string
+              publisher:
+                type: string
+              track:
+                type: string
+              type:
+                type: string
+            type: object
+          nullable: true
+          type: array
       type: object
   securitySchemes:
     accountSid_authToken:

--- a/spec/yaml/twilio_voice_v1.yaml
+++ b/spec/yaml/twilio_voice_v1.yaml
@@ -1,159 +1,211 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    iso_country_code:
-      nullable: true
-      type: string
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_BY:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^BY[0-9a-fA-F]{32}$
-      type: string
-    sid_IB:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IB[0-9a-fA-F]{32}$
-      type: string
-    sid_IL:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^IL[0-9a-fA-F]{32}$
-      type: string
-    sid_NE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^NE[0-9a-fA-F]{32}$
-      type: string
-    sid_NY:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^NY[0-9a-fA-F]{32}$
-      type: string
-    sid_SD:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^SD[0-9a-fA-F]{32}$
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
     voice.v1.byoc_trunk:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cnam_lookup_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether Caller ID Name (CNAM) lookup is enabled for the trunk
+          nullable: true
+          type: boolean
         connection_policy_sid:
-          $ref: '#/components/schemas/sid_NY'
+          description: Origination Connection Policy (to your Carrier)
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NY[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         from_domain_sid:
-          $ref: '#/components/schemas/sid_SD'
+          description: The SID of the SIP Domain that should be used in the `From`
+            header of originating calls
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SD[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_BY'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^BY[0-9a-fA-F]{32}$
+          type: string
         status_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call status_callback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         status_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL that we call with status updates
+          format: uri
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method used with voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs while executing TwiML
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method to use with voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when receiving a call
+          format: uri
+          nullable: true
+          type: string
       type: object
     voice.v1.connection_policy:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related resources
+          nullable: true
+          type: object
         sid:
-          $ref: '#/components/schemas/sid_NY'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NY[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     voice.v1.connection_policy.connection_policy_target:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         connection_policy_sid:
-          $ref: '#/components/schemas/sid_NY'
+          description: The SID of the Connection Policy that owns the Target
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NY[0-9a-fA-F]{32}$
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT when the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether the target is enabled
+          nullable: true
+          type: boolean
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         priority:
-          $ref: '#/components/schemas/integer'
+          description: The relative importance of the target
+          nullable: true
+          type: integer
         sid:
-          $ref: '#/components/schemas/sid_NE'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^NE[0-9a-fA-F]{32}$
+          type: string
         target:
-          $ref: '#/components/schemas/url'
+          description: The SIP address you want Twilio to route your calls to
+          format: uri
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         weight:
-          $ref: '#/components/schemas/integer'
+          description: The value that determines the relative load the Target should
+            receive compared to others with the same priority
+          nullable: true
+          type: integer
       type: object
     voice.v1.dialing_permissions:
       properties: {}
@@ -161,97 +213,206 @@ components:
     voice.v1.dialing_permissions.dialing_permissions_country:
       properties:
         continent:
-          $ref: '#/components/schemas/string'
+          description: The name of the continent in which the country is located
+          nullable: true
+          type: string
         country_codes:
-          $ref: '#/components/schemas/string_list'
+          description: The E.164 assigned country codes(s)
+          items:
+            type: string
+          nullable: true
+          type: array
         high_risk_special_numbers_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether dialing to high-risk special services numbers is enabled
+          nullable: true
+          type: boolean
         high_risk_tollfraud_numbers_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether dialing to high-risk toll fraud numbers is enabled,
+            else `false`
+          nullable: true
+          type: boolean
         iso_code:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of URLs related to this resource
+          nullable: true
+          type: object
         low_risk_numbers_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether dialing to low-risk numbers is enabled
+          nullable: true
+          type: boolean
         name:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of this resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     voice.v1.dialing_permissions.dialing_permissions_country-instance:
       properties:
         continent:
-          $ref: '#/components/schemas/string'
+          description: The name of the continent in which the country is located
+          nullable: true
+          type: string
         country_codes:
-          $ref: '#/components/schemas/string_list'
+          description: The E.164 assigned country codes(s)
+          items:
+            type: string
+          nullable: true
+          type: array
         high_risk_special_numbers_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether dialing to high-risk special services numbers is enabled
+          nullable: true
+          type: boolean
         high_risk_tollfraud_numbers_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether dialing to high-risk toll fraud numbers is enabled,
+            else `false`
+          nullable: true
+          type: boolean
         iso_code:
-          $ref: '#/components/schemas/iso_country_code'
+          description: The ISO country code
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: A list of URLs related to this resource
+          nullable: true
+          type: object
         low_risk_numbers_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether dialing to low-risk numbers is enabled
+          nullable: true
+          type: boolean
         name:
-          $ref: '#/components/schemas/string'
+          description: The name of the country
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of this resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     voice.v1.dialing_permissions.dialing_permissions_country.dialing_permissions_hrs_prefixes:
       properties:
         prefix:
-          $ref: '#/components/schemas/string'
+          description: A prefix that includes the E.164 assigned country code
+          nullable: true
+          type: string
       type: object
     voice.v1.dialing_permissions.dialing_permissions_country_bulk_update:
       properties:
         update_count:
-          $ref: '#/components/schemas/integer'
+          description: The number of countries updated
+          nullable: true
+          type: integer
         update_request:
-          $ref: '#/components/schemas/string'
+          description: A URL encoded JSON array of update objects
+          nullable: true
+          type: string
       type: object
     voice.v1.dialing_permissions.dialing_permissions_settings:
       properties:
         dialing_permissions_inheritance:
-          $ref: '#/components/schemas/boolean'
+          description: '`true` if the sub-account will inherit voice dialing permissions
+            from the Master Project; otherwise `false`'
+          nullable: true
+          type: boolean
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of this resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     voice.v1.ip_record:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cidr_prefix_length:
-          $ref: '#/components/schemas/integer'
+          description: An integer representing the length of the [CIDR](https://tools.ietf.org/html/rfc4632)
+            prefix to use with this IP address. By default the entire IP address is
+            used, which for IPv4 is value 32.
+          nullable: true
+          type: integer
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         ip_address:
-          $ref: '#/components/schemas/string'
+          description: An IP address in dotted decimal notation, IPv4 only.
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IL'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IL[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     voice.v1.source_ip_mapping:
       properties:
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT that the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The RFC 2822 date and time in GMT that the resource was last
+            updated
+          format: date-time
+          nullable: true
+          type: string
         ip_record_sid:
-          $ref: '#/components/schemas/sid_IL'
+          description: The unique string that identifies an IP Record
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IL[0-9a-fA-F]{32}$
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_IB'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^IB[0-9a-fA-F]{32}$
+          type: string
         sip_domain_sid:
-          $ref: '#/components/schemas/sid_SD'
+          description: The unique string that identifies a SIP Domain
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^SD[0-9a-fA-F]{32}$
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
   securitySchemes:
     accountSid_authToken:

--- a/spec/yaml/twilio_wireless_v1.yaml
+++ b/spec/yaml/twilio_wireless_v1.yaml
@@ -1,288 +1,476 @@
 components:
   schemas:
-    boolean:
-      nullable: true
-      type: boolean
-    command_command_mode:
-      enum:
-      - text
-      - binary
-      nullable: true
-      type: string
-    command_direction:
-      enum:
-      - from_sim
-      - to_sim
-      nullable: true
-      type: string
-    command_status:
-      enum:
-      - queued
-      - sent
-      - delivered
-      - received
-      - failed
-      nullable: true
-      type: string
-    command_transport:
-      enum:
-      - sms
-      - ip
-      nullable: true
-      type: string
-    date_time_iso8601:
-      format: date-time
-      nullable: true
-      type: string
-    http_method:
-      enum:
-      - HEAD
-      - GET
-      - POST
-      - PATCH
-      - PUT
-      - DELETE
-      nullable: true
-      type: string
-    integer:
-      nullable: true
-      type: integer
-    object:
-      nullable: true
-      type: object
-    sid_AC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^AC[0-9a-fA-F]{32}$
-      type: string
-    sid_DC:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^DC[0-9a-fA-F]{32}$
-      type: string
-    sid_DE:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^DE[0-9a-fA-F]{32}$
-      type: string
-    sid_WP:
-      maxLength: 34
-      minLength: 34
-      nullable: true
-      pattern: ^WP[0-9a-fA-F]{32}$
-      type: string
-    sid_like_DE:
-      nullable: true
-      type: string
-    sid_like_WN:
-      nullable: true
-      type: string
-    sim_reset_status:
-      enum:
-      - resetting
-      nullable: true
-      type: string
-    sim_status:
-      enum:
-      - new
-      - ready
-      - active
-      - suspended
-      - deactivated
-      - canceled
-      - scheduled
-      - updating
-      nullable: true
-      type: string
-    string:
-      nullable: true
-      type: string
-    string_list:
-      items:
-        type: string
-      nullable: true
-      type: array
-    uri_map:
-      nullable: true
-      type: object
-    url:
-      format: uri
-      nullable: true
-      type: string
     wireless.v1.account_usage_record:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         commands:
-          $ref: '#/components/schemas/object'
+          description: An object that describes the aggregated Commands usage for
+            all SIMs during the specified period
+          nullable: true
+          type: object
         data:
-          $ref: '#/components/schemas/object'
+          description: An object that describes the aggregated Data usage for all
+            SIMs over the period
+          nullable: true
+          type: object
         period:
-          $ref: '#/components/schemas/object'
+          description: The time period for which usage is reported
+          nullable: true
+          type: object
       type: object
     wireless.v1.command:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         command:
-          $ref: '#/components/schemas/string'
+          description: The message being sent to or from the SIM
+          nullable: true
+          type: string
         command_mode:
-          $ref: '#/components/schemas/command_command_mode'
+          description: The mode used to send the SMS message
+          enum:
+          - text
+          - binary
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was last
+            updated format
+          format: date-time
+          nullable: true
+          type: string
         delivery_receipt_requested:
-          $ref: '#/components/schemas/boolean'
+          description: Whether to request a delivery receipt
+          nullable: true
+          type: boolean
         direction:
-          $ref: '#/components/schemas/command_direction'
+          description: The direction of the Command
+          enum:
+          - from_sim
+          - to_sim
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_DC'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DC[0-9a-fA-F]{32}$
+          type: string
         sim_sid:
-          $ref: '#/components/schemas/sid_DE'
+          description: The SID of the Sim resource that the Command was sent to or
+            from
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DE[0-9a-fA-F]{32}$
+          type: string
         status:
-          $ref: '#/components/schemas/command_status'
+          description: The status of the Command
+          enum:
+          - queued
+          - sent
+          - delivered
+          - received
+          - failed
+          nullable: true
+          type: string
         transport:
-          $ref: '#/components/schemas/command_transport'
+          description: The type of transport used
+          enum:
+          - sms
+          - ip
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
       type: object
     wireless.v1.rate_plan:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         data_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether SIMs can use GPRS/3G/4G/LTE data connectivity
+          nullable: true
+          type: boolean
         data_limit:
-          $ref: '#/components/schemas/integer'
+          description: The total data usage in Megabytes that the Network allows during
+            one month on the home network
+          nullable: true
+          type: integer
         data_metering:
-          $ref: '#/components/schemas/string'
+          description: The model used to meter data usage
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date when the resource was created, given as GMT in ISO
+            8601 format
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date when the resource was last updated, given as GMT in
+            ISO 8601 format
+          format: date-time
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the resource
+          nullable: true
+          type: string
         international_roaming:
-          $ref: '#/components/schemas/string_list'
+          description: The services that SIMs capable of using GPRS/3G/4G/LTE data
+            connectivity can use outside of the United States
+          items:
+            type: string
+          nullable: true
+          type: array
         international_roaming_data_limit:
-          $ref: '#/components/schemas/integer'
+          description: The total data usage (download and upload combined) in Megabytes
+            that the Network allows during one month when roaming outside the United
+            States
+          nullable: true
+          type: integer
         messaging_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether SIMs can make, send, and receive SMS using Commands
+          nullable: true
+          type: boolean
         national_roaming_data_limit:
-          $ref: '#/components/schemas/integer'
+          description: The total data usage in Megabytes that the Network allows during
+            one month on non-home networks in the United States
+          nullable: true
+          type: integer
         national_roaming_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether SIMs can roam on networks other than the home network
+            in the United States
+          nullable: true
+          type: boolean
         sid:
-          $ref: '#/components/schemas/sid_WP'
+          description: The unique string that identifies the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WP[0-9a-fA-F]{32}$
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         voice_enabled:
-          $ref: '#/components/schemas/boolean'
+          description: Whether SIMs can make and receive voice calls
+          nullable: true
+          type: boolean
       type: object
     wireless.v1.sim:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account to which the Sim resource belongs
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         commands_callback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call commands_callback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         commands_callback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the SIM originates a machine-to-machine
+            Command
+          format: uri
+          nullable: true
+          type: string
         date_created:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the resource was created
+          format: date-time
+          nullable: true
+          type: string
         date_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The ISO 8601 date and time in GMT when the Sim resource was
+            last updated
+          format: date-time
+          nullable: true
+          type: string
         e_id:
-          $ref: '#/components/schemas/string'
+          description: Deprecated
+          nullable: true
+          type: string
         friendly_name:
-          $ref: '#/components/schemas/string'
+          description: The string that you assigned to describe the Sim resource
+          nullable: true
+          type: string
         iccid:
-          $ref: '#/components/schemas/string'
+          description: The ICCID associated with the SIM
+          nullable: true
+          type: string
         ip_address:
-          $ref: '#/components/schemas/string'
+          description: Deprecated
+          nullable: true
+          type: string
         links:
-          $ref: '#/components/schemas/uri_map'
+          description: The URLs of related subresources
+          nullable: true
+          type: object
         rate_plan_sid:
-          $ref: '#/components/schemas/sid_WP'
+          description: The SID of the RatePlan resource to which the Sim resource
+            is assigned.
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^WP[0-9a-fA-F]{32}$
+          type: string
         reset_status:
-          $ref: '#/components/schemas/sim_reset_status'
+          description: The connectivity reset status of the SIM
+          enum:
+          - resetting
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_DE'
+          description: The unique string that identifies the Sim resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^DE[0-9a-fA-F]{32}$
+          type: string
         sms_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call sms_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs while retrieving or executing
+            the TwiML requested from the sms_url
+          format: uri
+          nullable: true
+          type: string
         sms_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call sms_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         sms_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the SIM-connected device sends an SMS
+            message that is not a Command
+          format: uri
+          nullable: true
+          type: string
         status:
-          $ref: '#/components/schemas/sim_status'
+          description: The status of the Sim resource
+          enum:
+          - new
+          - ready
+          - active
+          - suspended
+          - deactivated
+          - canceled
+          - scheduled
+          - updating
+          nullable: true
+          type: string
         unique_name:
-          $ref: '#/components/schemas/string'
+          description: An application-defined string that uniquely identifies the
+            resource
+          nullable: true
+          type: string
         url:
-          $ref: '#/components/schemas/url'
+          description: The absolute URL of the resource
+          format: uri
+          nullable: true
+          type: string
         voice_fallback_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call voice_fallback_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_fallback_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when an error occurs while retrieving or executing
+            the TwiML requested from voice_url
+          format: uri
+          nullable: true
+          type: string
         voice_method:
-          $ref: '#/components/schemas/http_method'
+          description: The HTTP method we use to call voice_url
+          enum:
+          - HEAD
+          - GET
+          - POST
+          - PATCH
+          - PUT
+          - DELETE
+          nullable: true
+          type: string
         voice_url:
-          $ref: '#/components/schemas/url'
+          description: The URL we call when the SIM-connected device makes a voice
+            call
+          format: uri
+          nullable: true
+          type: string
       type: object
     wireless.v1.sim.data_session:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         cell_id:
-          $ref: '#/components/schemas/string'
+          description: The unique ID of the cellular tower that the device was attached
+            to at the moment when the Data Session was last updated
+          nullable: true
+          type: string
         cell_location_estimate:
-          $ref: '#/components/schemas/object'
+          description: An object with the estimated location where the device's Data
+            Session took place
+          nullable: true
+          type: object
         end:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that the record ended, given as GMT in ISO 8601 format
+          format: date-time
+          nullable: true
+          type: string
         imei:
-          $ref: '#/components/schemas/string'
+          description: The unique ID of the device using the SIM to connect
+          nullable: true
+          type: string
         last_updated:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that the resource was last updated, given as GMT in
+            ISO 8601 format
+          format: date-time
+          nullable: true
+          type: string
         operator_country:
-          $ref: '#/components/schemas/string'
+          description: The three letter country code representing where the device's
+            Data Session took place
+          nullable: true
+          type: string
         operator_mcc:
-          $ref: '#/components/schemas/string'
+          description: The 'mobile country code' is the unique ID of the home country
+            where the Data Session took place
+          nullable: true
+          type: string
         operator_mnc:
-          $ref: '#/components/schemas/string'
+          description: The 'mobile network code' is the unique ID specific to the
+            mobile operator network where the Data Session took place
+          nullable: true
+          type: string
         operator_name:
-          $ref: '#/components/schemas/string'
+          description: The friendly name of the mobile operator network that the SIM-connected
+            device is attached to
+          nullable: true
+          type: string
         packets_downloaded:
-          $ref: '#/components/schemas/integer'
+          description: The number of packets downloaded by the device between the
+            start time and when the Data Session was last updated
+          nullable: true
+          type: integer
         packets_uploaded:
-          $ref: '#/components/schemas/integer'
+          description: The number of packets uploaded by the device between the start
+            time and when the Data Session was last updated
+          nullable: true
+          type: integer
         radio_link:
-          $ref: '#/components/schemas/string'
+          description: The generation of wireless technology that the device was using
+          nullable: true
+          type: string
         sid:
-          $ref: '#/components/schemas/sid_like_WN'
+          description: The unique string that identifies the resource
+          nullable: true
+          type: string
         sim_sid:
-          $ref: '#/components/schemas/sid_like_DE'
+          description: The SID of the Sim resource that the Data Session is for
+          nullable: true
+          type: string
         start:
-          $ref: '#/components/schemas/date_time_iso8601'
+          description: The date that the Data Session started, given as GMT in ISO
+            8601 format
+          format: date-time
+          nullable: true
+          type: string
       type: object
     wireless.v1.sim.usage_record:
       properties:
         account_sid:
-          $ref: '#/components/schemas/sid_AC'
+          description: The SID of the Account that created the resource
+          maxLength: 34
+          minLength: 34
+          nullable: true
+          pattern: ^AC[0-9a-fA-F]{32}$
+          type: string
         commands:
-          $ref: '#/components/schemas/object'
+          description: An object that describes the SIM's usage of Commands during
+            the specified period
+          nullable: true
+          type: object
         data:
-          $ref: '#/components/schemas/object'
+          description: An object that describes the SIM's data usage during the specified
+            period
+          nullable: true
+          type: object
         period:
-          $ref: '#/components/schemas/object'
+          description: The time period for which the usage is reported
+          nullable: true
+          type: object
         sim_sid:
-          $ref: '#/components/schemas/sid_like_DE'
+          description: The SID of the Sim resource that this Usage Record is for
+          nullable: true
+          type: string
       type: object
   securitySchemes:
     accountSid_authToken:


### PR DESCRIPTION
# Fixes #
[DI-1214](https://issues.corp.twilio.com/browse/DI-1214)

Add property descriptions to OAI and roll back changes that moved property schema definitions to global component schema.

Related PRs:
https://code.hq.twilio.com/twilio/yps/pull/72
https://github.com/twilio/twilio-cli-core/pull/117