### PR TITLE
chore: drop unneeded class names

### DIFF
--- a/spec/json/twilio_accounts_v1.json
+++ b/spec/json/twilio_accounts_v1.json
@@ -297,7 +297,6 @@
         }
       ],
       "x-twilio": {
-        "className": "credential",
         "defaultOutputProperties": [],
         "pathType": "list"
       }

--- a/spec/json/twilio_api_v2010.json
+++ b/spec/json/twilio_api_v2010.json
@@ -24346,7 +24346,6 @@
         }
       ],
       "x-twilio": {
-        "className": "sip",
         "defaultOutputProperties": [],
         "parent": "/Accounts.json",
         "pathType": "list"
@@ -28892,7 +28891,6 @@
         }
       ],
       "x-twilio": {
-        "className": "usage",
         "defaultOutputProperties": [],
         "parent": "/Accounts.json",
         "pathType": "list"

--- a/spec/json/twilio_numbers_v2.json
+++ b/spec/json/twilio_numbers_v2.json
@@ -639,7 +639,6 @@
         }
       ],
       "x-twilio": {
-        "className": "regulatory_compliance",
         "defaultOutputProperties": [],
         "pathType": "list"
       }

--- a/spec/json/twilio_pricing_v1.json
+++ b/spec/json/twilio_pricing_v1.json
@@ -429,7 +429,6 @@
         }
       ],
       "x-twilio": {
-        "className": "messaging",
         "defaultOutputProperties": [
           "name"
         ],
@@ -591,7 +590,6 @@
         }
       ],
       "x-twilio": {
-        "className": "phone_number",
         "defaultOutputProperties": [
           "name"
         ],
@@ -749,7 +747,6 @@
         }
       ],
       "x-twilio": {
-        "className": "voice",
         "defaultOutputProperties": [
           "name"
         ],

--- a/spec/json/twilio_pricing_v2.json
+++ b/spec/json/twilio_pricing_v2.json
@@ -630,7 +630,6 @@
         }
       ],
       "x-twilio": {
-        "className": "voice",
         "defaultOutputProperties": [
           "name"
         ],

--- a/spec/yaml/twilio_accounts_v1.yaml
+++ b/spec/yaml/twilio_accounts_v1.yaml
@@ -227,7 +227,6 @@ paths:
     servers:
     - url: https://accounts.twilio.com
     x-twilio:
-      className: credential
       defaultOutputProperties: []
       pathType: list
   /v1/Credentials/AWS:

--- a/spec/yaml/twilio_api_v2010.yaml
+++ b/spec/yaml/twilio_api_v2010.yaml
@@ -19927,7 +19927,6 @@ paths:
     servers:
     - url: https://api.twilio.com
     x-twilio:
-      className: sip
       defaultOutputProperties: []
       parent: /Accounts.json
       pathType: list
@@ -23154,7 +23153,6 @@ paths:
     servers:
     - url: https://api.twilio.com
     x-twilio:
-      className: usage
       defaultOutputProperties: []
       parent: /Accounts.json
       pathType: list

--- a/spec/yaml/twilio_numbers_v2.yaml
+++ b/spec/yaml/twilio_numbers_v2.yaml
@@ -530,7 +530,6 @@ paths:
     servers:
     - url: https://numbers.twilio.com
     x-twilio:
-      className: regulatory_compliance
       defaultOutputProperties: []
       pathType: list
   /v2/RegulatoryCompliance/Bundles:

--- a/spec/yaml/twilio_pricing_v1.yaml
+++ b/spec/yaml/twilio_pricing_v1.yaml
@@ -320,7 +320,6 @@ paths:
     servers:
     - url: https://pricing.twilio.com
     x-twilio:
-      className: messaging
       defaultOutputProperties:
       - name
       pathType: instance
@@ -426,7 +425,6 @@ paths:
     servers:
     - url: https://pricing.twilio.com
     x-twilio:
-      className: phone_number
       defaultOutputProperties:
       - name
       pathType: list
@@ -528,7 +526,6 @@ paths:
     servers:
     - url: https://pricing.twilio.com
     x-twilio:
-      className: voice
       defaultOutputProperties:
       - name
       pathType: instance

--- a/spec/yaml/twilio_pricing_v2.yaml
+++ b/spec/yaml/twilio_pricing_v2.yaml
@@ -453,7 +453,6 @@ paths:
     servers:
     - url: https://pricing.twilio.com
     x-twilio:
-      className: voice
       defaultOutputProperties:
       - name
       pathType: instance


### PR DESCRIPTION
Refactored the setting of the className vendor extension so it's not set when it matches the singularized path name.