### PR TITLE
docs: Add blank defaults for optional enums

### DIFF
--- a/spec/json/twilio_api_v2010.json
+++ b/spec/json/twilio_api_v2010.json
@@ -3972,25 +3972,29 @@
         "type": "string",
         "enum": [
           "retain"
-        ]
+        ],
+        "default": ""
       },
       "message_enum_address_retention": {
         "type": "string",
         "enum": [
           "retain"
-        ]
+        ],
+        "default": ""      
       },
       "message_enum_traffic_type": {
         "type": "string",
         "enum": [
           "free"
-        ]
+        ],
+        "default": ""
       },
       "message_enum_schedule_type": {
         "type": "string",
         "enum": [
           "fixed"
-        ]
+        ],
+        "default": ""
       },
       "api.v2010.account.message.message_feedback": {
         "type": "object",


### PR DESCRIPTION
When rendering this spec in Swagger UI, the first item in the enum is getting selected by default and causing errors in some cases (e.g.`message_enum_schedule_type` of `fixed` fails unless you are sending a scheduled message). Setting the default to blank solves it.
