### PR TITLE
docs: Add tags to all json specs

### DIFF
--- a/spec/json/twilio_accounts_v1.json
+++ b/spec/json/twilio_accounts_v1.json
@@ -228,6 +228,9 @@
         "operationId": "UpdateAuthTokenPromotion",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Promote"
         ]
       }
     },
@@ -332,6 +335,9 @@
         "operationId": "ListCredentialAws",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AWS"
         ]
       },
       "post": {
@@ -386,7 +392,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "AWS"
+        ]
       }
     },
     "/v1/Credentials/AWS/{Sid}": {
@@ -441,6 +450,9 @@
         "operationId": "FetchCredentialAws",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AWS"
         ]
       },
       "post": {
@@ -495,7 +507,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "AWS"
+        ]
       },
       "delete": {
         "description": "Delete a Credential from your account",
@@ -526,6 +541,9 @@
         "operationId": "DeleteCredentialAws",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AWS"
         ]
       }
     },
@@ -618,6 +636,9 @@
         "operationId": "ListCredentialPublicKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PublicKeys"
         ]
       },
       "post": {
@@ -672,7 +693,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PublicKeys"
+        ]
       }
     },
     "/v1/Credentials/PublicKeys/{Sid}": {
@@ -727,6 +751,9 @@
         "operationId": "FetchCredentialPublicKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PublicKeys"
         ]
       },
       "post": {
@@ -781,7 +808,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PublicKeys"
+        ]
       },
       "delete": {
         "description": "Delete a Credential from your account",
@@ -812,6 +842,9 @@
         "operationId": "DeleteCredentialPublicKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PublicKeys"
         ]
       }
     },
@@ -853,6 +886,9 @@
         "operationId": "CreateSecondaryAuthToken",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Secondary"
         ]
       },
       "delete": {
@@ -870,6 +906,9 @@
         "operationId": "DeleteSecondaryAuthToken",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Secondary"
         ]
       }
     }

--- a/spec/json/twilio_api_v2010.json
+++ b/spec/json/twilio_api_v2010.json
@@ -9559,7 +9559,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Accounts"
+        ]
       },
       "get": {
         "description": "Retrieves a collection of Accounts belonging to the account used to make the request",
@@ -9649,6 +9652,9 @@
         "operationId": "ListAccount",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Accounts"
         ]
       }
     },
@@ -9703,6 +9709,9 @@
         "operationId": "FetchAccount",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Accounts"
         ]
       },
       "post": {
@@ -9762,7 +9771,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Accounts"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Addresses.json": {
@@ -9875,7 +9887,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Addresses"
+        ]
       },
       "get": {
         "description": "",
@@ -9985,6 +10000,9 @@
         "operationId": "ListAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Addresses"
         ]
       }
     },
@@ -10046,6 +10064,9 @@
         "operationId": "DeleteAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Addresses"
         ]
       },
       "get": {
@@ -10096,6 +10117,9 @@
         "operationId": "FetchAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Addresses"
         ]
       },
       "post": {
@@ -10190,7 +10214,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Addresses"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Applications.json": {
@@ -10369,7 +10396,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Applications"
+        ]
       },
       "get": {
         "description": "Retrieve a list of applications representing an application within the requesting account",
@@ -10462,6 +10492,9 @@
         "operationId": "ListApplication",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Applications"
         ]
       }
     },
@@ -10522,6 +10555,9 @@
         "operationId": "DeleteApplication",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Applications"
         ]
       },
       "get": {
@@ -10572,6 +10608,9 @@
         "operationId": "FetchApplication",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Applications"
         ]
       },
       "post": {
@@ -10746,7 +10785,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Applications"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/AuthorizedConnectApps/{ConnectAppSid}.json": {
@@ -10812,6 +10854,9 @@
         "operationId": "FetchAuthorizedConnectApp",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AuthorizedConnectApps"
         ]
       }
     },
@@ -10913,6 +10958,9 @@
         "operationId": "ListAuthorizedConnectApp",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AuthorizedConnectApps"
         ]
       }
     },
@@ -11016,6 +11064,9 @@
         "operationId": "ListAvailablePhoneNumberCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AvailablePhoneNumbers"
         ]
       }
     },
@@ -11082,6 +11133,9 @@
         "operationId": "FetchAvailablePhoneNumberCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AvailablePhoneNumbers"
         ]
       }
     },
@@ -11339,6 +11393,9 @@
         "operationId": "ListAvailablePhoneNumberLocal",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Local"
         ]
       }
     },
@@ -11596,6 +11653,9 @@
         "operationId": "ListAvailablePhoneNumberMachineToMachine",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "MachineToMachine"
         ]
       }
     },
@@ -11853,6 +11913,9 @@
         "operationId": "ListAvailablePhoneNumberMobile",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Mobile"
         ]
       }
     },
@@ -12110,6 +12173,9 @@
         "operationId": "ListAvailablePhoneNumberNational",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "National"
         ]
       }
     },
@@ -12367,6 +12433,9 @@
         "operationId": "ListAvailablePhoneNumberSharedCost",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SharedCost"
         ]
       }
     },
@@ -12624,6 +12693,9 @@
         "operationId": "ListAvailablePhoneNumberTollFree",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TollFree"
         ]
       }
     },
@@ -12881,6 +12953,9 @@
         "operationId": "ListAvailablePhoneNumberVoip",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Voip"
         ]
       }
     },
@@ -12936,6 +13011,9 @@
         "operationId": "FetchBalance",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Balance"
         ]
       }
     },
@@ -13222,7 +13300,10 @@
               "application_sid"
             ]
           ]
-        }
+        },
+        "tags": [
+          "Calls"
+        ]
       },
       "get": {
         "description": "Retrieves a collection of calls made to and from your account",
@@ -13399,6 +13480,9 @@
         "operationId": "ListCall",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Calls"
         ]
       }
     },
@@ -13461,6 +13545,9 @@
         "operationId": "DeleteCall",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Calls"
         ]
       },
       "get": {
@@ -13511,6 +13598,9 @@
         "operationId": "FetchCall",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Calls"
         ]
       },
       "post": {
@@ -13641,7 +13731,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Calls"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Calls/{CallSid}/Events.json": {
@@ -13754,6 +13847,9 @@
         "operationId": "ListCallEvent",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Events"
         ]
       }
     },
@@ -13821,6 +13917,9 @@
         "operationId": "FetchCallFeedback",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Feedback"
         ]
       },
       "post": {
@@ -13892,7 +13991,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Feedback"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Calls/FeedbackSummary.json": {
@@ -13996,7 +14098,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FeedbackSummary"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Calls/FeedbackSummary/{Sid}.json": {
@@ -14064,6 +14169,9 @@
         "operationId": "FetchCallFeedbackSummary",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "FeedbackSummary"
         ]
       },
       "delete": {
@@ -14107,6 +14215,9 @@
         "operationId": "DeleteCallFeedbackSummary",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "FeedbackSummary"
         ]
       }
     },
@@ -14187,6 +14298,9 @@
         "operationId": "FetchCallNotification",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Notifications"
         ]
       }
     },
@@ -14337,6 +14451,9 @@
         "operationId": "ListCallNotification",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Notifications"
         ]
       }
     },
@@ -14455,7 +14572,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Recordings"
+        ]
       },
       "get": {
         "description": "Retrieve a list of recordings belonging to the call used to make the request",
@@ -14579,6 +14699,9 @@
         "operationId": "ListCallRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -14681,7 +14804,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Recordings"
+        ]
       },
       "get": {
         "description": "Fetch an instance of a recording for a call",
@@ -14743,6 +14869,9 @@
         "operationId": "FetchCallRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       },
       "delete": {
@@ -14798,6 +14927,9 @@
         "operationId": "DeleteCallRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -14865,6 +14997,9 @@
         "operationId": "FetchConference",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conferences"
         ]
       },
       "post": {
@@ -14947,7 +15082,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Conferences"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Conferences.json": {
@@ -15120,6 +15258,9 @@
         "operationId": "ListConference",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conferences"
         ]
       }
     },
@@ -15222,7 +15363,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Recordings"
+        ]
       },
       "get": {
         "description": "Fetch an instance of a recording for a call",
@@ -15284,6 +15428,9 @@
         "operationId": "FetchConferenceRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       },
       "delete": {
@@ -15339,6 +15486,9 @@
         "operationId": "DeleteConferenceRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -15482,6 +15632,9 @@
         "operationId": "ListConferenceRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -15548,6 +15701,9 @@
         "operationId": "FetchConnectApp",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ConnectApps"
         ]
       },
       "post": {
@@ -15658,7 +15814,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ConnectApps"
+        ]
       },
       "delete": {
         "description": "Delete an instance of a connect-app",
@@ -15701,6 +15860,9 @@
         "operationId": "DeleteConnectApp",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ConnectApps"
         ]
       }
     },
@@ -15802,6 +15964,9 @@
         "operationId": "ListConnectApp",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ConnectApps"
         ]
       }
     },
@@ -15916,6 +16081,9 @@
         "operationId": "ListDependentPhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "DependentPhoneNumbers"
         ]
       }
     },
@@ -16163,7 +16331,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IncomingPhoneNumbers"
+        ]
       },
       "get": {
         "description": "Fetch an incoming-phone-number belonging to the account used to make the request.",
@@ -16213,6 +16384,9 @@
         "operationId": "FetchIncomingPhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IncomingPhoneNumbers"
         ]
       },
       "delete": {
@@ -16256,6 +16430,9 @@
         "operationId": "DeleteIncomingPhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IncomingPhoneNumbers"
         ]
       }
     },
@@ -16391,6 +16568,9 @@
         "operationId": "ListIncomingPhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IncomingPhoneNumbers"
         ]
       },
       "post": {
@@ -16619,7 +16799,10 @@
               "area_code"
             ]
           ]
-        }
+        },
+        "tags": [
+          "IncomingPhoneNumbers"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns/{Sid}.json": {
@@ -16699,6 +16882,9 @@
         "operationId": "FetchIncomingPhoneNumberAssignedAddOn",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "AssignedAddOns"
         ]
       },
       "delete": {
@@ -16754,6 +16940,9 @@
         "operationId": "DeleteIncomingPhoneNumberAssignedAddOn",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "AssignedAddOns"
         ]
       }
     },
@@ -16869,6 +17058,9 @@
         "operationId": "ListIncomingPhoneNumberAssignedAddOn",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "AssignedAddOns"
         ]
       },
       "post": {
@@ -16941,7 +17133,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "AssignedAddOns"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns/{AssignedAddOnSid}/Extensions/{Sid}.json": {
@@ -17034,6 +17229,9 @@
         "operationId": "FetchIncomingPhoneNumberAssignedAddOnExtension",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Extensions"
         ]
       }
     },
@@ -17162,6 +17360,9 @@
         "operationId": "ListIncomingPhoneNumberAssignedAddOnExtension",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Extensions"
         ]
       }
     },
@@ -17297,6 +17498,9 @@
         "operationId": "ListIncomingPhoneNumberLocal",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Local"
         ]
       },
       "post": {
@@ -17516,7 +17720,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Local"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers/Mobile.json": {
@@ -17651,6 +17858,9 @@
         "operationId": "ListIncomingPhoneNumberMobile",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Mobile"
         ]
       },
       "post": {
@@ -17870,7 +18080,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Mobile"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers/TollFree.json": {
@@ -18005,6 +18218,9 @@
         "operationId": "ListIncomingPhoneNumberTollFree",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TollFree"
         ]
       },
       "post": {
@@ -18224,7 +18440,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "TollFree"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Keys/{Sid}.json": {
@@ -18291,6 +18510,9 @@
         "operationId": "FetchKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Keys"
         ]
       },
       "post": {
@@ -18357,7 +18579,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Keys"
+        ]
       },
       "delete": {
         "description": "",
@@ -18400,6 +18625,9 @@
         "operationId": "DeleteKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Keys"
         ]
       }
     },
@@ -18502,6 +18730,9 @@
         "operationId": "ListKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Keys"
         ]
       },
       "post": {
@@ -18559,7 +18790,10 @@
         },
         "x-twilio": {
           "className": "new_key"
-        }
+        },
+        "tags": [
+          "Keys"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Messages/{MessageSid}/Media/{Sid}.json": {
@@ -18631,6 +18865,9 @@
         "operationId": "DeleteMedia",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Media"
         ]
       },
       "get": {
@@ -18693,6 +18930,9 @@
         "operationId": "FetchMedia",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Media"
         ]
       }
     },
@@ -18834,6 +19074,9 @@
         "operationId": "ListMedia",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Media"
         ]
       }
     },
@@ -18911,6 +19154,9 @@
         "operationId": "FetchMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "post": {
@@ -19003,7 +19249,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Queues/{QueueSid}/Members.json": {
@@ -19118,6 +19367,9 @@
         "operationId": "ListMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       }
     },
@@ -19299,7 +19551,10 @@
               "media_url"
             ]
           ]
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "get": {
         "description": "Retrieve a list of messages belonging to the account used to make the request",
@@ -19429,6 +19684,9 @@
         "operationId": "ListMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -19492,6 +19750,9 @@
         "operationId": "DeleteMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "get": {
@@ -19542,6 +19803,9 @@
         "operationId": "FetchMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "post": {
@@ -19613,7 +19877,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Messages/{MessageSid}/Feedback.json": {
@@ -19697,7 +19964,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Feedback"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/SigningKeys.json": {
@@ -19771,7 +20041,10 @@
         },
         "x-twilio": {
           "className": "new_signing_key"
-        }
+        },
+        "tags": [
+          "SigningKeys"
+        ]
       },
       "get": {
         "description": "",
@@ -19856,6 +20129,9 @@
         "operationId": "ListSigningKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SigningKeys"
         ]
       }
     },
@@ -19924,6 +20200,9 @@
         "operationId": "FetchNotification",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Notifications"
         ]
       }
     },
@@ -20062,6 +20341,9 @@
         "operationId": "ListNotification",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Notifications"
         ]
       }
     },
@@ -20129,6 +20411,9 @@
         "operationId": "FetchOutgoingCallerId",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "OutgoingCallerIds"
         ]
       },
       "post": {
@@ -20195,7 +20480,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "OutgoingCallerIds"
+        ]
       },
       "delete": {
         "description": "Delete the caller-id specified from the account",
@@ -20238,6 +20526,9 @@
         "operationId": "DeleteOutgoingCallerId",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "OutgoingCallerIds"
         ]
       }
     },
@@ -20357,6 +20648,9 @@
         "operationId": "ListOutgoingCallerId",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "OutgoingCallerIds"
         ]
       },
       "post": {
@@ -20448,7 +20742,10 @@
         },
         "x-twilio": {
           "className": "validation_request"
-        }
+        },
+        "tags": [
+          "OutgoingCallerIds"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Conferences/{ConferenceSid}/Participants/{CallSid}.json": {
@@ -20526,6 +20823,9 @@
         "operationId": "FetchParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       },
       "post": {
@@ -20678,7 +20978,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       },
       "delete": {
         "description": "Kick a participant from a given conference",
@@ -20730,6 +21033,9 @@
         "operationId": "DeleteParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -21038,7 +21344,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       },
       "get": {
         "description": "Retrieve a list of participants belonging to the account used to make the request",
@@ -21159,6 +21468,9 @@
         "operationId": "ListParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -21307,7 +21619,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Payments"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Calls/{CallSid}/Payments/{Sid}.json": {
@@ -21419,7 +21734,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Payments"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Queues/{Sid}.json": {
@@ -21487,6 +21805,9 @@
         "operationId": "FetchQueue",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Queues"
         ]
       },
       "post": {
@@ -21557,7 +21878,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Queues"
+        ]
       },
       "delete": {
         "description": "Remove an empty queue",
@@ -21600,6 +21924,9 @@
         "operationId": "DeleteQueue",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Queues"
         ]
       }
     },
@@ -21703,6 +22030,9 @@
         "operationId": "ListQueue",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Queues"
         ]
       },
       "post": {
@@ -21764,7 +22094,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Queues"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Recordings/{Sid}.json": {
@@ -21841,6 +22174,9 @@
         "operationId": "FetchRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       },
       "delete": {
@@ -21884,6 +22220,9 @@
         "operationId": "DeleteRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -22045,6 +22384,9 @@
         "operationId": "ListRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -22125,6 +22467,9 @@
         "operationId": "FetchRecordingAddOnResult",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AddOnResults"
         ]
       },
       "delete": {
@@ -22180,6 +22525,9 @@
         "operationId": "DeleteRecordingAddOnResult",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AddOnResults"
         ]
       }
     },
@@ -22295,6 +22643,9 @@
         "operationId": "ListRecordingAddOnResult",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AddOnResults"
         ]
       }
     },
@@ -22386,6 +22737,9 @@
         "operationId": "FetchRecordingAddOnResultPayload",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Payloads"
         ]
       },
       "delete": {
@@ -22453,6 +22807,9 @@
         "operationId": "DeleteRecordingAddOnResultPayload",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Payloads"
         ]
       }
     },
@@ -22579,6 +22936,9 @@
         "operationId": "ListRecordingAddOnResultPayload",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Payloads"
         ]
       }
     },
@@ -22659,6 +23019,9 @@
         "operationId": "FetchRecordingTranscription",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Transcriptions"
         ]
       },
       "delete": {
@@ -22714,6 +23077,9 @@
         "operationId": "DeleteRecordingTranscription",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Transcriptions"
         ]
       }
     },
@@ -22829,6 +23195,9 @@
         "operationId": "ListRecordingTranscription",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Transcriptions"
         ]
       }
     },
@@ -22896,6 +23265,9 @@
         "operationId": "FetchShortCode",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ShortCodes"
         ]
       },
       "post": {
@@ -23002,7 +23374,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ShortCodes"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/SMS/ShortCodes.json": {
@@ -23120,6 +23495,9 @@
         "operationId": "ListShortCode",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ShortCodes"
         ]
       }
     },
@@ -23186,6 +23564,9 @@
         "operationId": "FetchSigningKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SigningKeys"
         ]
       },
       "post": {
@@ -23252,7 +23633,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SigningKeys"
+        ]
       },
       "delete": {
         "description": "",
@@ -23295,6 +23679,9 @@
         "operationId": "DeleteSigningKey",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SigningKeys"
         ]
       }
     },
@@ -23425,7 +23812,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CredentialListMappings"
+        ]
       },
       "get": {
         "description": "Retrieve a list of credential list mappings belonging to the domain used in the request",
@@ -23522,6 +23912,9 @@
         "operationId": "ListSipAuthCallsCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       }
     },
@@ -23601,6 +23994,9 @@
         "operationId": "FetchSipAuthCallsCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       },
       "delete": {
@@ -23656,6 +24052,9 @@
         "operationId": "DeleteSipAuthCallsCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       }
     },
@@ -23745,7 +24144,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpAccessControlListMappings"
+        ]
       },
       "get": {
         "description": "Retrieve a list of IP Access Control List mappings belonging to the domain used in the request",
@@ -23842,6 +24244,9 @@
         "operationId": "ListSipAuthCallsIpAccessControlListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlListMappings"
         ]
       }
     },
@@ -23921,6 +24326,9 @@
         "operationId": "FetchSipAuthCallsIpAccessControlListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlListMappings"
         ]
       },
       "delete": {
@@ -23976,6 +24384,9 @@
         "operationId": "DeleteSipAuthCallsIpAccessControlListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlListMappings"
         ]
       }
     },
@@ -24079,7 +24490,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CredentialListMappings"
+        ]
       },
       "get": {
         "description": "Retrieve a list of credential list mappings belonging to the domain used in the request",
@@ -24176,6 +24590,9 @@
         "operationId": "ListSipAuthRegistrationsCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       }
     },
@@ -24255,6 +24672,9 @@
         "operationId": "FetchSipAuthRegistrationsCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       },
       "delete": {
@@ -24310,6 +24730,9 @@
         "operationId": "DeleteSipAuthRegistrationsCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       }
     },
@@ -24424,6 +24847,9 @@
         "operationId": "ListSipCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -24498,7 +24924,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/SIP/CredentialLists/{CredentialListSid}/Credentials/{Sid}.json": {
@@ -24577,6 +25006,9 @@
         "operationId": "FetchSipCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -24655,7 +25087,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       },
       "delete": {
         "description": "Delete a credential resource.",
@@ -24710,6 +25145,9 @@
         "operationId": "DeleteSipCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       }
     },
@@ -24811,6 +25249,9 @@
         "operationId": "ListSipCredentialList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialLists"
         ]
       },
       "post": {
@@ -24868,7 +25309,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CredentialLists"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/SIP/CredentialLists/{Sid}.json": {
@@ -24934,6 +25378,9 @@
         "operationId": "FetchSipCredentialList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialLists"
         ]
       },
       "post": {
@@ -25003,7 +25450,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CredentialLists"
+        ]
       },
       "delete": {
         "description": "Delete a Credential List",
@@ -25046,6 +25496,9 @@
         "operationId": "DeleteSipCredentialList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialLists"
         ]
       }
     },
@@ -25134,7 +25587,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CredentialListMappings"
+        ]
       },
       "get": {
         "description": "Read multiple CredentialListMapping resources from an account.",
@@ -25231,6 +25687,9 @@
         "operationId": "ListSipCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       }
     },
@@ -25309,6 +25768,9 @@
         "operationId": "FetchSipCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       },
       "delete": {
@@ -25364,6 +25826,9 @@
         "operationId": "DeleteSipCredentialListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialListMappings"
         ]
       }
     },
@@ -25466,6 +25931,9 @@
         "operationId": "ListSipDomain",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Domains"
         ]
       },
       "post": {
@@ -25607,7 +26075,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Domains"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/SIP/Domains/{Sid}.json": {
@@ -25674,6 +26145,9 @@
         "operationId": "FetchSipDomain",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Domains"
         ]
       },
       "post": {
@@ -25824,7 +26298,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Domains"
+        ]
       },
       "delete": {
         "description": "Delete an instance of a Domain",
@@ -25867,6 +26344,9 @@
         "operationId": "DeleteSipDomain",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Domains"
         ]
       }
     },
@@ -25968,6 +26448,9 @@
         "operationId": "ListSipIpAccessControlList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlLists"
         ]
       },
       "post": {
@@ -26025,7 +26508,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpAccessControlLists"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/SIP/IpAccessControlLists/{Sid}.json": {
@@ -26091,6 +26577,9 @@
         "operationId": "FetchSipIpAccessControlList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlLists"
         ]
       },
       "post": {
@@ -26160,7 +26649,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpAccessControlLists"
+        ]
       },
       "delete": {
         "description": "Delete an IpAccessControlList from the requested account",
@@ -26203,6 +26695,9 @@
         "operationId": "DeleteSipIpAccessControlList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlLists"
         ]
       }
     },
@@ -26281,6 +26776,9 @@
         "operationId": "FetchSipIpAccessControlListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlListMappings"
         ]
       },
       "delete": {
@@ -26336,6 +26834,9 @@
         "operationId": "DeleteSipIpAccessControlListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlListMappings"
         ]
       }
     },
@@ -26424,7 +26925,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpAccessControlListMappings"
+        ]
       },
       "get": {
         "description": "Retrieve a list of IpAccessControlListMapping resources.",
@@ -26521,6 +27025,9 @@
         "operationId": "ListSipIpAccessControlListMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlListMappings"
         ]
       }
     },
@@ -26635,6 +27142,9 @@
         "operationId": "ListSipIpAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAddresses"
         ]
       },
       "post": {
@@ -26713,7 +27223,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpAddresses"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/SIP/IpAccessControlLists/{IpAccessControlListSid}/IpAddresses/{Sid}.json": {
@@ -26792,6 +27305,9 @@
         "operationId": "FetchSipIpAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAddresses"
         ]
       },
       "post": {
@@ -26878,7 +27394,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpAddresses"
+        ]
       },
       "delete": {
         "description": "Delete an IpAddress resource.",
@@ -26933,6 +27452,9 @@
         "operationId": "DeleteSipIpAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAddresses"
         ]
       }
     },
@@ -27834,7 +28356,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Siprec"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Calls/{CallSid}/Siprec/{Sid}.json": {
@@ -27929,7 +28454,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Siprec"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Calls/{CallSid}/Streams.json": {
@@ -28834,7 +29362,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Streams"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Calls/{CallSid}/Streams/{Sid}.json": {
@@ -28929,7 +29460,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Streams"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Tokens.json": {
@@ -28999,7 +29533,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Tokens"
+        ]
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Transcriptions/{Sid}.json": {
@@ -29067,6 +29604,9 @@
         "operationId": "FetchTranscription",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Transcriptions"
         ]
       },
       "delete": {
@@ -29110,6 +29650,9 @@
         "operationId": "DeleteTranscription",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Transcriptions"
         ]
       }
     },
@@ -29213,6 +29756,9 @@
         "operationId": "ListTranscription",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Transcriptions"
         ]
       }
     },
@@ -29365,6 +29911,9 @@
         "operationId": "ListUsageRecord",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Records"
         ]
       }
     },
@@ -29504,6 +30053,9 @@
         "operationId": "ListUsageRecordAllTime",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "AllTime"
         ]
       }
     },
@@ -29643,6 +30195,9 @@
         "operationId": "ListUsageRecordDaily",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Daily"
         ]
       }
     },
@@ -29782,6 +30337,9 @@
         "operationId": "ListUsageRecordLastMonth",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "LastMonth"
         ]
       }
     },
@@ -29921,6 +30479,9 @@
         "operationId": "ListUsageRecordMonthly",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Monthly"
         ]
       }
     },
@@ -30060,6 +30621,9 @@
         "operationId": "ListUsageRecordThisMonth",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ThisMonth"
         ]
       }
     },
@@ -30199,6 +30763,9 @@
         "operationId": "ListUsageRecordToday",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Today"
         ]
       }
     },
@@ -30338,6 +30905,9 @@
         "operationId": "ListUsageRecordYearly",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Yearly"
         ]
       }
     },
@@ -30477,6 +31047,9 @@
         "operationId": "ListUsageRecordYesterday",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Yesterday"
         ]
       }
     },
@@ -30545,6 +31118,9 @@
         "operationId": "FetchUsageTrigger",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Triggers"
         ]
       },
       "post": {
@@ -30629,7 +31205,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Triggers"
+        ]
       },
       "delete": {
         "description": "",
@@ -30672,6 +31251,9 @@
         "operationId": "DeleteUsageTrigger",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Triggers"
         ]
       }
     },
@@ -30786,7 +31368,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Triggers"
+        ]
       },
       "get": {
         "description": "Retrieve a list of usage-triggers belonging to the account used to make the request",
@@ -30898,6 +31483,9 @@
         "operationId": "ListUsageTrigger",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Triggers"
         ]
       }
     }

--- a/spec/json/twilio_autopilot_v1.json
+++ b/spec/json/twilio_autopilot_v1.json
@@ -1006,6 +1006,9 @@
         "operationId": "FetchAssistant",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Assistants"
         ]
       },
       "post": {
@@ -1084,7 +1087,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Assistants"
+        ]
       },
       "delete": {
         "description": "",
@@ -1112,6 +1118,9 @@
         "operationId": "DeleteAssistant",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Assistants"
         ]
       }
     },
@@ -1203,6 +1212,9 @@
         "operationId": "ListAssistant",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Assistants"
         ]
       },
       "post": {
@@ -1266,7 +1278,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Assistants"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/Defaults": {
@@ -1317,6 +1332,9 @@
         "operationId": "FetchDefaults",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Defaults"
         ]
       },
       "post": {
@@ -1367,7 +1385,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Defaults"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/Dialogues/{Sid}": {
@@ -1427,6 +1448,9 @@
         "operationId": "FetchDialogue",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Dialogues"
         ]
       }
     },
@@ -1513,6 +1537,9 @@
         "operationId": "FetchField",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fields"
         ]
       },
       "delete": {
@@ -1559,6 +1586,9 @@
         "operationId": "DeleteField",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fields"
         ]
       }
     },
@@ -1669,6 +1699,9 @@
         "operationId": "ListField",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fields"
         ]
       },
       "post": {
@@ -1737,7 +1770,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Fields"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/FieldTypes/{Sid}": {
@@ -1798,6 +1834,9 @@
         "operationId": "FetchFieldType",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldTypes"
         ]
       },
       "post": {
@@ -1862,7 +1901,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FieldTypes"
+        ]
       },
       "delete": {
         "description": "",
@@ -1899,6 +1941,9 @@
         "operationId": "DeleteFieldType",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldTypes"
         ]
       }
     },
@@ -2000,6 +2045,9 @@
         "operationId": "ListFieldType",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldTypes"
         ]
       },
       "post": {
@@ -2058,7 +2106,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FieldTypes"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/FieldTypes/{FieldTypeSid}/FieldValues/{Sid}": {
@@ -2128,6 +2179,9 @@
         "operationId": "FetchFieldValue",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldValues"
         ]
       },
       "delete": {
@@ -2174,6 +2228,9 @@
         "operationId": "DeleteFieldValue",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldValues"
         ]
       }
     },
@@ -2292,6 +2349,9 @@
         "operationId": "ListFieldValue",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldValues"
         ]
       },
       "post": {
@@ -2364,7 +2424,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FieldValues"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/ModelBuilds/{Sid}": {
@@ -2426,6 +2489,9 @@
         "operationId": "FetchModelBuild",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "ModelBuilds"
         ]
       },
       "post": {
@@ -2486,7 +2552,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ModelBuilds"
+        ]
       },
       "delete": {
         "description": "",
@@ -2523,6 +2592,9 @@
         "operationId": "DeleteModelBuild",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "ModelBuilds"
         ]
       }
     },
@@ -2625,6 +2697,9 @@
         "operationId": "ListModelBuild",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "ModelBuilds"
         ]
       },
       "post": {
@@ -2681,7 +2756,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ModelBuilds"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/Queries/{Sid}": {
@@ -2743,6 +2821,9 @@
         "operationId": "FetchQuery",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Queries"
         ]
       },
       "post": {
@@ -2810,7 +2891,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Queries"
+        ]
       },
       "delete": {
         "description": "",
@@ -2847,6 +2931,9 @@
         "operationId": "DeleteQuery",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -2984,6 +3071,9 @@
         "operationId": "ListQuery",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Queries"
         ]
       },
       "post": {
@@ -3051,7 +3141,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/v1/Assistants/Restore": {
@@ -3112,7 +3205,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Restore"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/Tasks/{TaskSid}/Samples/{Sid}": {
@@ -3186,6 +3282,9 @@
         "operationId": "FetchSample",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Samples"
         ]
       },
       "post": {
@@ -3266,7 +3365,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Samples"
+        ]
       },
       "delete": {
         "description": "",
@@ -3315,6 +3417,9 @@
         "operationId": "DeleteSample",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Samples"
         ]
       }
     },
@@ -3434,6 +3539,9 @@
         "operationId": "ListSample",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Samples"
         ]
       },
       "post": {
@@ -3506,7 +3614,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Samples"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/StyleSheet": {
@@ -3556,6 +3667,9 @@
         "operationId": "FetchStyleSheet",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "StyleSheet"
         ]
       },
       "post": {
@@ -3606,7 +3720,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "StyleSheet"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/Tasks/{Sid}": {
@@ -3667,6 +3784,9 @@
         "operationId": "FetchTask",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Tasks"
         ]
       },
       "post": {
@@ -3739,7 +3859,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Tasks"
+        ]
       },
       "delete": {
         "description": "",
@@ -3776,6 +3899,9 @@
         "operationId": "DeleteTask",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Tasks"
         ]
       }
     },
@@ -3877,6 +4003,9 @@
         "operationId": "ListTask",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Tasks"
         ]
       },
       "post": {
@@ -3943,7 +4072,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Tasks"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/Tasks/{TaskSid}/Actions": {
@@ -4003,6 +4135,9 @@
         "operationId": "FetchTaskActions",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Actions"
         ]
       },
       "post": {
@@ -4062,7 +4197,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Actions"
+        ]
       }
     },
     "/v1/Assistants/{AssistantSid}/Tasks/{TaskSid}/Statistics": {
@@ -4123,6 +4261,9 @@
         "operationId": "FetchTaskStatistics",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Statistics"
         ]
       }
     },
@@ -4186,6 +4327,9 @@
         "operationId": "FetchWebhook",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -4259,7 +4403,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "delete": {
         "description": "",
@@ -4296,6 +4443,9 @@
         "operationId": "DeleteWebhook",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     },
@@ -4399,6 +4549,9 @@
         "operationId": "ListWebhook",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -4468,7 +4621,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       }
     }
   },

--- a/spec/json/twilio_bulkexports_v1.json
+++ b/spec/json/twilio_bulkexports_v1.json
@@ -27,7 +27,7 @@
           "resource_type": {
             "type": "string",
             "nullable": true,
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants"
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants"
           }
         }
       },
@@ -47,7 +47,7 @@
           "resource_type": {
             "type": "string",
             "nullable": true,
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants"
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants"
           },
           "url": {
             "type": "string",
@@ -85,7 +85,7 @@
           "resource_type": {
             "type": "string",
             "nullable": true,
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants"
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants"
           },
           "url": {
             "type": "string",
@@ -106,7 +106,7 @@
           "resource_type": {
             "type": "string",
             "nullable": true,
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants"
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants"
           },
           "start_day": {
             "type": "string",
@@ -176,7 +176,7 @@
           "resource_type": {
             "type": "string",
             "nullable": true,
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants"
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants"
           },
           "friendly_name": {
             "type": "string",
@@ -300,7 +300,7 @@
           {
             "name": "ResourceType",
             "in": "path",
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants",
             "schema": {
               "type": "string"
             },
@@ -336,6 +336,9 @@
         "operationId": "FetchDay",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Days"
         ]
       }
     },
@@ -364,7 +367,7 @@
           {
             "name": "ResourceType",
             "in": "path",
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants",
             "schema": {
               "type": "string"
             },
@@ -440,6 +443,9 @@
         "operationId": "ListDay",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Days"
         ]
       }
     },
@@ -460,7 +466,7 @@
           {
             "name": "ResourceType",
             "in": "path",
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants",
             "schema": {
               "type": "string"
             },
@@ -487,6 +493,9 @@
         "operationId": "FetchExport",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Exports"
         ]
       }
     },
@@ -526,7 +535,7 @@
           {
             "name": "ResourceType",
             "in": "path",
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants",
             "schema": {
               "type": "string"
             },
@@ -553,6 +562,9 @@
         "operationId": "FetchExportConfiguration",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Configuration"
         ]
       },
       "post": {
@@ -561,7 +573,7 @@
           {
             "name": "ResourceType",
             "in": "path",
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants",
             "schema": {
               "type": "string"
             },
@@ -613,7 +625,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Configuration"
+        ]
       }
     },
     "/v1/Exports/{ResourceType}/Jobs": {
@@ -647,7 +662,7 @@
           {
             "name": "ResourceType",
             "in": "path",
-            "description": "The type of communication \u2013 Messages, Calls, Conferences, and Participants",
+            "description": "The type of communication – Messages, Calls, Conferences, and Participants",
             "schema": {
               "type": "string"
             },
@@ -723,6 +738,9 @@
         "operationId": "ListExportCustomJob",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Jobs"
         ]
       },
       "post": {
@@ -731,7 +749,7 @@
           {
             "name": "ResourceType",
             "in": "path",
-            "description": "The type of communication \u2013 Messages or Calls, Conferences, and Participants",
+            "description": "The type of communication – Messages or Calls, Conferences, and Participants",
             "schema": {
               "type": "string"
             },
@@ -799,7 +817,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Jobs"
+        ]
       }
     },
     "/v1/Exports/Jobs/{JobSid}": {
@@ -862,6 +883,9 @@
         "operationId": "FetchJob",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Jobs"
         ]
       },
       "delete": {
@@ -893,6 +917,9 @@
         "operationId": "DeleteJob",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Jobs"
         ]
       }
     },

--- a/spec/json/twilio_chat_v1.json
+++ b/spec/json/twilio_chat_v1.json
@@ -853,6 +853,9 @@
         "operationId": "FetchChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "delete": {
@@ -893,6 +896,9 @@
         "operationId": "DeleteChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -964,7 +970,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Channels": {
@@ -1048,7 +1057,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       },
       "get": {
         "description": "",
@@ -1147,6 +1159,9 @@
         "operationId": "ListChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -1238,6 +1253,9 @@
         "operationId": "ListCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -1306,7 +1324,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       }
     },
     "/v1/Credentials/{Sid}": {
@@ -1360,6 +1381,9 @@
         "operationId": "FetchCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -1434,7 +1458,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       },
       "delete": {
         "description": "",
@@ -1465,6 +1492,9 @@
         "operationId": "DeleteCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       }
     },
@@ -1541,6 +1571,9 @@
         "operationId": "FetchInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       },
       "delete": {
@@ -1593,6 +1626,9 @@
         "operationId": "DeleteInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -1683,7 +1719,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Invites"
+        ]
       },
       "get": {
         "description": "",
@@ -1790,6 +1829,9 @@
         "operationId": "ListInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -1866,6 +1908,9 @@
         "operationId": "FetchMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "delete": {
@@ -1918,6 +1963,9 @@
         "operationId": "DeleteMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "post": {
@@ -2001,7 +2049,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Channels/{ChannelSid}/Members": {
@@ -2091,7 +2142,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       },
       "get": {
         "description": "",
@@ -2198,6 +2252,9 @@
         "operationId": "ListMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       }
     },
@@ -2278,6 +2335,9 @@
         "operationId": "FetchMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "delete": {
@@ -2333,6 +2393,9 @@
         "operationId": "DeleteMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "post": {
@@ -2415,7 +2478,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Channels/{ChannelSid}/Messages": {
@@ -2510,7 +2576,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "get": {
         "description": "",
@@ -2618,6 +2687,9 @@
         "operationId": "ListMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -2685,6 +2757,9 @@
         "operationId": "FetchRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "delete": {
@@ -2728,6 +2803,9 @@
         "operationId": "DeleteRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "post": {
@@ -2800,7 +2878,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Roles": {
@@ -2888,7 +2969,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       },
       "get": {
         "description": "",
@@ -2975,6 +3059,9 @@
         "operationId": "ListRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       }
     },
@@ -3029,6 +3116,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -3060,6 +3150,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -3509,7 +3602,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v1/Services": {
@@ -3568,7 +3664,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -3643,6 +3742,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -3707,6 +3809,9 @@
         "operationId": "FetchUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "delete": {
@@ -3747,6 +3852,9 @@
         "operationId": "DeleteUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "post": {
@@ -3821,7 +3929,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Users": {
@@ -3910,7 +4021,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "get": {
         "description": "",
@@ -3997,6 +4111,9 @@
         "operationId": "ListUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -4110,6 +4227,9 @@
         "operationId": "ListUserChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     }

--- a/spec/json/twilio_chat_v2.json
+++ b/spec/json/twilio_chat_v2.json
@@ -1274,6 +1274,9 @@
         "operationId": "ListBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -1341,6 +1344,9 @@
         "operationId": "FetchBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       },
       "delete": {
@@ -1384,6 +1390,9 @@
         "operationId": "DeleteBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -1448,6 +1457,9 @@
         "operationId": "FetchChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "delete": {
@@ -1497,6 +1509,9 @@
         "operationId": "DeleteChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -1591,7 +1606,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Channels": {
@@ -1698,7 +1716,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       },
       "get": {
         "description": "",
@@ -1797,6 +1818,9 @@
         "operationId": "ListChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -1909,6 +1933,9 @@
         "operationId": "ListChannelWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -2010,7 +2037,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Channels/{ChannelSid}/Webhooks/{Sid}": {
@@ -2085,6 +2115,9 @@
         "operationId": "FetchChannelWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -2190,7 +2223,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "delete": {
         "description": "",
@@ -2242,6 +2278,9 @@
         "operationId": "DeleteChannelWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     },
@@ -2333,6 +2372,9 @@
         "operationId": "ListCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -2401,7 +2443,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       }
     },
     "/v2/Credentials/{Sid}": {
@@ -2455,6 +2500,9 @@
         "operationId": "FetchCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -2529,7 +2577,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       },
       "delete": {
         "description": "",
@@ -2560,6 +2611,9 @@
         "operationId": "DeleteCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       }
     },
@@ -2636,6 +2690,9 @@
         "operationId": "FetchInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       },
       "delete": {
@@ -2688,6 +2745,9 @@
         "operationId": "DeleteInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -2778,7 +2838,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Invites"
+        ]
       },
       "get": {
         "description": "",
@@ -2885,6 +2948,9 @@
         "operationId": "ListInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -2958,6 +3024,9 @@
         "operationId": "FetchMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "delete": {
@@ -3016,6 +3085,9 @@
         "operationId": "DeleteMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "post": {
@@ -3124,7 +3196,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Channels/{ChannelSid}/Members": {
@@ -3247,7 +3322,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       },
       "get": {
         "description": "",
@@ -3354,6 +3432,9 @@
         "operationId": "ListMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       }
     },
@@ -3431,6 +3512,9 @@
         "operationId": "FetchMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "delete": {
@@ -3492,6 +3576,9 @@
         "operationId": "DeleteMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "post": {
@@ -3598,7 +3685,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Channels/{ChannelSid}/Messages": {
@@ -3717,7 +3807,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "get": {
         "description": "",
@@ -3822,6 +3915,9 @@
         "operationId": "ListMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -3889,6 +3985,9 @@
         "operationId": "FetchRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "delete": {
@@ -3932,6 +4031,9 @@
         "operationId": "DeleteRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "post": {
@@ -4004,7 +4106,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Roles": {
@@ -4092,7 +4197,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       },
       "get": {
         "description": "",
@@ -4179,6 +4287,9 @@
         "operationId": "ListRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       }
     },
@@ -4233,6 +4344,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -4264,6 +4378,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -4461,7 +4578,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v2/Services": {
@@ -4520,7 +4640,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -4595,6 +4718,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -4660,6 +4786,9 @@
         "operationId": "FetchUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "delete": {
@@ -4700,6 +4829,9 @@
         "operationId": "DeleteUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "post": {
@@ -4783,7 +4915,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Users": {
@@ -4882,7 +5017,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "get": {
         "description": "",
@@ -4969,6 +5107,9 @@
         "operationId": "ListUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -5096,6 +5237,9 @@
         "operationId": "ListUserBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -5174,6 +5318,9 @@
         "operationId": "FetchUserBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       },
       "delete": {
@@ -5226,6 +5373,9 @@
         "operationId": "DeleteUserBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -5339,6 +5489,9 @@
         "operationId": "ListUserChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -5412,6 +5565,9 @@
         "operationId": "FetchUserChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "delete": {
@@ -5470,6 +5626,9 @@
         "operationId": "DeleteUserChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -5553,7 +5712,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     }
   },

--- a/spec/json/twilio_chat_v3.json
+++ b/spec/json/twilio_chat_v3.json
@@ -224,7 +224,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/v3/Services/{ServiceSid}/Channels": {

--- a/spec/json/twilio_conversations_v1.json
+++ b/spec/json/twilio_conversations_v1.json
@@ -568,12 +568,12 @@
           "last_read_message_index": {
             "type": "integer",
             "nullable": true,
-            "description": "Index of last \u201cread\u201d message in the Conversation for the Participant."
+            "description": "Index of last “read” message in the Conversation for the Participant."
           },
           "last_read_timestamp": {
             "type": "string",
             "nullable": true,
-            "description": "Timestamp of last \u201cread\u201d message in the Conversation for the Participant."
+            "description": "Timestamp of last “read” message in the Conversation for the Participant."
           }
         }
       },
@@ -1487,12 +1487,12 @@
           "last_read_message_index": {
             "type": "integer",
             "nullable": true,
-            "description": "Index of last \u201cread\u201d message in the Conversation for the Participant."
+            "description": "Index of last “read” message in the Conversation for the Participant."
           },
           "last_read_timestamp": {
             "type": "string",
             "nullable": true,
-            "description": "Timestamp of last \u201cread\u201d message in the Conversation for the Participant."
+            "description": "Timestamp of last “read” message in the Conversation for the Participant."
           }
         }
       },
@@ -2373,6 +2373,9 @@
         "operationId": "FetchConfiguration",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Configuration"
         ]
       },
       "post": {
@@ -2431,7 +2434,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Configuration"
+        ]
       }
     },
     "/v1/Configuration/Addresses": {
@@ -2532,6 +2538,9 @@
         "operationId": "ListConfigurationAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Addresses"
         ]
       },
       "post": {
@@ -2628,7 +2637,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Addresses"
+        ]
       }
     },
     "/v1/Configuration/Addresses/{Sid}": {
@@ -2681,6 +2693,9 @@
         "operationId": "FetchConfigurationAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Addresses"
         ]
       },
       "post": {
@@ -2775,7 +2790,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Addresses"
+        ]
       },
       "delete": {
         "description": "Remove an existing address configuration",
@@ -2803,6 +2821,9 @@
         "operationId": "DeleteConfigurationAddress",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Addresses"
         ]
       }
     },
@@ -2845,6 +2866,9 @@
         "operationId": "FetchConfigurationWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -2905,7 +2929,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       }
     },
     "/v1/Conversations": {
@@ -3011,7 +3038,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Conversations"
+        ]
       },
       "get": {
         "description": "Retrieve a list of conversations in your account's default service",
@@ -3086,6 +3116,9 @@
         "operationId": "ListConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       }
     },
@@ -3201,7 +3234,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Conversations"
+        ]
       },
       "delete": {
         "description": "Remove a conversation from your account's default service",
@@ -3238,6 +3274,9 @@
         "operationId": "DeleteConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       },
       "get": {
@@ -3273,6 +3312,9 @@
         "operationId": "FetchConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       }
     },
@@ -3376,7 +3418,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all messages in the conversation",
@@ -3469,6 +3514,9 @@
         "operationId": "ListConversationMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -3577,7 +3625,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "delete": {
         "description": "Remove a message from the conversation",
@@ -3626,6 +3677,9 @@
         "operationId": "DeleteConversationMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "get": {
@@ -3673,6 +3727,9 @@
         "operationId": "FetchConversationMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -3751,6 +3808,9 @@
         "operationId": "FetchConversationMessageReceipt",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Receipts"
         ]
       }
     },
@@ -3866,6 +3926,9 @@
         "operationId": "ListConversationMessageReceipt",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Receipts"
         ]
       }
     },
@@ -3975,7 +4038,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all participants of the conversation",
@@ -4059,6 +4125,9 @@
         "operationId": "ListConversationParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -4172,17 +4241,20 @@
                   "LastReadMessageIndex": {
                     "type": "integer",
                     "nullable": true,
-                    "description": "Index of last \u201cread\u201d message in the [Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) for the Participant."
+                    "description": "Index of last “read” message in the [Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) for the Participant."
                   },
                   "LastReadTimestamp": {
                     "type": "string",
-                    "description": "Timestamp of last \u201cread\u201d message in the [Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) for the Participant."
+                    "description": "Timestamp of last “read” message in the [Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) for the Participant."
                   }
                 }
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       },
       "delete": {
         "description": "Remove a participant from the conversation",
@@ -4228,6 +4300,9 @@
         "operationId": "DeleteConversationParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       },
       "get": {
@@ -4272,6 +4347,9 @@
         "operationId": "FetchConversationParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -4372,6 +4450,9 @@
         "operationId": "ListConversationScopedWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -4461,7 +4542,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       }
     },
     "/v1/Conversations/{ConversationSid}/Webhooks/{Sid}": {
@@ -4524,6 +4608,9 @@
         "operationId": "FetchConversationScopedWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -4613,7 +4700,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "delete": {
         "description": "Remove an existing webhook scoped to the conversation",
@@ -4653,6 +4743,9 @@
         "operationId": "DeleteConversationScopedWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     },
@@ -4737,7 +4830,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all push notification credentials on your account",
@@ -4812,6 +4908,9 @@
         "operationId": "ListCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       }
     },
@@ -4907,7 +5006,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       },
       "delete": {
         "description": "Remove a push notification credential from your account",
@@ -4938,6 +5040,9 @@
         "operationId": "DeleteCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "get": {
@@ -4976,6 +5081,9 @@
         "operationId": "FetchCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       }
     },
@@ -5083,6 +5191,9 @@
         "operationId": "ListParticipantConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ParticipantConversations"
         ]
       }
     },
@@ -5156,7 +5267,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all user roles in your account's default service",
@@ -5231,6 +5345,9 @@
         "operationId": "ListRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       }
     },
@@ -5307,7 +5424,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       },
       "delete": {
         "description": "Remove a user role from your account's default service",
@@ -5338,6 +5458,9 @@
         "operationId": "DeleteRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "get": {
@@ -5376,6 +5499,9 @@
         "operationId": "FetchRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       }
     },
@@ -5434,7 +5560,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all conversation services on your account",
@@ -5509,6 +5638,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -5555,6 +5687,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "get": {
@@ -5593,6 +5728,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -5653,6 +5791,9 @@
         "operationId": "DeleteServiceBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       },
       "get": {
@@ -5703,6 +5844,9 @@
         "operationId": "FetchServiceBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -5830,6 +5974,9 @@
         "operationId": "ListServiceBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -5883,6 +6030,9 @@
         "operationId": "FetchServiceConfiguration",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Configuration"
         ]
       },
       "post": {
@@ -5958,7 +6108,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Configuration"
+        ]
       }
     },
     "/v1/Services/{ChatServiceSid}/Conversations": {
@@ -6077,7 +6230,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Conversations"
+        ]
       },
       "get": {
         "description": "Retrieve a list of conversations in your service",
@@ -6164,6 +6320,9 @@
         "operationId": "ListServiceConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       }
     },
@@ -6292,7 +6451,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Conversations"
+        ]
       },
       "delete": {
         "description": "Remove a conversation from your service",
@@ -6341,6 +6503,9 @@
         "operationId": "DeleteServiceConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       },
       "get": {
@@ -6388,6 +6553,9 @@
         "operationId": "FetchServiceConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       }
     },
@@ -6503,7 +6671,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all messages in the conversation",
@@ -6608,6 +6779,9 @@
         "operationId": "ListServiceConversationMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -6728,7 +6902,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "delete": {
         "description": "Remove a message from the conversation",
@@ -6789,6 +6966,9 @@
         "operationId": "DeleteServiceConversationMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "get": {
@@ -6848,6 +7028,9 @@
         "operationId": "FetchServiceConversationMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -6938,6 +7121,9 @@
         "operationId": "FetchServiceConversationMessageReceipt",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Receipts"
         ]
       }
     },
@@ -7065,6 +7251,9 @@
         "operationId": "ListServiceConversationMessageReceipt",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Receipts"
         ]
       }
     },
@@ -7186,7 +7375,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all participants of the conversation",
@@ -7282,6 +7474,9 @@
         "operationId": "ListServiceConversationParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -7407,17 +7602,20 @@
                   "LastReadMessageIndex": {
                     "type": "integer",
                     "nullable": true,
-                    "description": "Index of last \u201cread\u201d message in the [Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) for the Participant."
+                    "description": "Index of last “read” message in the [Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) for the Participant."
                   },
                   "LastReadTimestamp": {
                     "type": "string",
-                    "description": "Timestamp of last \u201cread\u201d message in the [Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) for the Participant."
+                    "description": "Timestamp of last “read” message in the [Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) for the Participant."
                   }
                 }
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       },
       "delete": {
         "description": "Remove a participant from the conversation",
@@ -7475,6 +7673,9 @@
         "operationId": "DeleteServiceConversationParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       },
       "get": {
@@ -7531,6 +7732,9 @@
         "operationId": "FetchServiceConversationParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -7648,7 +7852,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all webhooks scoped to the conversation",
@@ -7744,6 +7951,9 @@
         "operationId": "ListServiceConversationScopedWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     },
@@ -7861,7 +8071,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "delete": {
         "description": "Remove an existing webhook scoped to the conversation",
@@ -7913,6 +8126,9 @@
         "operationId": "DeleteServiceConversationScopedWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "get": {
@@ -7972,6 +8188,9 @@
         "operationId": "FetchServiceConversationScopedWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     },
@@ -8089,7 +8308,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Notifications"
+        ]
       },
       "get": {
         "description": "Fetch push notification service settings",
@@ -8127,6 +8349,9 @@
         "operationId": "FetchServiceNotification",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Notifications"
         ]
       }
     },
@@ -8247,6 +8472,9 @@
         "operationId": "ListServiceParticipantConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ParticipantConversations"
         ]
       }
     },
@@ -8335,7 +8563,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all user roles in your service",
@@ -8422,6 +8653,9 @@
         "operationId": "ListServiceRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       }
     },
@@ -8511,7 +8745,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       },
       "delete": {
         "description": "Remove a user role from your service",
@@ -8554,6 +8791,9 @@
         "operationId": "DeleteServiceRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "get": {
@@ -8604,6 +8844,9 @@
         "operationId": "FetchServiceRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       }
     },
@@ -8701,7 +8944,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all conversation users in your service",
@@ -8788,6 +9034,9 @@
         "operationId": "ListServiceUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -8887,7 +9136,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "delete": {
         "description": "Remove a conversation user from your service",
@@ -8936,6 +9188,9 @@
         "operationId": "DeleteServiceUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "get": {
@@ -8983,6 +9238,9 @@
         "operationId": "FetchServiceUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -9086,7 +9344,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Conversations"
+        ]
       },
       "delete": {
         "description": "Delete a specific User Conversation.",
@@ -9135,6 +9396,9 @@
         "operationId": "DeleteServiceUserConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       },
       "get": {
@@ -9191,6 +9455,9 @@
         "operationId": "FetchServiceUserConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       }
     },
@@ -9307,6 +9574,9 @@
         "operationId": "ListServiceUserConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       }
     },
@@ -9393,7 +9663,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "get": {
         "description": "Fetch a specific service webhook configuration.",
@@ -9431,6 +9704,9 @@
         "operationId": "FetchServiceWebhookConfiguration",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     },
@@ -9515,7 +9791,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all conversation users in your account's default service",
@@ -9590,6 +9869,9 @@
         "operationId": "ListUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -9676,7 +9958,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "delete": {
         "description": "Remove a conversation user from your account's default service",
@@ -9713,6 +9998,9 @@
         "operationId": "DeleteUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "get": {
@@ -9748,6 +10036,9 @@
         "operationId": "FetchUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -9839,7 +10130,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Conversations"
+        ]
       },
       "delete": {
         "description": "Delete a specific User Conversation.",
@@ -9876,6 +10170,9 @@
         "operationId": "DeleteUserConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       },
       "get": {
@@ -9920,6 +10217,9 @@
         "operationId": "FetchUserConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       }
     },
@@ -10024,6 +10324,9 @@
         "operationId": "ListUserConversation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conversations"
         ]
       }
     }

--- a/spec/json/twilio_events_v1.json
+++ b/spec/json/twilio_events_v1.json
@@ -421,6 +421,9 @@
         "operationId": "ListEventType",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Types"
         ]
       }
     },
@@ -473,6 +476,9 @@
         "operationId": "FetchEventType",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Types"
         ]
       }
     },
@@ -522,6 +528,9 @@
         "operationId": "FetchSchema",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Schemas"
         ]
       }
     },
@@ -638,6 +647,9 @@
         "operationId": "ListSchemaVersion",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Versions"
         ]
       }
     },
@@ -700,6 +712,9 @@
         "operationId": "FetchSchemaVersion",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Versions"
         ]
       }
     },
@@ -758,6 +773,9 @@
         "operationId": "FetchSink",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Sinks"
         ]
       },
       "delete": {
@@ -789,6 +807,9 @@
         "operationId": "DeleteSink",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Sinks"
         ]
       },
       "post": {
@@ -846,7 +867,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Sinks"
+        ]
       }
     },
     "/v1/Sinks": {
@@ -919,7 +943,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Sinks"
+        ]
       },
       "get": {
         "description": "Retrieve a paginated list of Sinks belonging to the account used to make the request.",
@@ -1010,6 +1037,9 @@
         "operationId": "ListSink",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Sinks"
         ]
       }
     },
@@ -1064,6 +1094,9 @@
         "operationId": "CreateSinkTest",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Test"
         ]
       }
     },
@@ -1137,7 +1170,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Validate"
+        ]
       }
     },
     "/v1/Subscriptions/{SubscriptionSid}/SubscribedEvents": {
@@ -1242,6 +1278,9 @@
         "operationId": "ListSubscribedEvent",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "SubscribedEvents"
         ]
       },
       "post": {
@@ -1303,7 +1342,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SubscribedEvents"
+        ]
       }
     },
     "/v1/Subscriptions/{SubscriptionSid}/SubscribedEvents/{Type}": {
@@ -1368,6 +1410,9 @@
         "operationId": "FetchSubscribedEvent",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "SubscribedEvents"
         ]
       },
       "post": {
@@ -1431,7 +1476,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SubscribedEvents"
+        ]
       },
       "delete": {
         "description": "Remove an event type from a subscription.",
@@ -1471,6 +1519,9 @@
         "operationId": "DeleteSubscribedEvent",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "SubscribedEvents"
         ]
       }
     },
@@ -1575,6 +1626,9 @@
         "operationId": "ListSubscription",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Subscriptions"
         ]
       },
       "post": {
@@ -1632,7 +1686,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Subscriptions"
+        ]
       }
     },
     "/v1/Subscriptions/{Sid}": {
@@ -1688,6 +1745,9 @@
         "operationId": "FetchSubscription",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Subscriptions"
         ]
       },
       "post": {
@@ -1749,7 +1809,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Subscriptions"
+        ]
       },
       "delete": {
         "description": "Delete a specific Subscription.",
@@ -1780,6 +1843,9 @@
         "operationId": "DeleteSubscription",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Subscriptions"
         ]
       }
     }

--- a/spec/json/twilio_flex_v1.json
+++ b/spec/json/twilio_flex_v1.json
@@ -825,6 +825,9 @@
         "operationId": "ListChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -913,7 +916,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/v1/Channels/{Sid}": {
@@ -968,6 +974,9 @@
         "operationId": "FetchChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "delete": {
@@ -999,6 +1008,9 @@
         "operationId": "DeleteChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -1050,6 +1062,9 @@
         "operationId": "FetchConfiguration",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Configuration"
         ]
       }
     },
@@ -1150,6 +1165,9 @@
         "operationId": "ListFlexFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "FlexFlows"
         ]
       },
       "post": {
@@ -1196,7 +1214,7 @@
                   "ChannelType": {
                     "type": "string",
                     "$ref": "#/components/schemas/flex_flow_enum_channel_type",
-                    "description": "The channel type. One of `web`, `facebook`, `sms`, `whatsapp`, `line` or `custom`. By default, Studio\u2019s Send to Flex widget passes it on to the Task attributes for Tasks created based on this Flex Flow. The Task attributes will be used by the Flex UI to render the respective Task as appropriate (applying channel-specific design and length limits). If `channelType` is `facebook`, `whatsapp` or `line`, the Send to Flex widget should set the Task Channel to Programmable Chat."
+                    "description": "The channel type. One of `web`, `facebook`, `sms`, `whatsapp`, `line` or `custom`. By default, Studio’s Send to Flex widget passes it on to the Task attributes for Tasks created based on this Flex Flow. The Task attributes will be used by the Flex UI to render the respective Task as appropriate (applying channel-specific design and length limits). If `channelType` is `facebook`, `whatsapp` or `line`, the Send to Flex widget should set the Task Channel to Programmable Chat."
                   },
                   "ContactIdentity": {
                     "type": "string",
@@ -1274,7 +1292,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FlexFlows"
+        ]
       }
     },
     "/v1/FlexFlows/{Sid}": {
@@ -1329,6 +1350,9 @@
         "operationId": "FetchFlexFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "FlexFlows"
         ]
       },
       "post": {
@@ -1389,7 +1413,7 @@
                   "ChannelType": {
                     "type": "string",
                     "$ref": "#/components/schemas/flex_flow_enum_channel_type",
-                    "description": "The channel type. One of `web`, `facebook`, `sms`, `whatsapp`, `line` or `custom`. By default, Studio\u2019s Send to Flex widget passes it on to the Task attributes for Tasks created based on this Flex Flow. The Task attributes will be used by the Flex UI to render the respective Task as appropriate (applying channel-specific design and length limits). If `channelType` is `facebook`, `whatsapp` or `line`, the Send to Flex widget should set the Task Channel to Programmable Chat."
+                    "description": "The channel type. One of `web`, `facebook`, `sms`, `whatsapp`, `line` or `custom`. By default, Studio’s Send to Flex widget passes it on to the Task attributes for Tasks created based on this Flex Flow. The Task attributes will be used by the Flex UI to render the respective Task as appropriate (applying channel-specific design and length limits). If `channelType` is `facebook`, `whatsapp` or `line`, the Send to Flex widget should set the Task Channel to Programmable Chat."
                   },
                   "ContactIdentity": {
                     "type": "string",
@@ -1462,7 +1486,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FlexFlows"
+        ]
       },
       "delete": {
         "description": "",
@@ -1493,6 +1520,9 @@
         "operationId": "DeleteFlexFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "FlexFlows"
         ]
       }
     },
@@ -1545,6 +1575,9 @@
         "operationId": "FetchInteraction",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Interactions"
         ]
       }
     },
@@ -1605,7 +1638,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Interactions"
+        ]
       }
     },
     "/v1/Interactions/{InteractionSid}/Channels/{Sid}": {
@@ -1671,6 +1707,9 @@
         "operationId": "FetchInteractionChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -1744,7 +1783,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/v1/Interactions/{InteractionSid}/Channels": {
@@ -1847,6 +1889,9 @@
         "operationId": "ListInteractionChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -1931,7 +1976,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Invites"
+        ]
       },
       "get": {
         "description": "List all Invites for a Channel.",
@@ -2030,6 +2078,9 @@
         "operationId": "ListInteractionChannelInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -2120,7 +2171,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       },
       "get": {
         "description": "List all Participants for a Channel.",
@@ -2219,6 +2273,9 @@
         "operationId": "ListInteractionChannelParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -2317,7 +2374,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       }
     },
     "/v1/WebChannels": {
@@ -2407,6 +2467,9 @@
         "operationId": "ListWebChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "WebChannels"
         ]
       },
       "post": {
@@ -2476,7 +2539,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "WebChannels"
+        ]
       }
     },
     "/v1/WebChannels/{Sid}": {
@@ -2529,6 +2595,9 @@
         "operationId": "FetchWebChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "WebChannels"
         ]
       },
       "post": {
@@ -2588,7 +2657,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "WebChannels"
+        ]
       },
       "delete": {
         "description": "",
@@ -2619,6 +2691,9 @@
         "operationId": "DeleteWebChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "WebChannels"
         ]
       }
     }

--- a/spec/json/twilio_frontline_v1.json
+++ b/spec/json/twilio_frontline_v1.json
@@ -125,6 +125,9 @@
         "operationId": "FetchUser",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "post": {
@@ -189,7 +192,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       }
     }
   },

--- a/spec/json/twilio_insights_v1.json
+++ b/spec/json/twilio_insights_v1.json
@@ -1449,6 +1449,9 @@
         "operationId": "FetchAccountSettings",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "post": {
@@ -1500,7 +1503,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Settings"
+        ]
       }
     },
     "/v1/Voice/{CallSid}/Annotation": {
@@ -1587,17 +1593,20 @@
                   },
                   "Comment": {
                     "type": "string",
-                    "description": "Specify any comments pertaining to the call. This of type string with a max limit of 100 characters. Twilio does not treat this field as PII, so don\u2019t put any PII in here."
+                    "description": "Specify any comments pertaining to the call. This of type string with a max limit of 100 characters. Twilio does not treat this field as PII, so don’t put any PII in here."
                   },
                   "Incident": {
                     "type": "string",
-                    "description": "Associate this call with an incident or support ticket. This is of type string with a max limit of 100 characters. Twilio does not treat this field as PII, so don\u2019t put any PII in here."
+                    "description": "Associate this call with an incident or support ticket. This is of type string with a max limit of 100 characters. Twilio does not treat this field as PII, so don’t put any PII in here."
                   }
                 }
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Annotation"
+        ]
       },
       "get": {
         "description": "Fetch a specific Annotation.",
@@ -1635,6 +1644,9 @@
         "operationId": "FetchAnnotation",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Annotation"
         ]
       }
     },
@@ -1686,6 +1698,9 @@
         "operationId": "FetchCall",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Voice"
         ]
       }
     },
@@ -1933,6 +1948,9 @@
         "operationId": "ListCallSummaries",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Summaries"
         ]
       }
     },
@@ -1986,6 +2004,9 @@
         "operationId": "FetchConference",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conferences"
         ]
       }
     },
@@ -2159,6 +2180,9 @@
         "operationId": "ListConference",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Conferences"
         ]
       }
     },
@@ -2244,6 +2268,9 @@
         "operationId": "FetchConferenceParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -2374,6 +2401,9 @@
         "operationId": "ListConferenceParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -2489,6 +2519,9 @@
         "operationId": "ListEvent",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Events"
         ]
       }
     },
@@ -2613,6 +2646,9 @@
         "operationId": "ListMetric",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Metrics"
         ]
       }
     },
@@ -2679,6 +2715,9 @@
         "operationId": "FetchSummary",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Summary"
         ]
       }
     },
@@ -2738,6 +2777,9 @@
         "operationId": "FetchVideoParticipantSummary",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -2837,6 +2879,9 @@
         "operationId": "ListVideoParticipantSummary",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -2887,6 +2932,9 @@
         "operationId": "FetchVideoRoomSummary",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Rooms"
         ]
       }
     },
@@ -3027,6 +3075,9 @@
         "operationId": "ListVideoRoomSummary",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Rooms"
         ]
       }
     }

--- a/spec/json/twilio_ip_messaging_v1.json
+++ b/spec/json/twilio_ip_messaging_v1.json
@@ -745,6 +745,9 @@
         "operationId": "FetchChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "delete": {
@@ -785,6 +788,9 @@
         "operationId": "DeleteChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -856,7 +862,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Channels": {
@@ -940,7 +949,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       },
       "get": {
         "description": "",
@@ -1039,6 +1051,9 @@
         "operationId": "ListChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -1130,6 +1145,9 @@
         "operationId": "ListCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -1198,7 +1216,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       }
     },
     "/v1/Credentials/{Sid}": {
@@ -1252,6 +1273,9 @@
         "operationId": "FetchCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -1326,7 +1350,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       },
       "delete": {
         "description": "",
@@ -1357,6 +1384,9 @@
         "operationId": "DeleteCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       }
     },
@@ -1433,6 +1463,9 @@
         "operationId": "FetchInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       },
       "delete": {
@@ -1485,6 +1518,9 @@
         "operationId": "DeleteInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -1575,7 +1611,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Invites"
+        ]
       },
       "get": {
         "description": "",
@@ -1682,6 +1721,9 @@
         "operationId": "ListInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -1758,6 +1800,9 @@
         "operationId": "FetchMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "delete": {
@@ -1810,6 +1855,9 @@
         "operationId": "DeleteMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "post": {
@@ -1893,7 +1941,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Channels/{ChannelSid}/Members": {
@@ -1983,7 +2034,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       },
       "get": {
         "description": "",
@@ -2090,6 +2144,9 @@
         "operationId": "ListMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       }
     },
@@ -2170,6 +2227,9 @@
         "operationId": "FetchMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "delete": {
@@ -2225,6 +2285,9 @@
         "operationId": "DeleteMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "post": {
@@ -2307,7 +2370,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Channels/{ChannelSid}/Messages": {
@@ -2402,7 +2468,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "get": {
         "description": "",
@@ -2510,6 +2579,9 @@
         "operationId": "ListMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -2577,6 +2649,9 @@
         "operationId": "FetchRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "delete": {
@@ -2620,6 +2695,9 @@
         "operationId": "DeleteRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "post": {
@@ -2692,7 +2770,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Roles": {
@@ -2780,7 +2861,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       },
       "get": {
         "description": "",
@@ -2867,6 +2951,9 @@
         "operationId": "ListRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       }
     },
@@ -2921,6 +3008,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -2952,6 +3042,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -3401,7 +3494,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v1/Services": {
@@ -3460,7 +3556,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -3535,6 +3634,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -3599,6 +3701,9 @@
         "operationId": "FetchUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "delete": {
@@ -3639,6 +3744,9 @@
         "operationId": "DeleteUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "post": {
@@ -3713,7 +3821,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Users": {
@@ -3802,7 +3913,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "get": {
         "description": "",
@@ -3889,6 +4003,9 @@
         "operationId": "ListUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -4002,6 +4119,9 @@
         "operationId": "ListUserChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     }

--- a/spec/json/twilio_ip_messaging_v2.json
+++ b/spec/json/twilio_ip_messaging_v2.json
@@ -1117,6 +1117,9 @@
         "operationId": "ListBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -1184,6 +1187,9 @@
         "operationId": "FetchBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       },
       "delete": {
@@ -1227,6 +1233,9 @@
         "operationId": "DeleteBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -1291,6 +1300,9 @@
         "operationId": "FetchChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "delete": {
@@ -1340,6 +1352,9 @@
         "operationId": "DeleteChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -1434,7 +1449,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Channels": {
@@ -1541,7 +1559,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       },
       "get": {
         "description": "",
@@ -1640,6 +1661,9 @@
         "operationId": "ListChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -1752,6 +1776,9 @@
         "operationId": "ListChannelWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -1853,7 +1880,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Channels/{ChannelSid}/Webhooks/{Sid}": {
@@ -1928,6 +1958,9 @@
         "operationId": "FetchChannelWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "post": {
@@ -2033,7 +2066,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "delete": {
         "description": "",
@@ -2085,6 +2121,9 @@
         "operationId": "DeleteChannelWebhook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     },
@@ -2176,6 +2215,9 @@
         "operationId": "ListCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -2244,7 +2286,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       }
     },
     "/v2/Credentials/{Sid}": {
@@ -2298,6 +2343,9 @@
         "operationId": "FetchCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -2372,7 +2420,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       },
       "delete": {
         "description": "",
@@ -2403,6 +2454,9 @@
         "operationId": "DeleteCredential",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Credentials"
         ]
       }
     },
@@ -2479,6 +2533,9 @@
         "operationId": "FetchInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       },
       "delete": {
@@ -2531,6 +2588,9 @@
         "operationId": "DeleteInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -2621,7 +2681,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Invites"
+        ]
       },
       "get": {
         "description": "",
@@ -2728,6 +2791,9 @@
         "operationId": "ListInvite",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Invites"
         ]
       }
     },
@@ -2801,6 +2867,9 @@
         "operationId": "FetchMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "delete": {
@@ -2859,6 +2928,9 @@
         "operationId": "DeleteMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       },
       "post": {
@@ -2967,7 +3039,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Channels/{ChannelSid}/Members": {
@@ -3090,7 +3165,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Members"
+        ]
       },
       "get": {
         "description": "",
@@ -3197,6 +3275,9 @@
         "operationId": "ListMember",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Members"
         ]
       }
     },
@@ -3274,6 +3355,9 @@
         "operationId": "FetchMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "delete": {
@@ -3335,6 +3419,9 @@
         "operationId": "DeleteMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "post": {
@@ -3441,7 +3528,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Channels/{ChannelSid}/Messages": {
@@ -3560,7 +3650,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       },
       "get": {
         "description": "",
@@ -3665,6 +3758,9 @@
         "operationId": "ListMessage",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -3732,6 +3828,9 @@
         "operationId": "FetchRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "delete": {
@@ -3775,6 +3874,9 @@
         "operationId": "DeleteRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       },
       "post": {
@@ -3847,7 +3949,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Roles": {
@@ -3935,7 +4040,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Roles"
+        ]
       },
       "get": {
         "description": "",
@@ -4022,6 +4130,9 @@
         "operationId": "ListRole",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Roles"
         ]
       }
     },
@@ -4076,6 +4187,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -4107,6 +4221,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -4304,7 +4421,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v2/Services": {
@@ -4363,7 +4483,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -4438,6 +4561,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -4503,6 +4629,9 @@
         "operationId": "FetchUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "delete": {
@@ -4543,6 +4672,9 @@
         "operationId": "DeleteUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       },
       "post": {
@@ -4626,7 +4758,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Users": {
@@ -4725,7 +4860,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "get": {
         "description": "",
@@ -4812,6 +4950,9 @@
         "operationId": "ListUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -4939,6 +5080,9 @@
         "operationId": "ListUserBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -5017,6 +5161,9 @@
         "operationId": "FetchUserBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       },
       "delete": {
@@ -5069,6 +5216,9 @@
         "operationId": "DeleteUserBinding",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -5182,6 +5332,9 @@
         "operationId": "ListUserChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -5255,6 +5408,9 @@
         "operationId": "FetchUserChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "delete": {
@@ -5304,6 +5460,9 @@
         "operationId": "DeleteUserChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -5387,7 +5546,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     }
   },

--- a/spec/json/twilio_lookups_v1.json
+++ b/spec/json/twilio_lookups_v1.json
@@ -161,6 +161,9 @@
         "operationId": "FetchPhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       }
     }

--- a/spec/json/twilio_lookups_v2.json
+++ b/spec/json/twilio_lookups_v2.json
@@ -178,6 +178,9 @@
         "operationId": "FetchPhoneNumber",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       }
     }

--- a/spec/json/twilio_media_v1.json
+++ b/spec/json/twilio_media_v1.json
@@ -506,7 +506,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "MediaProcessors"
+        ]
       },
       "get": {
         "description": "Returns a list of MediaProcessors.",
@@ -599,6 +602,9 @@
         "operationId": "ListMediaProcessor",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "MediaProcessors"
         ]
       }
     },
@@ -654,6 +660,9 @@
         "operationId": "FetchMediaProcessor",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "MediaProcessors"
         ]
       },
       "post": {
@@ -712,7 +721,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "MediaProcessors"
+        ]
       }
     },
     "/v1/MediaRecordings/{Sid}": {
@@ -758,6 +770,9 @@
         "operationId": "DeleteMediaRecording",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "MediaRecordings"
         ]
       },
       "get": {
@@ -796,6 +811,9 @@
         "operationId": "FetchMediaRecording",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "MediaRecordings"
         ]
       }
     },
@@ -926,6 +944,9 @@
         "operationId": "ListMediaRecording",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "MediaRecordings"
         ]
       }
     },
@@ -979,6 +1000,9 @@
         "operationId": "FetchPlayerStreamer",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PlayerStreamers"
         ]
       },
       "post": {
@@ -1037,7 +1061,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PlayerStreamers"
+        ]
       }
     },
     "/v1/PlayerStreamers": {
@@ -1114,7 +1141,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PlayerStreamers"
+        ]
       },
       "get": {
         "description": "Returns a list of PlayerStreamers.",
@@ -1207,6 +1237,9 @@
         "operationId": "ListPlayerStreamer",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PlayerStreamers"
         ]
       }
     },
@@ -1278,7 +1311,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PlaybackGrant"
+        ]
       },
       "get": {
         "description": "**This method is not enabled.** Returns a single PlaybackGrant resource identified by a SID.",
@@ -1316,6 +1352,9 @@
         "operationId": "FetchPlayerStreamerPlaybackGrant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PlaybackGrant"
         ]
       }
     }

--- a/spec/json/twilio_messaging_v1.json
+++ b/spec/json/twilio_messaging_v1.json
@@ -1064,7 +1064,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "AlphaSenders"
+        ]
       },
       "get": {
         "description": "",
@@ -1151,6 +1154,9 @@
         "operationId": "ListAlphaSender",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "AlphaSenders"
         ]
       }
     },
@@ -1214,6 +1220,9 @@
         "operationId": "FetchAlphaSender",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "AlphaSenders"
         ]
       },
       "delete": {
@@ -1254,6 +1263,9 @@
         "operationId": "DeleteAlphaSender",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "AlphaSenders"
         ]
       }
     },
@@ -1307,6 +1319,9 @@
         "operationId": "FetchBrandRegistrations",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "BrandRegistrations"
         ]
       },
       "post": {
@@ -1345,6 +1360,9 @@
         "operationId": "UpdateBrandRegistrations",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "BrandRegistrations"
         ]
       }
     },
@@ -1435,6 +1453,9 @@
         "operationId": "ListBrandRegistrations",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "BrandRegistrations"
         ]
       },
       "post": {
@@ -1501,7 +1522,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "BrandRegistrations"
+        ]
       }
     },
     "/v1/a2p/BrandRegistrations/{BrandSid}/Vettings": {
@@ -1585,7 +1609,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Vettings"
+        ]
       },
       "get": {
         "description": "",
@@ -1681,6 +1708,9 @@
         "operationId": "ListBrandVetting",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Vettings"
         ]
       }
     },
@@ -1753,6 +1783,9 @@
         "operationId": "FetchBrandVetting",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Vettings"
         ]
       }
     },
@@ -1803,6 +1836,9 @@
         "operationId": "FetchDeactivation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Deactivations"
         ]
       }
     },
@@ -1870,7 +1906,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PreregisteredUsa2p"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/PhoneNumbers": {
@@ -1947,7 +1986,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PhoneNumbers"
+        ]
       },
       "get": {
         "description": "",
@@ -2034,6 +2076,9 @@
         "operationId": "ListPhoneNumber",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       }
     },
@@ -2091,6 +2136,9 @@
         "operationId": "DeletePhoneNumber",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       },
       "get": {
@@ -2138,6 +2186,9 @@
         "operationId": "FetchPhoneNumber",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       }
     },
@@ -2279,7 +2330,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -2354,6 +2408,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -2506,7 +2563,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -2544,6 +2604,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -2575,6 +2638,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -2652,7 +2718,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ShortCodes"
+        ]
       },
       "get": {
         "description": "",
@@ -2739,6 +2808,9 @@
         "operationId": "ListShortCode",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "ShortCodes"
         ]
       }
     },
@@ -2796,6 +2868,9 @@
         "operationId": "DeleteShortCode",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "ShortCodes"
         ]
       },
       "get": {
@@ -2843,6 +2918,9 @@
         "operationId": "FetchShortCode",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "ShortCodes"
         ]
       }
     },
@@ -2897,6 +2975,9 @@
         "operationId": "FetchTollfreeVerification",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Verifications"
         ]
       }
     },
@@ -3008,6 +3089,9 @@
         "operationId": "ListTollfreeVerification",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Verifications"
         ]
       },
       "post": {
@@ -3158,7 +3242,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Verifications"
+        ]
       }
     },
     "/v1/Services/{MessagingServiceSid}/Compliance/Usa2p": {
@@ -3264,7 +3351,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Usa2p"
+        ]
       },
       "get": {
         "description": "",
@@ -3351,6 +3441,9 @@
         "operationId": "ListUsAppToPerson",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Usa2p"
         ]
       }
     },
@@ -3412,6 +3505,9 @@
         "operationId": "DeleteUsAppToPerson",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Usa2p"
         ]
       },
       "get": {
@@ -3462,6 +3558,9 @@
         "operationId": "FetchUsAppToPerson",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Usa2p"
         ]
       }
     },
@@ -3527,6 +3626,9 @@
         "operationId": "FetchUsAppToPersonUsecase",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Usecases"
         ]
       }
     },
@@ -3565,6 +3667,9 @@
         "operationId": "FetchUsecase",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Usecases"
         ]
       }
     }

--- a/spec/json/twilio_microvisor_v1.json
+++ b/spec/json/twilio_microvisor_v1.json
@@ -214,6 +214,9 @@
         "operationId": "ListApp",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Apps"
         ]
       }
     },
@@ -264,6 +267,9 @@
         "operationId": "FetchApp",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Apps"
         ]
       },
       "delete": {
@@ -292,6 +298,9 @@
         "operationId": "DeleteApp",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Apps"
         ]
       }
     },
@@ -382,6 +391,9 @@
         "operationId": "ListDevice",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Devices"
         ]
       }
     },
@@ -432,6 +444,9 @@
         "operationId": "FetchDevice",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Devices"
         ]
       },
       "post": {
@@ -491,7 +506,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Devices"
+        ]
       }
     }
   },

--- a/spec/json/twilio_monitor_v1.json
+++ b/spec/json/twilio_monitor_v1.json
@@ -397,6 +397,9 @@
         "operationId": "FetchAlert",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Alerts"
         ]
       }
     },
@@ -515,6 +518,9 @@
         "operationId": "ListAlert",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Alerts"
         ]
       }
     },
@@ -570,6 +576,9 @@
         "operationId": "FetchEvent",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Events"
         ]
       }
     },
@@ -718,6 +727,9 @@
         "operationId": "ListEvent",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Events"
         ]
       }
     }

--- a/spec/json/twilio_notify_v1.json
+++ b/spec/json/twilio_notify_v1.json
@@ -512,6 +512,9 @@
         "operationId": "FetchBinding",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Bindings"
         ]
       },
       "delete": {
@@ -555,6 +558,9 @@
         "operationId": "DeleteBinding",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -664,7 +670,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Bindings"
+        ]
       },
       "get": {
         "description": "",
@@ -791,6 +800,9 @@
         "operationId": "ListBinding",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Bindings"
         ]
       }
     },
@@ -882,6 +894,9 @@
         "operationId": "ListCredential",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -950,7 +965,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       }
     },
     "/v1/Credentials/{Sid}": {
@@ -1004,6 +1022,9 @@
         "operationId": "FetchCredential",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Credentials"
         ]
       },
       "post": {
@@ -1078,7 +1099,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Credentials"
+        ]
       },
       "delete": {
         "description": "",
@@ -1109,6 +1133,9 @@
         "operationId": "DeleteCredential",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Credentials"
         ]
       }
     },
@@ -1262,7 +1289,10 @@
               "tag"
             ]
           ]
-        }
+        },
+        "tags": [
+          "Notifications"
+        ]
       }
     },
     "/v1/Services": {
@@ -1382,7 +1412,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -1465,6 +1498,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -1512,6 +1548,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "get": {
@@ -1550,6 +1589,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -1668,7 +1710,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     }
   },

--- a/spec/json/twilio_numbers_v2.json
+++ b/spec/json/twilio_numbers_v2.json
@@ -781,7 +781,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Bundles"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Bundles for an account.",
@@ -953,6 +956,9 @@
         "operationId": "ListBundle",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bundles"
         ]
       }
     },
@@ -1008,6 +1014,9 @@
         "operationId": "FetchBundle",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bundles"
         ]
       },
       "post": {
@@ -1076,7 +1085,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Bundles"
+        ]
       },
       "delete": {
         "description": "Delete a specific Bundle.",
@@ -1107,6 +1119,9 @@
         "operationId": "DeleteBundle",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Bundles"
         ]
       }
     },
@@ -1175,7 +1190,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Copies"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Bundles Copies for a Bundle.",
@@ -1262,6 +1280,9 @@
         "operationId": "ListBundleCopy",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Copies"
         ]
       }
     },
@@ -1330,7 +1351,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "EndUsers"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all End User for an account.",
@@ -1405,6 +1429,9 @@
         "operationId": "ListEndUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUsers"
         ]
       }
     },
@@ -1459,6 +1486,9 @@
         "operationId": "FetchEndUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUsers"
         ]
       },
       "post": {
@@ -1516,7 +1546,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "EndUsers"
+        ]
       },
       "delete": {
         "description": "Delete a specific End User.",
@@ -1547,6 +1580,9 @@
         "operationId": "DeleteEndUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUsers"
         ]
       }
     },
@@ -1638,6 +1674,9 @@
         "operationId": "ListEndUserType",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUserTypes"
         ]
       }
     },
@@ -1689,6 +1728,9 @@
         "operationId": "FetchEndUserType",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUserTypes"
         ]
       }
     },
@@ -1742,6 +1784,9 @@
         "operationId": "CreateEvaluation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Evaluations"
         ]
       },
       "get": {
@@ -1829,6 +1874,9 @@
         "operationId": "ListEvaluation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Evaluations"
         ]
       }
     },
@@ -1894,6 +1942,9 @@
         "operationId": "FetchEvaluation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Evaluations"
         ]
       }
     },
@@ -1969,7 +2020,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ItemAssignments"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Assigned Items for an account.",
@@ -2056,6 +2110,9 @@
         "operationId": "ListItemAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ItemAssignments"
         ]
       }
     },
@@ -2121,6 +2178,9 @@
         "operationId": "FetchItemAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ItemAssignments"
         ]
       },
       "delete": {
@@ -2164,6 +2224,9 @@
         "operationId": "DeleteItemAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ItemAssignments"
         ]
       }
     },
@@ -2280,6 +2343,9 @@
         "operationId": "ListRegulation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Regulations"
         ]
       }
     },
@@ -2334,6 +2400,9 @@
         "operationId": "FetchRegulation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Regulations"
         ]
       }
     },
@@ -2420,7 +2489,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ReplaceItems"
+        ]
       }
     },
     "/v2/RegulatoryCompliance/SupportingDocuments": {
@@ -2487,7 +2559,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SupportingDocuments"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Supporting Document for an account.",
@@ -2562,6 +2637,9 @@
         "operationId": "ListSupportingDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocuments"
         ]
       }
     },
@@ -2616,6 +2694,9 @@
         "operationId": "FetchSupportingDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocuments"
         ]
       },
       "post": {
@@ -2673,7 +2754,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SupportingDocuments"
+        ]
       },
       "delete": {
         "description": "Delete a specific Supporting Document.",
@@ -2704,6 +2788,9 @@
         "operationId": "DeleteSupportingDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocuments"
         ]
       }
     },
@@ -2795,6 +2882,9 @@
         "operationId": "ListSupportingDocumentType",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocumentTypes"
         ]
       }
     },
@@ -2846,6 +2936,9 @@
         "operationId": "FetchSupportingDocumentType",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocumentTypes"
         ]
       }
     }

--- a/spec/json/twilio_preview.json
+++ b/spec/json/twilio_preview.json
@@ -2915,6 +2915,9 @@
         "operationId": "FetchDeployedDevicesCertificate",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Certificates"
         ]
       },
       "delete": {
@@ -2955,6 +2958,9 @@
         "operationId": "DeleteDeployedDevicesCertificate",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Certificates"
         ]
       },
       "post": {
@@ -3025,7 +3031,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Certificates"
+        ]
       }
     },
     "/DeployedDevices/Fleets/{FleetSid}/Certificates": {
@@ -3103,7 +3112,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Certificates"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Certificate credentials belonging to the Fleet.",
@@ -3198,6 +3210,9 @@
         "operationId": "ListDeployedDevicesCertificate",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Certificates"
         ]
       }
     },
@@ -3258,6 +3273,9 @@
         "operationId": "FetchDeployedDevicesDeployment",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Deployments"
         ]
       },
       "delete": {
@@ -3298,6 +3316,9 @@
         "operationId": "DeleteDeployedDevicesDeployment",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Deployments"
         ]
       },
       "post": {
@@ -3368,7 +3389,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Deployments"
+        ]
       }
     },
     "/DeployedDevices/Fleets/{FleetSid}/Deployments": {
@@ -3439,7 +3463,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Deployments"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Deployments belonging to the Fleet.",
@@ -3523,6 +3550,9 @@
         "operationId": "ListDeployedDevicesDeployment",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Deployments"
         ]
       }
     },
@@ -3580,6 +3610,9 @@
         "operationId": "FetchDeployedDevicesDevice",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Devices"
         ]
       },
       "delete": {
@@ -3617,6 +3650,9 @@
         "operationId": "DeleteDeployedDevicesDevice",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Devices"
         ]
       },
       "post": {
@@ -3692,7 +3728,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Devices"
+        ]
       }
     },
     "/DeployedDevices/Fleets/{FleetSid}/Devices": {
@@ -3775,7 +3814,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Devices"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Devices belonging to the Fleet.",
@@ -3870,6 +3912,9 @@
         "operationId": "ListDeployedDevicesDevice",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Devices"
         ]
       }
     },
@@ -3917,6 +3962,9 @@
         "operationId": "FetchDeployedDevicesFleet",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fleets"
         ]
       },
       "delete": {
@@ -3945,6 +3993,9 @@
         "operationId": "DeleteDeployedDevicesFleet",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fleets"
         ]
       },
       "post": {
@@ -4003,7 +4054,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Fleets"
+        ]
       }
     },
     "/DeployedDevices/Fleets": {
@@ -4055,7 +4109,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Fleets"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Fleets belonging to your account.",
@@ -4130,6 +4187,9 @@
         "operationId": "ListDeployedDevicesFleet",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fleets"
         ]
       }
     },
@@ -4190,6 +4250,9 @@
         "operationId": "FetchDeployedDevicesKey",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Keys"
         ]
       },
       "delete": {
@@ -4230,6 +4293,9 @@
         "operationId": "DeleteDeployedDevicesKey",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Keys"
         ]
       },
       "post": {
@@ -4300,7 +4366,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Keys"
+        ]
       }
     },
     "/DeployedDevices/Fleets/{FleetSid}/Keys": {
@@ -4371,7 +4440,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Keys"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Keys credentials belonging to the Fleet.",
@@ -4466,6 +4538,9 @@
         "operationId": "ListDeployedDevicesKey",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Keys"
         ]
       }
     },
@@ -4516,6 +4591,9 @@
         "operationId": "FetchHostedNumbersAuthorizationDocument",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "AuthorizationDocuments"
         ]
       },
       "post": {
@@ -4604,7 +4682,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "AuthorizationDocuments"
+        ]
       }
     },
     "/HostedNumbers/AuthorizationDocuments": {
@@ -4708,6 +4789,9 @@
         "operationId": "ListHostedNumbersAuthorizationDocument",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "AuthorizationDocuments"
         ]
       },
       "post": {
@@ -4784,7 +4868,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "AuthorizationDocuments"
+        ]
       }
     },
     "/HostedNumbers/AuthorizationDocuments/{SigningDocumentSid}/DependentHostedNumberOrders": {
@@ -4929,6 +5016,9 @@
         "operationId": "ListHostedNumbersDependentHostedNumberOrder",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "DependentHostedNumberOrders"
         ]
       }
     },
@@ -4979,6 +5069,9 @@
         "operationId": "FetchHostedNumbersHostedNumberOrder",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "HostedNumberOrders"
         ]
       },
       "delete": {
@@ -5010,6 +5103,9 @@
         "operationId": "DeleteHostedNumbersHostedNumberOrder",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "HostedNumberOrders"
         ]
       },
       "post": {
@@ -5108,7 +5204,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "HostedNumberOrders"
+        ]
       }
     },
     "/HostedNumbers/HostedNumberOrders": {
@@ -5240,6 +5339,9 @@
         "operationId": "ListHostedNumbersHostedNumberOrder",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "HostedNumberOrders"
         ]
       },
       "post": {
@@ -5395,7 +5497,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "HostedNumberOrders"
+        ]
       }
     },
     "/marketplace/AvailableAddOns/{Sid}": {
@@ -5445,6 +5550,9 @@
         "operationId": "FetchMarketplaceAvailableAddOn",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "AvailableAddOns"
         ]
       }
     },
@@ -5532,6 +5640,9 @@
         "operationId": "ListMarketplaceAvailableAddOn",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "AvailableAddOns"
         ]
       }
     },
@@ -5596,6 +5707,9 @@
         "operationId": "FetchMarketplaceAvailableAddOnExtension",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Extensions"
         ]
       }
     },
@@ -5697,6 +5811,9 @@
         "operationId": "ListMarketplaceAvailableAddOnExtension",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Extensions"
         ]
       }
     },
@@ -5767,7 +5884,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "InstalledAddOns"
+        ]
       },
       "get": {
         "description": "Retrieve a list of Add-ons currently installed on this Account.",
@@ -5842,6 +5962,9 @@
         "operationId": "ListMarketplaceInstalledAddOn",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "InstalledAddOns"
         ]
       }
     },
@@ -5885,6 +6008,9 @@
         "operationId": "DeleteMarketplaceInstalledAddOn",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "InstalledAddOns"
         ]
       },
       "get": {
@@ -5923,6 +6049,9 @@
         "operationId": "FetchMarketplaceInstalledAddOn",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "InstalledAddOns"
         ]
       },
       "post": {
@@ -5980,7 +6109,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "InstalledAddOns"
+        ]
       }
     },
     "/marketplace/InstalledAddOns/{InstalledAddOnSid}/Extensions/{Sid}": {
@@ -6044,6 +6176,9 @@
         "operationId": "FetchMarketplaceInstalledAddOnExtension",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Extensions"
         ]
       },
       "post": {
@@ -6113,7 +6248,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Extensions"
+        ]
       }
     },
     "/marketplace/InstalledAddOns/{InstalledAddOnSid}/Extensions": {
@@ -6214,6 +6352,9 @@
         "operationId": "ListMarketplaceInstalledAddOnExtension",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Extensions"
         ]
       }
     },
@@ -6274,6 +6415,9 @@
         "operationId": "FetchSyncDocument",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Documents"
         ]
       },
       "delete": {
@@ -6314,6 +6458,9 @@
         "operationId": "DeleteSyncDocument",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Documents"
         ]
       },
       "post": {
@@ -6387,7 +6534,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Documents"
+        ]
       }
     },
     "/Sync/Services/{ServiceSid}/Documents": {
@@ -6457,7 +6607,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Documents"
+        ]
       },
       "get": {
         "description": "",
@@ -6544,6 +6697,9 @@
         "operationId": "ListSyncDocument",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Documents"
         ]
       }
     },
@@ -6614,6 +6770,9 @@
         "operationId": "FetchSyncDocumentPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "delete": {
@@ -6663,6 +6822,9 @@
         "operationId": "DeleteSyncDocumentPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "post": {
@@ -6748,7 +6910,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Permissions"
+        ]
       }
     },
     "/Sync/Services/{ServiceSid}/Documents/{DocumentSid}/Permissions": {
@@ -6858,6 +7023,9 @@
         "operationId": "ListSyncDocumentPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       }
     },
@@ -6908,6 +7076,9 @@
         "operationId": "FetchSyncService",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -6939,6 +7110,9 @@
         "operationId": "DeleteSyncService",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -7006,7 +7180,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/Sync/Services": {
@@ -7071,7 +7248,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -7146,6 +7326,9 @@
         "operationId": "ListSyncService",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -7207,6 +7390,9 @@
         "operationId": "FetchSyncSyncList",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Lists"
         ]
       },
       "delete": {
@@ -7247,6 +7433,9 @@
         "operationId": "DeleteSyncSyncList",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Lists"
         ]
       }
     },
@@ -7315,7 +7504,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Lists"
+        ]
       },
       "get": {
         "description": "",
@@ -7402,6 +7594,9 @@
         "operationId": "ListSyncSyncList",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Lists"
         ]
       }
     },
@@ -7472,6 +7667,9 @@
         "operationId": "FetchSyncSyncListItem",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Items"
         ]
       },
       "delete": {
@@ -7529,6 +7727,9 @@
         "operationId": "DeleteSyncSyncListItem",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Items"
         ]
       },
       "post": {
@@ -7611,7 +7812,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Items"
+        ]
       }
     },
     "/Sync/Services/{ServiceSid}/Lists/{ListSid}/Items": {
@@ -7690,7 +7894,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Items"
+        ]
       },
       "get": {
         "description": "",
@@ -7812,6 +8019,9 @@
         "operationId": "ListSyncSyncListItem",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Items"
         ]
       }
     },
@@ -7882,6 +8092,9 @@
         "operationId": "FetchSyncSyncListPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "delete": {
@@ -7931,6 +8144,9 @@
         "operationId": "DeleteSyncSyncListPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "post": {
@@ -8016,7 +8232,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Permissions"
+        ]
       }
     },
     "/Sync/Services/{ServiceSid}/Lists/{ListSid}/Permissions": {
@@ -8126,6 +8345,9 @@
         "operationId": "ListSyncSyncListPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       }
     },
@@ -8187,6 +8409,9 @@
         "operationId": "FetchSyncSyncMap",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Maps"
         ]
       },
       "delete": {
@@ -8227,6 +8452,9 @@
         "operationId": "DeleteSyncSyncMap",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Maps"
         ]
       }
     },
@@ -8295,7 +8523,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Maps"
+        ]
       },
       "get": {
         "description": "",
@@ -8382,6 +8613,9 @@
         "operationId": "ListSyncSyncMap",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Maps"
         ]
       }
     },
@@ -8452,6 +8686,9 @@
         "operationId": "FetchSyncSyncMapItem",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Items"
         ]
       },
       "delete": {
@@ -8509,6 +8746,9 @@
         "operationId": "DeleteSyncSyncMapItem",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Items"
         ]
       },
       "post": {
@@ -8591,7 +8831,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Items"
+        ]
       }
     },
     "/Sync/Services/{ServiceSid}/Maps/{MapSid}/Items": {
@@ -8675,7 +8918,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Items"
+        ]
       },
       "get": {
         "description": "",
@@ -8797,6 +9043,9 @@
         "operationId": "ListSyncSyncMapItem",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Items"
         ]
       }
     },
@@ -8867,6 +9116,9 @@
         "operationId": "FetchSyncSyncMapPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "delete": {
@@ -8916,6 +9168,9 @@
         "operationId": "DeleteSyncSyncMapPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "post": {
@@ -9001,7 +9256,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Permissions"
+        ]
       }
     },
     "/Sync/Services/{ServiceSid}/Maps/{MapSid}/Permissions": {
@@ -9111,6 +9369,9 @@
         "operationId": "ListSyncSyncMapPermission",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Permissions"
         ]
       }
     },
@@ -9158,6 +9419,9 @@
         "operationId": "FetchUnderstandAssistant",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Assistants"
         ]
       },
       "post": {
@@ -9235,7 +9499,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Assistants"
+        ]
       },
       "delete": {
         "description": "",
@@ -9263,6 +9530,9 @@
         "operationId": "DeleteUnderstandAssistant",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Assistants"
         ]
       }
     },
@@ -9350,6 +9620,9 @@
         "operationId": "ListUnderstandAssistant",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Assistants"
         ]
       },
       "post": {
@@ -9416,7 +9689,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Assistants"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/FallbackActions": {
@@ -9465,6 +9741,9 @@
         "operationId": "FetchUnderstandAssistantFallbackActions",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FallbackActions"
         ]
       },
       "post": {
@@ -9515,7 +9794,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FallbackActions"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/InitiationActions": {
@@ -9564,6 +9846,9 @@
         "operationId": "FetchUnderstandAssistantInitiationActions",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "InitiationActions"
         ]
       },
       "post": {
@@ -9614,7 +9899,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "InitiationActions"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/Dialogues/{Sid}": {
@@ -9671,6 +9959,9 @@
         "operationId": "FetchUnderstandDialogue",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Dialogues"
         ]
       }
     },
@@ -9750,6 +10041,9 @@
         "operationId": "FetchUnderstandField",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fields"
         ]
       },
       "delete": {
@@ -9796,6 +10090,9 @@
         "operationId": "DeleteUnderstandField",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fields"
         ]
       }
     },
@@ -9902,6 +10199,9 @@
         "operationId": "ListUnderstandField",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Fields"
         ]
       },
       "post": {
@@ -9970,7 +10270,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Fields"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/FieldTypes/{Sid}": {
@@ -10027,6 +10330,9 @@
         "operationId": "FetchUnderstandFieldType",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldTypes"
         ]
       },
       "post": {
@@ -10091,7 +10397,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FieldTypes"
+        ]
       },
       "delete": {
         "description": "",
@@ -10128,6 +10437,9 @@
         "operationId": "DeleteUnderstandFieldType",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldTypes"
         ]
       }
     },
@@ -10225,6 +10537,9 @@
         "operationId": "ListUnderstandFieldType",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldTypes"
         ]
       },
       "post": {
@@ -10283,7 +10598,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FieldTypes"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/FieldTypes/{FieldTypeSid}/FieldValues/{Sid}": {
@@ -10349,6 +10667,9 @@
         "operationId": "FetchUnderstandFieldValue",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldValues"
         ]
       },
       "delete": {
@@ -10395,6 +10716,9 @@
         "operationId": "DeleteUnderstandFieldValue",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldValues"
         ]
       }
     },
@@ -10509,6 +10833,9 @@
         "operationId": "ListUnderstandFieldValue",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "FieldValues"
         ]
       },
       "post": {
@@ -10581,7 +10908,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "FieldValues"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/ModelBuilds/{Sid}": {
@@ -10638,6 +10968,9 @@
         "operationId": "FetchUnderstandModelBuild",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "ModelBuilds"
         ]
       },
       "post": {
@@ -10698,7 +11031,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ModelBuilds"
+        ]
       },
       "delete": {
         "description": "",
@@ -10735,6 +11071,9 @@
         "operationId": "DeleteUnderstandModelBuild",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "ModelBuilds"
         ]
       }
     },
@@ -10832,6 +11171,9 @@
         "operationId": "ListUnderstandModelBuild",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "ModelBuilds"
         ]
       },
       "post": {
@@ -10888,7 +11230,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ModelBuilds"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/Queries/{Sid}": {
@@ -10945,6 +11290,9 @@
         "operationId": "FetchUnderstandQuery",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Queries"
         ]
       },
       "post": {
@@ -11012,7 +11360,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Queries"
+        ]
       },
       "delete": {
         "description": "",
@@ -11049,6 +11400,9 @@
         "operationId": "DeleteUnderstandQuery",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -11170,6 +11524,9 @@
         "operationId": "ListUnderstandQuery",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Queries"
         ]
       },
       "post": {
@@ -11241,7 +11598,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/Tasks/{TaskSid}/Samples/{Sid}": {
@@ -11310,6 +11670,9 @@
         "operationId": "FetchUnderstandSample",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Samples"
         ]
       },
       "post": {
@@ -11390,7 +11753,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Samples"
+        ]
       },
       "delete": {
         "description": "",
@@ -11439,6 +11805,9 @@
         "operationId": "DeleteUnderstandSample",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Samples"
         ]
       }
     },
@@ -11553,6 +11922,9 @@
         "operationId": "ListUnderstandSample",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Samples"
         ]
       },
       "post": {
@@ -11625,7 +11997,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Samples"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/StyleSheet": {
@@ -11673,6 +12048,9 @@
         "operationId": "FetchUnderstandStyleSheet",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "StyleSheet"
         ]
       },
       "post": {
@@ -11723,7 +12101,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "StyleSheet"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/Tasks/{Sid}": {
@@ -11780,6 +12161,9 @@
         "operationId": "FetchUnderstandTask",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Tasks"
         ]
       },
       "post": {
@@ -11852,7 +12236,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Tasks"
+        ]
       },
       "delete": {
         "description": "",
@@ -11889,6 +12276,9 @@
         "operationId": "DeleteUnderstandTask",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Tasks"
         ]
       }
     },
@@ -11986,6 +12376,9 @@
         "operationId": "ListUnderstandTask",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Tasks"
         ]
       },
       "post": {
@@ -12052,7 +12445,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Tasks"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/Tasks/{TaskSid}/Actions": {
@@ -12110,6 +12506,9 @@
         "operationId": "FetchUnderstandTaskActions",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Actions"
         ]
       },
       "post": {
@@ -12169,7 +12568,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Actions"
+        ]
       }
     },
     "/understand/Assistants/{AssistantSid}/Tasks/{TaskSid}/Statistics": {
@@ -12227,6 +12629,9 @@
         "operationId": "FetchUnderstandTaskStatistics",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Statistics"
         ]
       }
     },
@@ -12277,6 +12682,9 @@
         "operationId": "FetchWirelessCommand",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Commands"
         ]
       }
     },
@@ -12396,6 +12804,9 @@
         "operationId": "ListWirelessCommand",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Commands"
         ]
       },
       "post": {
@@ -12464,7 +12875,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Commands"
+        ]
       }
     },
     "/wireless/RatePlans": {
@@ -12551,6 +12965,9 @@
         "operationId": "ListWirelessRatePlan",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "RatePlans"
         ]
       },
       "post": {
@@ -12630,7 +13047,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "RatePlans"
+        ]
       }
     },
     "/wireless/RatePlans/{Sid}": {
@@ -12677,6 +13097,9 @@
         "operationId": "FetchWirelessRatePlan",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "RatePlans"
         ]
       },
       "post": {
@@ -12732,7 +13155,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "RatePlans"
+        ]
       },
       "delete": {
         "description": "",
@@ -12760,6 +13186,9 @@
         "operationId": "DeleteWirelessRatePlan",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "RatePlans"
         ]
       }
     },
@@ -12807,6 +13236,9 @@
         "operationId": "FetchWirelessSim",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Sims"
         ]
       },
       "post": {
@@ -12969,7 +13401,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Sims"
+        ]
       }
     },
     "/wireless/Sims": {
@@ -13096,6 +13531,9 @@
         "operationId": "ListWirelessSim",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Sims"
         ]
       }
     },
@@ -13160,6 +13598,9 @@
         "operationId": "FetchWirelessUsage",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Usage"
         ]
       }
     },
@@ -13217,6 +13658,9 @@
         "operationId": "FetchTrustedCommsBrandedChannel",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "BrandedChannels"
         ]
       }
     },
@@ -13287,6 +13731,9 @@
         "operationId": "FetchTrustedCommsBrandsInformation",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "BrandsInformation"
         ]
       }
     },
@@ -13368,7 +13815,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/TrustedComms/CPS": {
@@ -13419,6 +13869,9 @@
         "operationId": "FetchTrustedCommsCps",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "CPS"
         ]
       }
     },
@@ -13488,6 +13941,9 @@
         "operationId": "FetchTrustedCommsCurrentCall",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "CurrentCall"
         ]
       }
     }

--- a/spec/json/twilio_pricing_v1.json
+++ b/spec/json/twilio_pricing_v1.json
@@ -525,6 +525,9 @@
         "operationId": "ListMessagingCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -579,6 +582,9 @@
         "operationId": "FetchMessagingCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -684,6 +690,9 @@
         "operationId": "ListPhoneNumberCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -736,6 +745,9 @@
         "operationId": "FetchPhoneNumberCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -841,6 +853,9 @@
         "operationId": "ListVoiceCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -893,6 +908,9 @@
         "operationId": "FetchVoiceCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -947,6 +965,9 @@
         "operationId": "FetchVoiceNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Numbers"
         ]
       }
     },

--- a/spec/json/twilio_pricing_v2.json
+++ b/spec/json/twilio_pricing_v2.json
@@ -507,6 +507,9 @@
         "operationId": "ListTrunkingCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -558,6 +561,9 @@
         "operationId": "FetchTrunkingCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -619,6 +625,9 @@
         "operationId": "FetchTrunkingNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Numbers"
         ]
       }
     },
@@ -740,6 +749,9 @@
         "operationId": "ListVoiceCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -792,6 +804,9 @@
         "operationId": "FetchVoiceCountry",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -854,6 +869,9 @@
         "operationId": "FetchVoiceNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Numbers"
         ]
       }
     },

--- a/spec/json/twilio_proxy_v1.json
+++ b/spec/json/twilio_proxy_v1.json
@@ -938,6 +938,9 @@
         "operationId": "FetchInteraction",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Interactions"
         ]
       },
       "delete": {
@@ -993,6 +996,9 @@
         "operationId": "DeleteInteraction",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Interactions"
         ]
       }
     },
@@ -1109,6 +1115,9 @@
         "operationId": "ListInteraction",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Interactions"
         ]
       }
     },
@@ -1220,7 +1229,10 @@
               "media_url"
             ]
           ]
-        }
+        },
+        "tags": [
+          "MessageInteractions"
+        ]
       },
       "get": {
         "description": "",
@@ -1331,6 +1343,9 @@
         "operationId": "ListMessageInteraction",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "MessageInteractions"
         ]
       }
     },
@@ -1422,6 +1437,9 @@
         "operationId": "FetchMessageInteraction",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "MessageInteractions"
         ]
       }
     },
@@ -1502,6 +1520,9 @@
         "operationId": "FetchParticipant",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Participants"
         ]
       },
       "delete": {
@@ -1557,6 +1578,9 @@
         "operationId": "DeleteParticipant",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -1674,6 +1698,9 @@
         "operationId": "ListParticipant",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Participants"
         ]
       },
       "post": {
@@ -1762,7 +1789,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/PhoneNumbers": {
@@ -1845,7 +1875,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PhoneNumbers"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Phone Numbers in the Proxy Number Pool for a Service. A maximum of 100 records will be returned per page.",
@@ -1932,6 +1965,9 @@
         "operationId": "ListPhoneNumber",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       }
     },
@@ -1992,6 +2028,9 @@
         "operationId": "DeletePhoneNumber",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       },
       "get": {
@@ -2042,6 +2081,9 @@
         "operationId": "FetchPhoneNumber",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       },
       "post": {
@@ -2108,7 +2150,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PhoneNumbers"
+        ]
       }
     },
     "/v1/Services/{Sid}": {
@@ -2159,6 +2204,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -2190,6 +2238,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -2280,7 +2331,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v1/Services": {
@@ -2371,6 +2425,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -2450,7 +2507,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Sessions/{Sid}": {
@@ -2515,6 +2575,9 @@
         "operationId": "FetchSession",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Sessions"
         ]
       },
       "delete": {
@@ -2558,6 +2621,9 @@
         "operationId": "DeleteSession",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Sessions"
         ]
       },
       "post": {
@@ -2638,7 +2704,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Sessions"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Sessions": {
@@ -2743,6 +2812,9 @@
         "operationId": "ListSession",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Sessions"
         ]
       },
       "post": {
@@ -2825,7 +2897,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Sessions"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/ShortCodes": {
@@ -2902,7 +2977,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ShortCodes"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Short Codes in the Proxy Number Pool for the Service. A maximum of 100 records will be returned per page.",
@@ -2989,6 +3067,9 @@
         "operationId": "ListShortCode",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "ShortCodes"
         ]
       }
     },
@@ -3049,6 +3130,9 @@
         "operationId": "DeleteShortCode",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "ShortCodes"
         ]
       },
       "get": {
@@ -3099,6 +3183,9 @@
         "operationId": "FetchShortCode",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "ShortCodes"
         ]
       },
       "post": {
@@ -3165,7 +3252,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ShortCodes"
+        ]
       }
     }
   },

--- a/spec/json/twilio_routes_v2.json
+++ b/spec/json/twilio_routes_v2.json
@@ -248,7 +248,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PhoneNumbers"
+        ]
       },
       "get": {
         "description": "Fetch the Inbound Processing Region assigned to a phone number.",
@@ -283,6 +286,9 @@
         "operationId": "FetchPhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       }
     },
@@ -354,7 +360,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SipDomains"
+        ]
       },
       "get": {
         "description": "",
@@ -389,6 +398,9 @@
         "operationId": "FetchSipDomain",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SipDomains"
         ]
       }
     },
@@ -460,7 +472,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Trunks"
+        ]
       },
       "get": {
         "description": "Fetch the Inbound Processing Region assigned to a SIP Trunk.",
@@ -495,6 +510,9 @@
         "operationId": "FetchTrunks",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Trunks"
         ]
       }
     }

--- a/spec/json/twilio_serverless_v1.json
+++ b/spec/json/twilio_serverless_v1.json
@@ -950,6 +950,9 @@
         "operationId": "ListAsset",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Assets"
         ]
       },
       "post": {
@@ -1004,7 +1007,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Assets"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Assets/{Sid}": {
@@ -1068,6 +1074,9 @@
         "operationId": "FetchAsset",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Assets"
         ]
       },
       "delete": {
@@ -1108,6 +1117,9 @@
         "operationId": "DeleteAsset",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Assets"
         ]
       },
       "post": {
@@ -1174,7 +1186,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Assets"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Assets/{AssetSid}/Versions": {
@@ -1289,6 +1304,9 @@
         "operationId": "ListAssetVersion",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Versions"
         ]
       }
     },
@@ -1367,6 +1385,9 @@
         "operationId": "FetchAssetVersion",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Versions"
         ]
       }
     },
@@ -1468,6 +1489,9 @@
         "operationId": "ListBuild",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Builds"
         ]
       },
       "post": {
@@ -1543,7 +1567,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Builds"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Builds/{Sid}": {
@@ -1607,6 +1634,9 @@
         "operationId": "FetchBuild",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Builds"
         ]
       },
       "delete": {
@@ -1647,6 +1677,9 @@
         "operationId": "DeleteBuild",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Builds"
         ]
       }
     },
@@ -1711,6 +1744,9 @@
         "operationId": "FetchBuildStatus",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Status"
         ]
       }
     },
@@ -1824,6 +1860,9 @@
         "operationId": "ListDeployment",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Deployments"
         ]
       },
       "post": {
@@ -1890,7 +1929,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Deployments"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Environments/{EnvironmentSid}/Deployments/{Sid}": {
@@ -1966,6 +2008,9 @@
         "operationId": "FetchDeployment",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Deployments"
         ]
       }
     },
@@ -2068,6 +2113,9 @@
         "operationId": "ListEnvironment",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Environments"
         ]
       },
       "post": {
@@ -2126,7 +2174,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Environments"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Environments/{Sid}": {
@@ -2191,6 +2242,9 @@
         "operationId": "FetchEnvironment",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Environments"
         ]
       },
       "delete": {
@@ -2231,6 +2285,9 @@
         "operationId": "DeleteEnvironment",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Environments"
         ]
       }
     },
@@ -2332,6 +2389,9 @@
         "operationId": "ListFunction",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Functions"
         ]
       },
       "post": {
@@ -2386,7 +2446,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Functions"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Functions/{Sid}": {
@@ -2450,6 +2513,9 @@
         "operationId": "FetchFunction",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Functions"
         ]
       },
       "delete": {
@@ -2490,6 +2556,9 @@
         "operationId": "DeleteFunction",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Functions"
         ]
       },
       "post": {
@@ -2556,7 +2625,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Functions"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Functions/{FunctionSid}/Versions": {
@@ -2671,6 +2743,9 @@
         "operationId": "ListFunctionVersion",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Versions"
         ]
       }
     },
@@ -2749,6 +2824,9 @@
         "operationId": "FetchFunctionVersion",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Versions"
         ]
       }
     },
@@ -2825,6 +2903,9 @@
         "operationId": "FetchFunctionVersionContent",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Content"
         ]
       }
     },
@@ -2963,6 +3044,9 @@
         "operationId": "ListLog",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Logs"
         ]
       }
     },
@@ -3035,6 +3119,9 @@
         "operationId": "FetchLog",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Logs"
         ]
       }
     },
@@ -3126,6 +3213,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -3182,7 +3272,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v1/Services/{Sid}": {
@@ -3233,6 +3326,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -3261,6 +3357,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -3320,7 +3419,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Environments/{EnvironmentSid}/Variables": {
@@ -3433,6 +3535,9 @@
         "operationId": "ListVariable",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Variables"
         ]
       },
       "post": {
@@ -3504,7 +3609,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Variables"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Environments/{EnvironmentSid}/Variables/{Sid}": {
@@ -3580,6 +3688,9 @@
         "operationId": "FetchVariable",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Variables"
         ]
       },
       "post": {
@@ -3659,7 +3770,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Variables"
+        ]
       },
       "delete": {
         "description": "Delete a specific Variable.",
@@ -3711,6 +3825,9 @@
         "operationId": "DeleteVariable",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Variables"
         ]
       }
     }

--- a/spec/json/twilio_studio_v1.json
+++ b/spec/json/twilio_studio_v1.json
@@ -694,6 +694,9 @@
         "operationId": "ListEngagement",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Engagements"
         ]
       },
       "post": {
@@ -761,7 +764,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Engagements"
+        ]
       }
     },
     "/v1/Flows/{FlowSid}/Engagements/{Sid}": {
@@ -829,6 +835,9 @@
         "operationId": "FetchEngagement",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Engagements"
         ]
       },
       "delete": {
@@ -872,6 +881,9 @@
         "operationId": "DeleteEngagement",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Engagements"
         ]
       }
     },
@@ -938,6 +950,9 @@
         "operationId": "FetchEngagementContext",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Context"
         ]
       }
     },
@@ -1061,6 +1076,9 @@
         "operationId": "ListExecution",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Executions"
         ]
       },
       "post": {
@@ -1128,7 +1146,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Executions"
+        ]
       }
     },
     "/v1/Flows/{FlowSid}/Executions/{Sid}": {
@@ -1196,6 +1217,9 @@
         "operationId": "FetchExecution",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Executions"
         ]
       },
       "delete": {
@@ -1239,6 +1263,9 @@
         "operationId": "DeleteExecution",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Executions"
         ]
       },
       "post": {
@@ -1309,7 +1336,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Executions"
+        ]
       }
     },
     "/v1/Flows/{FlowSid}/Executions/{ExecutionSid}/Context": {
@@ -1375,6 +1405,9 @@
         "operationId": "FetchExecutionContext",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Context"
         ]
       }
     },
@@ -1492,6 +1525,9 @@
         "operationId": "ListExecutionStep",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Steps"
         ]
       }
     },
@@ -1572,6 +1608,9 @@
         "operationId": "FetchExecutionStep",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Steps"
         ]
       }
     },
@@ -1650,6 +1689,9 @@
         "operationId": "FetchExecutionStepContext",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Context"
         ]
       }
     },
@@ -1742,6 +1784,9 @@
         "operationId": "ListFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Flows"
         ]
       }
     },
@@ -1797,6 +1842,9 @@
         "operationId": "FetchFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Flows"
         ]
       },
       "delete": {
@@ -1828,6 +1876,9 @@
         "operationId": "DeleteFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Flows"
         ]
       }
     },
@@ -1945,6 +1996,9 @@
         "operationId": "ListStep",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Steps"
         ]
       }
     },
@@ -2025,6 +2079,9 @@
         "operationId": "FetchStep",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Steps"
         ]
       }
     },
@@ -2103,6 +2160,9 @@
         "operationId": "FetchStepContext",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Context"
         ]
       }
     }

--- a/spec/json/twilio_studio_v2.json
+++ b/spec/json/twilio_studio_v2.json
@@ -611,6 +611,9 @@
         "operationId": "ListExecution",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Executions"
         ]
       },
       "post": {
@@ -678,7 +681,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Executions"
+        ]
       }
     },
     "/v2/Flows/{FlowSid}/Executions/{Sid}": {
@@ -745,6 +751,9 @@
         "operationId": "FetchExecution",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Executions"
         ]
       },
       "delete": {
@@ -788,6 +797,9 @@
         "operationId": "DeleteExecution",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Executions"
         ]
       },
       "post": {
@@ -858,7 +870,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Executions"
+        ]
       }
     },
     "/v2/Flows/{FlowSid}/Executions/{ExecutionSid}/Context": {
@@ -924,6 +939,9 @@
         "operationId": "FetchExecutionContext",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Context"
         ]
       }
     },
@@ -1041,6 +1059,9 @@
         "operationId": "ListExecutionStep",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Steps"
         ]
       }
     },
@@ -1121,6 +1142,9 @@
         "operationId": "FetchExecutionStep",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Steps"
         ]
       }
     },
@@ -1199,6 +1223,9 @@
         "operationId": "FetchExecutionStepContext",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Context"
         ]
       }
     },
@@ -1273,7 +1300,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Flows"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Flows.",
@@ -1348,6 +1378,9 @@
         "operationId": "ListFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Flows"
         ]
       }
     },
@@ -1434,7 +1467,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Flows"
+        ]
       },
       "get": {
         "description": "Retrieve a specific Flow.",
@@ -1472,6 +1508,9 @@
         "operationId": "FetchFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Flows"
         ]
       },
       "delete": {
@@ -1503,6 +1542,9 @@
         "operationId": "DeleteFlow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Flows"
         ]
       }
     },
@@ -1609,6 +1651,9 @@
         "operationId": "ListFlowRevision",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Revisions"
         ]
       }
     },
@@ -1675,6 +1720,9 @@
         "operationId": "FetchFlowRevision",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Revisions"
         ]
       }
     },
@@ -1747,7 +1795,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Validate"
+        ]
       }
     },
     "/v2/Flows/{Sid}/TestUsers": {
@@ -1801,6 +1852,9 @@
         "operationId": "FetchTestUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TestUsers"
         ]
       },
       "post": {
@@ -1861,7 +1915,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "TestUsers"
+        ]
       }
     }
   },

--- a/spec/json/twilio_supersim_v1.json
+++ b/spec/json/twilio_supersim_v1.json
@@ -925,6 +925,9 @@
         "operationId": "ListBillingPeriod",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "BillingPeriods"
         ]
       }
     },
@@ -997,7 +1000,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ESimProfiles"
+        ]
       },
       "get": {
         "description": "Retrieve a list of eSIM Profiles.",
@@ -1097,6 +1103,9 @@
         "operationId": "ListEsimProfile",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "ESimProfiles"
         ]
       }
     },
@@ -1147,6 +1156,9 @@
         "operationId": "FetchEsimProfile",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "ESimProfiles"
         ]
       }
     },
@@ -1258,7 +1270,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Fleets"
+        ]
       },
       "get": {
         "description": "Retrieve a list of Fleets from your account.",
@@ -1341,6 +1356,9 @@
         "operationId": "ListFleet",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Fleets"
         ]
       }
     },
@@ -1392,6 +1410,9 @@
         "operationId": "FetchFleet",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Fleets"
         ]
       },
       "post": {
@@ -1487,7 +1508,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Fleets"
+        ]
       }
     },
     "/v1/IpCommands": {
@@ -1579,7 +1603,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpCommands"
+        ]
       },
       "get": {
         "description": "Retrieve a list of IP Commands from your account.",
@@ -1688,6 +1715,9 @@
         "operationId": "ListIpCommand",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "IpCommands"
         ]
       }
     },
@@ -1742,6 +1772,9 @@
         "operationId": "FetchIpCommand",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "IpCommands"
         ]
       }
     },
@@ -1794,6 +1827,9 @@
         "operationId": "FetchNetwork",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Networks"
         ]
       }
     },
@@ -1907,6 +1943,9 @@
         "operationId": "ListNetwork",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Networks"
         ]
       }
     },
@@ -1970,7 +2009,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "NetworkAccessProfiles"
+        ]
       },
       "get": {
         "description": "Retrieve a list of Network Access Profiles from your account.",
@@ -2045,6 +2087,9 @@
         "operationId": "ListNetworkAccessProfile",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "NetworkAccessProfiles"
         ]
       }
     },
@@ -2096,6 +2141,9 @@
         "operationId": "FetchNetworkAccessProfile",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "NetworkAccessProfiles"
         ]
       },
       "post": {
@@ -2147,7 +2195,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "NetworkAccessProfiles"
+        ]
       }
     },
     "/v1/NetworkAccessProfiles/{NetworkAccessProfileSid}/Networks": {
@@ -2247,6 +2298,9 @@
         "operationId": "ListNetworkAccessProfileNetwork",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Networks"
         ]
       },
       "post": {
@@ -2304,7 +2358,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Networks"
+        ]
       }
     },
     "/v1/NetworkAccessProfiles/{NetworkAccessProfileSid}/Networks/{Sid}": {
@@ -2363,6 +2420,9 @@
         "operationId": "DeleteNetworkAccessProfileNetwork",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Networks"
         ]
       },
       "get": {
@@ -2410,6 +2470,9 @@
         "operationId": "FetchNetworkAccessProfileNetwork",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Networks"
         ]
       }
     },
@@ -2474,7 +2537,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Sims"
+        ]
       },
       "get": {
         "description": "Retrieve a list of Super SIMs from your account.",
@@ -2574,6 +2640,9 @@
         "operationId": "ListSim",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Sims"
         ]
       }
     },
@@ -2625,6 +2694,9 @@
         "operationId": "FetchSim",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Sims"
         ]
       },
       "post": {
@@ -2717,7 +2789,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Sims"
+        ]
       }
     },
     "/v1/Sims/{SimSid}/IpAddresses": {
@@ -2818,6 +2893,9 @@
         "operationId": "ListSimIpAddress",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "IpAddresses"
         ]
       }
     },
@@ -2900,7 +2978,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SmsCommands"
+        ]
       },
       "get": {
         "description": "Retrieve a list of SMS Commands from your account.",
@@ -3001,6 +3082,9 @@
         "operationId": "ListSmsCommand",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "SmsCommands"
         ]
       }
     },
@@ -3055,6 +3139,9 @@
         "operationId": "FetchSmsCommand",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "SmsCommands"
         ]
       }
     },
@@ -3217,6 +3304,9 @@
         "operationId": "ListUsageRecord",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "UsageRecords"
         ]
       }
     }

--- a/spec/json/twilio_sync_v1.json
+++ b/spec/json/twilio_sync_v1.json
@@ -819,6 +819,9 @@
         "operationId": "FetchDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Documents"
         ]
       },
       "delete": {
@@ -856,6 +859,9 @@
         "operationId": "DeleteDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Documents"
         ]
       },
       "post": {
@@ -927,7 +933,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Documents"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Documents": {
@@ -1002,7 +1011,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Documents"
+        ]
       },
       "get": {
         "description": "",
@@ -1086,6 +1098,9 @@
         "operationId": "ListDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Documents"
         ]
       }
     },
@@ -1158,6 +1173,9 @@
         "operationId": "FetchDocumentPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "delete": {
@@ -1204,6 +1222,9 @@
         "operationId": "DeleteDocumentPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "post": {
@@ -1286,7 +1307,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Permissions"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Documents/{DocumentSid}/Permissions": {
@@ -1398,6 +1422,9 @@
         "operationId": "ListDocumentPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       }
     },
@@ -1449,6 +1476,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -1477,6 +1507,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -1553,7 +1586,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v1/Services": {
@@ -1634,7 +1670,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "",
@@ -1709,6 +1748,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -1787,7 +1829,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Lists/{Sid}": {
@@ -1849,6 +1894,9 @@
         "operationId": "FetchSyncList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Lists"
         ]
       },
       "delete": {
@@ -1886,6 +1934,9 @@
         "operationId": "DeleteSyncList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Lists"
         ]
       },
       "post": {
@@ -1950,7 +2001,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Lists"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Lists": {
@@ -2027,7 +2081,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Lists"
+        ]
       },
       "get": {
         "description": "",
@@ -2111,6 +2168,9 @@
         "operationId": "ListSyncList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Lists"
         ]
       }
     },
@@ -2182,6 +2242,9 @@
         "operationId": "FetchSyncListItem",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Items"
         ]
       },
       "delete": {
@@ -2217,7 +2280,7 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "If provided, applies this mutation if (and only if) the \u201crevision\u201d field of this [map item] matches the provided value. This matches the semantics of (and is implemented with) the HTTP [If-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match).",
+            "description": "If provided, applies this mutation if (and only if) the “revision” field of this [map item] matches the provided value. This matches the semantics of (and is implemented with) the HTTP [If-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match).",
             "schema": {
               "type": "string"
             }
@@ -2236,6 +2299,9 @@
         "operationId": "DeleteSyncListItem",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Items"
         ]
       },
       "post": {
@@ -2271,7 +2337,7 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "If provided, applies this mutation if (and only if) the \u201crevision\u201d field of this [map item] matches the provided value. This matches the semantics of (and is implemented with) the HTTP [If-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match).",
+            "description": "If provided, applies this mutation if (and only if) the “revision” field of this [map item] matches the provided value. This matches the semantics of (and is implemented with) the HTTP [If-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match).",
             "schema": {
               "type": "string"
             }
@@ -2324,7 +2390,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Items"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Lists/{ListSid}/Items": {
@@ -2416,7 +2485,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Items"
+        ]
       },
       "get": {
         "description": "",
@@ -2535,6 +2607,9 @@
         "operationId": "ListSyncListItem",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Items"
         ]
       }
     },
@@ -2607,6 +2682,9 @@
         "operationId": "FetchSyncListPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "delete": {
@@ -2653,6 +2731,9 @@
         "operationId": "DeleteSyncListPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "post": {
@@ -2735,7 +2816,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Permissions"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Lists/{ListSid}/Permissions": {
@@ -2847,6 +2931,9 @@
         "operationId": "ListSyncListPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       }
     },
@@ -2909,6 +2996,9 @@
         "operationId": "FetchSyncMap",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Maps"
         ]
       },
       "delete": {
@@ -2946,6 +3036,9 @@
         "operationId": "DeleteSyncMap",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Maps"
         ]
       },
       "post": {
@@ -3010,7 +3103,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Maps"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Maps": {
@@ -3087,7 +3183,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Maps"
+        ]
       },
       "get": {
         "description": "",
@@ -3171,6 +3270,9 @@
         "operationId": "ListSyncMap",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Maps"
         ]
       }
     },
@@ -3242,6 +3344,9 @@
         "operationId": "FetchSyncMapItem",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Items"
         ]
       },
       "delete": {
@@ -3277,7 +3382,7 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "If provided, applies this mutation if (and only if) the \u201crevision\u201d field of this [map item] matches the provided value. This matches the semantics of (and is implemented with) the HTTP [If-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match).",
+            "description": "If provided, applies this mutation if (and only if) the “revision” field of this [map item] matches the provided value. This matches the semantics of (and is implemented with) the HTTP [If-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match).",
             "schema": {
               "type": "string"
             }
@@ -3296,6 +3401,9 @@
         "operationId": "DeleteSyncMapItem",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Items"
         ]
       },
       "post": {
@@ -3331,7 +3439,7 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "If provided, applies this mutation if (and only if) the \u201crevision\u201d field of this [map item] matches the provided value. This matches the semantics of (and is implemented with) the HTTP [If-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match).",
+            "description": "If provided, applies this mutation if (and only if) the “revision” field of this [map item] matches the provided value. This matches the semantics of (and is implemented with) the HTTP [If-Match header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match).",
             "schema": {
               "type": "string"
             }
@@ -3384,7 +3492,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Items"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Maps/{MapSid}/Items": {
@@ -3481,7 +3592,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Items"
+        ]
       },
       "get": {
         "description": "",
@@ -3600,6 +3714,9 @@
         "operationId": "ListSyncMapItem",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Items"
         ]
       }
     },
@@ -3672,6 +3789,9 @@
         "operationId": "FetchSyncMapPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "delete": {
@@ -3718,6 +3838,9 @@
         "operationId": "DeleteSyncMapPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       },
       "post": {
@@ -3800,7 +3923,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Permissions"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Maps/{MapSid}/Permissions": {
@@ -3912,6 +4038,9 @@
         "operationId": "ListSyncMapPermission",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Permissions"
         ]
       }
     },
@@ -3974,6 +4103,9 @@
         "operationId": "FetchSyncStream",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Streams"
         ]
       },
       "delete": {
@@ -4011,6 +4143,9 @@
         "operationId": "DeleteSyncStream",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Streams"
         ]
       },
       "post": {
@@ -4071,7 +4206,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Streams"
+        ]
       }
     },
     "/v1/Services/{ServiceSid}/Streams": {
@@ -4144,7 +4282,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Streams"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Streams in a Service Instance.",
@@ -4228,6 +4369,9 @@
         "operationId": "ListSyncStream",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Streams"
         ]
       }
     }

--- a/spec/json/twilio_taskrouter_v1.json
+++ b/spec/json/twilio_taskrouter_v1.json
@@ -2105,6 +2105,9 @@
         "operationId": "FetchActivity",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Activities"
         ]
       },
       "post": {
@@ -2171,7 +2174,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Activities"
+        ]
       },
       "delete": {
         "description": "",
@@ -2214,6 +2220,9 @@
         "operationId": "DeleteActivity",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Activities"
         ]
       }
     },
@@ -2334,6 +2343,9 @@
         "operationId": "ListActivity",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Activities"
         ]
       },
       "post": {
@@ -2395,7 +2407,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Activities"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/Events/{Sid}": {
@@ -2462,6 +2477,9 @@
         "operationId": "FetchEvent",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Events"
         ]
       }
     },
@@ -2674,6 +2692,9 @@
         "operationId": "ListEvent",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Events"
         ]
       }
     },
@@ -2743,6 +2764,9 @@
         "operationId": "FetchTask",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Tasks"
         ]
       },
       "post": {
@@ -2834,7 +2858,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Tasks"
+        ]
       },
       "delete": {
         "description": "",
@@ -2885,6 +2912,9 @@
         "operationId": "DeleteTask",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Tasks"
         ]
       }
     },
@@ -3072,6 +3102,9 @@
         "operationId": "ListTask",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Tasks"
         ]
       },
       "post": {
@@ -3145,7 +3178,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Tasks"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/TaskChannels/{Sid}": {
@@ -3209,6 +3245,9 @@
         "operationId": "FetchTaskChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TaskChannels"
         ]
       },
       "post": {
@@ -3276,7 +3315,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "TaskChannels"
+        ]
       },
       "delete": {
         "description": "",
@@ -3316,6 +3358,9 @@
         "operationId": "DeleteTaskChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TaskChannels"
         ]
       }
     },
@@ -3420,6 +3465,9 @@
         "operationId": "ListTaskChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TaskChannels"
         ]
       },
       "post": {
@@ -3486,7 +3534,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "TaskChannels"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/TaskQueues/{Sid}": {
@@ -3553,6 +3604,9 @@
         "operationId": "FetchTaskQueue",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TaskQueues"
         ]
       },
       "post": {
@@ -3646,7 +3700,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "TaskQueues"
+        ]
       },
       "delete": {
         "description": "",
@@ -3689,6 +3746,9 @@
         "operationId": "DeleteTaskQueue",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TaskQueues"
         ]
       }
     },
@@ -3820,6 +3880,9 @@
         "operationId": "ListTaskQueue",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TaskQueues"
         ]
       },
       "post": {
@@ -3904,7 +3967,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "TaskQueues"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/TaskQueues/{TaskQueueSid}/CumulativeStatistics": {
@@ -4015,6 +4081,9 @@
         "operationId": "FetchTaskQueueCumulativeStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CumulativeStatistics"
         ]
       }
     },
@@ -4091,6 +4160,9 @@
         "operationId": "FetchTaskQueueRealTimeStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RealTimeStatistics"
         ]
       }
     },
@@ -4199,6 +4271,9 @@
         "operationId": "FetchTaskQueueStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Statistics"
         ]
       }
     },
@@ -4352,6 +4427,9 @@
         "operationId": "ListTaskQueuesStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Statistics"
         ]
       }
     },
@@ -4478,6 +4556,9 @@
         "operationId": "ListTaskReservation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Reservations"
         ]
       }
     },
@@ -4558,6 +4639,9 @@
         "operationId": "FetchTaskReservation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Reservations"
         ]
       },
       "post": {
@@ -4931,7 +5015,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Reservations"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/Workers": {
@@ -5097,6 +5184,9 @@
         "operationId": "ListWorker",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workers"
         ]
       },
       "post": {
@@ -5165,7 +5255,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Workers"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/Workers/{Sid}": {
@@ -5232,6 +5325,9 @@
         "operationId": "FetchWorker",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workers"
         ]
       },
       "post": {
@@ -5321,7 +5417,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Workers"
+        ]
       },
       "delete": {
         "description": "",
@@ -5372,6 +5471,9 @@
         "operationId": "DeleteWorker",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workers"
         ]
       }
     },
@@ -5489,6 +5591,9 @@
         "operationId": "ListWorkerChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       }
     },
@@ -5566,6 +5671,9 @@
         "operationId": "FetchWorkerChannel",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Channels"
         ]
       },
       "post": {
@@ -5645,7 +5753,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Channels"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/Workers/{WorkerSid}/Statistics": {
@@ -5745,6 +5856,9 @@
         "operationId": "FetchWorkerInstanceStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Statistics"
         ]
       }
     },
@@ -5870,6 +5984,9 @@
         "operationId": "ListWorkerReservation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Reservations"
         ]
       }
     },
@@ -5949,6 +6066,9 @@
         "operationId": "FetchWorkerReservation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Reservations"
         ]
       },
       "post": {
@@ -6313,7 +6433,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Reservations"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/Workers/Statistics": {
@@ -6428,6 +6551,9 @@
         "operationId": "FetchWorkerStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Statistics"
         ]
       }
     },
@@ -6521,6 +6647,9 @@
         "operationId": "FetchWorkersCumulativeStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CumulativeStatistics"
         ]
       }
     },
@@ -6583,6 +6712,9 @@
         "operationId": "FetchWorkersRealTimeStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RealTimeStatistics"
         ]
       }
     },
@@ -6650,6 +6782,9 @@
         "operationId": "FetchWorkflow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workflows"
         ]
       },
       "post": {
@@ -6738,7 +6873,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Workflows"
+        ]
       },
       "delete": {
         "description": "",
@@ -6781,6 +6919,9 @@
         "operationId": "DeleteWorkflow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workflows"
         ]
       }
     },
@@ -6893,6 +7034,9 @@
         "operationId": "ListWorkflow",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workflows"
         ]
       },
       "post": {
@@ -6969,7 +7113,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Workflows"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/Workflows/{WorkflowSid}/CumulativeStatistics": {
@@ -7080,6 +7227,9 @@
         "operationId": "FetchWorkflowCumulativeStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CumulativeStatistics"
         ]
       }
     },
@@ -7156,6 +7306,9 @@
         "operationId": "FetchWorkflowRealTimeStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RealTimeStatistics"
         ]
       }
     },
@@ -7264,6 +7417,9 @@
         "operationId": "FetchWorkflowStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Statistics"
         ]
       }
     },
@@ -7318,6 +7474,9 @@
         "operationId": "FetchWorkspace",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workspaces"
         ]
       },
       "post": {
@@ -7404,7 +7563,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Workspaces"
+        ]
       },
       "delete": {
         "description": "",
@@ -7435,6 +7597,9 @@
         "operationId": "DeleteWorkspace",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workspaces"
         ]
       }
     },
@@ -7534,6 +7699,9 @@
         "operationId": "ListWorkspace",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Workspaces"
         ]
       },
       "post": {
@@ -7599,7 +7767,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Workspaces"
+        ]
       }
     },
     "/v1/Workspaces/{WorkspaceSid}/CumulativeStatistics": {
@@ -7698,6 +7869,9 @@
         "operationId": "FetchWorkspaceCumulativeStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CumulativeStatistics"
         ]
       }
     },
@@ -7762,6 +7936,9 @@
         "operationId": "FetchWorkspaceRealTimeStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RealTimeStatistics"
         ]
       }
     },
@@ -7858,6 +8035,9 @@
         "operationId": "FetchWorkspaceStatistics",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Statistics"
         ]
       }
     }

--- a/spec/json/twilio_trunking_v1.json
+++ b/spec/json/twilio_trunking_v1.json
@@ -646,6 +646,9 @@
         "operationId": "FetchCredentialList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialLists"
         ]
       },
       "delete": {
@@ -689,6 +692,9 @@
         "operationId": "DeleteCredentialList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialLists"
         ]
       }
     },
@@ -766,7 +772,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CredentialLists"
+        ]
       },
       "get": {
         "description": "",
@@ -853,6 +862,9 @@
         "operationId": "ListCredentialList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CredentialLists"
         ]
       }
     },
@@ -920,6 +932,9 @@
         "operationId": "FetchIpAccessControlList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlLists"
         ]
       },
       "delete": {
@@ -963,6 +978,9 @@
         "operationId": "DeleteIpAccessControlList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlLists"
         ]
       }
     },
@@ -1040,7 +1058,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpAccessControlLists"
+        ]
       },
       "get": {
         "description": "List all IP Access Control Lists for a Trunk",
@@ -1127,6 +1148,9 @@
         "operationId": "ListIpAccessControlList",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpAccessControlLists"
         ]
       }
     },
@@ -1196,6 +1220,9 @@
         "operationId": "FetchOriginationUrl",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "OriginationUrls"
         ]
       },
       "delete": {
@@ -1239,6 +1266,9 @@
         "operationId": "DeleteOriginationUrl",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "OriginationUrls"
         ]
       },
       "post": {
@@ -1322,7 +1352,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "OriginationUrls"
+        ]
       }
     },
     "/v1/Trunks/{TrunkSid}/OriginationUrls": {
@@ -1419,7 +1452,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "OriginationUrls"
+        ]
       },
       "get": {
         "description": "",
@@ -1506,6 +1542,9 @@
         "operationId": "ListOriginationUrl",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "OriginationUrls"
         ]
       }
     },
@@ -1573,6 +1612,9 @@
         "operationId": "FetchPhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       },
       "delete": {
@@ -1616,6 +1658,9 @@
         "operationId": "DeletePhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       }
     },
@@ -1693,7 +1738,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "PhoneNumbers"
+        ]
       },
       "get": {
         "description": "",
@@ -1780,6 +1828,9 @@
         "operationId": "ListPhoneNumber",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PhoneNumbers"
         ]
       }
     },
@@ -1834,6 +1885,9 @@
         "operationId": "FetchRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recording"
         ]
       },
       "post": {
@@ -1894,7 +1948,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Recording"
+        ]
       }
     },
     "/v1/Trunks/{Sid}": {
@@ -1948,6 +2005,9 @@
         "operationId": "FetchTrunk",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Trunks"
         ]
       },
       "delete": {
@@ -1979,6 +2039,9 @@
         "operationId": "DeleteTrunk",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Trunks"
         ]
       },
       "post": {
@@ -2073,7 +2136,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Trunks"
+        ]
       }
     },
     "/v1/Trunks": {
@@ -2169,7 +2235,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Trunks"
+        ]
       },
       "get": {
         "description": "",
@@ -2244,6 +2313,9 @@
         "operationId": "ListTrunk",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Trunks"
         ]
       }
     }

--- a/spec/json/twilio_trusthub_v1.json
+++ b/spec/json/twilio_trusthub_v1.json
@@ -868,7 +868,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CustomerProfiles"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Customer-Profiles for an account.",
@@ -971,6 +974,9 @@
         "operationId": "ListCustomerProfile",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CustomerProfiles"
         ]
       }
     },
@@ -1026,6 +1032,9 @@
         "operationId": "FetchCustomerProfile",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CustomerProfiles"
         ]
       },
       "post": {
@@ -1094,7 +1103,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CustomerProfiles"
+        ]
       },
       "delete": {
         "description": "Delete a specific Customer-Profile.",
@@ -1125,6 +1137,9 @@
         "operationId": "DeleteCustomerProfile",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CustomerProfiles"
         ]
       }
     },
@@ -1206,7 +1221,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ChannelEndpointAssignments"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Assigned Items for an account.",
@@ -1312,6 +1330,9 @@
         "operationId": "ListCustomerProfileChannelEndpointAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ChannelEndpointAssignments"
         ]
       }
     },
@@ -1378,6 +1399,9 @@
         "operationId": "FetchCustomerProfileChannelEndpointAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ChannelEndpointAssignments"
         ]
       },
       "delete": {
@@ -1421,6 +1445,9 @@
         "operationId": "DeleteCustomerProfileChannelEndpointAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ChannelEndpointAssignments"
         ]
       }
     },
@@ -1497,7 +1524,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "EntityAssignments"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Assigned Items for an account.",
@@ -1584,6 +1614,9 @@
         "operationId": "ListCustomerProfileEntityAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EntityAssignments"
         ]
       }
     },
@@ -1650,6 +1683,9 @@
         "operationId": "FetchCustomerProfileEntityAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EntityAssignments"
         ]
       },
       "delete": {
@@ -1693,6 +1729,9 @@
         "operationId": "DeleteCustomerProfileEntityAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EntityAssignments"
         ]
       }
     },
@@ -1769,7 +1808,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Evaluations"
+        ]
       },
       "get": {
         "description": "Retrieve a list of Evaluations associated to the customer_profile resource.",
@@ -1856,6 +1898,9 @@
         "operationId": "ListCustomerProfileEvaluation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Evaluations"
         ]
       }
     },
@@ -1922,6 +1967,9 @@
         "operationId": "FetchCustomerProfileEvaluation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Evaluations"
         ]
       }
     },
@@ -1988,7 +2036,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "EndUsers"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all End User for an account.",
@@ -2063,6 +2114,9 @@
         "operationId": "ListEndUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUsers"
         ]
       }
     },
@@ -2116,6 +2170,9 @@
         "operationId": "FetchEndUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUsers"
         ]
       },
       "post": {
@@ -2173,7 +2230,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "EndUsers"
+        ]
       },
       "delete": {
         "description": "Delete a specific End User.",
@@ -2204,6 +2264,9 @@
         "operationId": "DeleteEndUser",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUsers"
         ]
       }
     },
@@ -2294,6 +2357,9 @@
         "operationId": "ListEndUserType",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUserTypes"
         ]
       }
     },
@@ -2344,6 +2410,9 @@
         "operationId": "FetchEndUserType",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EndUserTypes"
         ]
       }
     },
@@ -2435,6 +2504,9 @@
         "operationId": "ListPolicies",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Policies"
         ]
       }
     },
@@ -2489,6 +2561,9 @@
         "operationId": "FetchPolicies",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Policies"
         ]
       }
     },
@@ -2555,7 +2630,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SupportingDocuments"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Supporting Document for an account.",
@@ -2630,6 +2708,9 @@
         "operationId": "ListSupportingDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocuments"
         ]
       }
     },
@@ -2683,6 +2764,9 @@
         "operationId": "FetchSupportingDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocuments"
         ]
       },
       "post": {
@@ -2740,7 +2824,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SupportingDocuments"
+        ]
       },
       "delete": {
         "description": "Delete a specific Supporting Document.",
@@ -2771,6 +2858,9 @@
         "operationId": "DeleteSupportingDocument",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocuments"
         ]
       }
     },
@@ -2861,6 +2951,9 @@
         "operationId": "ListSupportingDocumentType",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocumentTypes"
         ]
       }
     },
@@ -2911,6 +3004,9 @@
         "operationId": "FetchSupportingDocumentType",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SupportingDocumentTypes"
         ]
       }
     },
@@ -2989,7 +3085,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "TrustProducts"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Customer-Profiles for an account.",
@@ -3092,6 +3191,9 @@
         "operationId": "ListTrustProduct",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TrustProducts"
         ]
       }
     },
@@ -3147,6 +3249,9 @@
         "operationId": "FetchTrustProduct",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TrustProducts"
         ]
       },
       "post": {
@@ -3215,7 +3320,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "TrustProducts"
+        ]
       },
       "delete": {
         "description": "Delete a specific Customer-Profile.",
@@ -3246,6 +3354,9 @@
         "operationId": "DeleteTrustProduct",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "TrustProducts"
         ]
       }
     },
@@ -3327,7 +3438,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ChannelEndpointAssignments"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Assigned Items for an account.",
@@ -3433,6 +3547,9 @@
         "operationId": "ListTrustProductChannelEndpointAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ChannelEndpointAssignments"
         ]
       }
     },
@@ -3499,6 +3616,9 @@
         "operationId": "FetchTrustProductChannelEndpointAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ChannelEndpointAssignments"
         ]
       },
       "delete": {
@@ -3542,6 +3662,9 @@
         "operationId": "DeleteTrustProductChannelEndpointAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ChannelEndpointAssignments"
         ]
       }
     },
@@ -3618,7 +3741,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "EntityAssignments"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Assigned Items for an account.",
@@ -3705,6 +3831,9 @@
         "operationId": "ListTrustProductEntityAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EntityAssignments"
         ]
       }
     },
@@ -3771,6 +3900,9 @@
         "operationId": "FetchTrustProductEntityAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EntityAssignments"
         ]
       },
       "delete": {
@@ -3814,6 +3946,9 @@
         "operationId": "DeleteTrustProductEntityAssignment",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "EntityAssignments"
         ]
       }
     },
@@ -3890,7 +4025,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Evaluations"
+        ]
       },
       "get": {
         "description": "Retrieve a list of Evaluations associated to the trust_product resource.",
@@ -3977,6 +4115,9 @@
         "operationId": "ListTrustProductEvaluation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Evaluations"
         ]
       }
     },
@@ -4043,6 +4184,9 @@
         "operationId": "FetchTrustProductEvaluation",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Evaluations"
         ]
       }
     }

--- a/spec/json/twilio_verify_v2.json
+++ b/spec/json/twilio_verify_v2.json
@@ -1535,7 +1535,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "AccessTokens"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/AccessTokens/{Sid}": {
@@ -1608,6 +1611,9 @@
         "operationId": "FetchAccessToken",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "AccessTokens"
         ]
       }
     },
@@ -1704,7 +1710,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Buckets"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Buckets for a Rate Limit.",
@@ -1803,6 +1812,9 @@
         "operationId": "ListBucket",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Buckets"
         ]
       }
     },
@@ -1907,7 +1919,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Buckets"
+        ]
       },
       "get": {
         "description": "Fetch a specific Bucket.",
@@ -1969,6 +1984,9 @@
         "operationId": "FetchBucket",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Buckets"
         ]
       },
       "delete": {
@@ -2024,6 +2042,9 @@
         "operationId": "DeleteBucket",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Buckets"
         ]
       }
     },
@@ -2132,7 +2153,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Challenges"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Challenges for a Factor.",
@@ -2257,6 +2281,9 @@
         "operationId": "ListChallenge",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Challenges"
         ]
       }
     },
@@ -2334,6 +2361,9 @@
         "operationId": "FetchChallenge",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Challenges"
         ]
       },
       "post": {
@@ -2412,7 +2442,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Challenges"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Entities": {
@@ -2486,7 +2519,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Entities"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Entities for a Service.",
@@ -2573,6 +2609,9 @@
         "operationId": "ListEntity",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Entities"
         ]
       }
     },
@@ -2630,6 +2669,9 @@
         "operationId": "DeleteEntity",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Entities"
         ]
       },
       "get": {
@@ -2677,6 +2719,9 @@
         "operationId": "FetchEntity",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Entities"
         ]
       }
     },
@@ -2747,6 +2792,9 @@
         "operationId": "DeleteFactor",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Factors"
         ]
       },
       "get": {
@@ -2806,6 +2854,9 @@
         "operationId": "FetchFactor",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Factors"
         ]
       },
       "post": {
@@ -2914,7 +2965,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Factors"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Entities/{Identity}/Factors": {
@@ -3028,6 +3082,9 @@
         "operationId": "ListFactor",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Factors"
         ]
       },
       "post": {
@@ -3085,7 +3142,7 @@
                 "properties": {
                   "FriendlyName": {
                     "type": "string",
-                    "description": "The friendly name of this Factor. This can be any string up to 64 characters, meant for humans to distinguish between Factors.\nFor `factor_type` `push`, this could be a device name.\nFor `factor_type` `totp`, this value is used as the \u201caccount name\u201d in constructing the `binding.uri` property.\nAt the same time, we recommend avoiding providing PII."
+                    "description": "The friendly name of this Factor. This can be any string up to 64 characters, meant for humans to distinguish between Factors.\nFor `factor_type` `push`, this could be a device name.\nFor `factor_type` `totp`, this value is used as the “account name” in constructing the `binding.uri` property.\nAt the same time, we recommend avoiding providing PII."
                   },
                   "FactorType": {
                     "type": "string",
@@ -3152,7 +3209,10 @@
         },
         "x-twilio": {
           "className": "new_factor"
-        }
+        },
+        "tags": [
+          "Factors"
+        ]
       }
     },
     "/v2/Forms/{FormType}": {
@@ -3202,6 +3262,9 @@
         "operationId": "FetchForm",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Forms"
         ]
       }
     },
@@ -3287,7 +3350,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "MessagingConfigurations"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Messaging Configurations for a Service.",
@@ -3374,6 +3440,9 @@
         "operationId": "ListMessagingConfiguration",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "MessagingConfigurations"
         ]
       }
     },
@@ -3463,7 +3532,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "MessagingConfigurations"
+        ]
       },
       "get": {
         "description": "Fetch a specific MessagingConfiguration.",
@@ -3510,6 +3582,9 @@
         "operationId": "FetchMessagingConfiguration",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "MessagingConfigurations"
         ]
       },
       "delete": {
@@ -3550,6 +3625,9 @@
         "operationId": "DeleteMessagingConfiguration",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "MessagingConfigurations"
         ]
       }
     },
@@ -3643,7 +3721,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Notifications"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/RateLimits": {
@@ -3725,7 +3806,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "RateLimits"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Rate Limits for a service.",
@@ -3812,6 +3896,9 @@
         "operationId": "ListRateLimit",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RateLimits"
         ]
       }
     },
@@ -3899,7 +3986,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "RateLimits"
+        ]
       },
       "get": {
         "description": "Fetch a specific Rate Limit.",
@@ -3949,6 +4039,9 @@
         "operationId": "FetchRateLimit",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RateLimits"
         ]
       },
       "delete": {
@@ -3992,6 +4085,9 @@
         "operationId": "DeleteRateLimit",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RateLimits"
         ]
       }
     },
@@ -4051,7 +4147,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Numbers"
+        ]
       }
     },
     "/v2/SafeList/Numbers/{PhoneNumber}": {
@@ -4102,6 +4201,9 @@
         "operationId": "FetchSafelist",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Numbers"
         ]
       },
       "delete": {
@@ -4130,6 +4232,9 @@
         "operationId": "DeleteSafelist",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Numbers"
         ]
       }
     },
@@ -4208,7 +4313,7 @@
                   },
                   "DoNotShareWarningEnabled": {
                     "type": "boolean",
-                    "description": "Whether to add a security warning at the end of an SMS verification body. Disabled by default and applies only to SMS. Example SMS body: `Your AppName verification code is: 1234. Don\u2019t share this code with anyone; our employees will never ask for the code`"
+                    "description": "Whether to add a security warning at the end of an SMS verification body. Disabled by default and applies only to SMS. Example SMS body: `Your AppName verification code is: 1234. Don’t share this code with anyone; our employees will never ask for the code`"
                   },
                   "CustomCodeEnabled": {
                     "type": "boolean",
@@ -4216,7 +4321,7 @@
                   },
                   "Push.IncludeDate": {
                     "type": "boolean",
-                    "description": "Optional configuration for the Push factors. If true, include the date in the Challenge's response. Otherwise, the date is omitted from the response. See [Challenge](https://www.twilio.com/docs/verify/api/challenge) resource\u2019s details parameter for more info. Default: false. **Deprecated** do not use this parameter. This timestamp value is the same one as the one found in `date_created`, please use that one instead."
+                    "description": "Optional configuration for the Push factors. If true, include the date in the Challenge's response. Otherwise, the date is omitted from the response. See [Challenge](https://www.twilio.com/docs/verify/api/challenge) resource’s details parameter for more info. Default: false. **Deprecated** do not use this parameter. This timestamp value is the same one as the one found in `date_created`, please use that one instead."
                   },
                   "Push.ApnCredentialSid": {
                     "type": "string",
@@ -4262,7 +4367,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Verification Services for an account.",
@@ -4337,6 +4445,9 @@
         "operationId": "ListService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       }
     },
@@ -4391,6 +4502,9 @@
         "operationId": "FetchService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "delete": {
@@ -4422,6 +4536,9 @@
         "operationId": "DeleteService",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Services"
         ]
       },
       "post": {
@@ -4506,7 +4623,7 @@
                   },
                   "Push.IncludeDate": {
                     "type": "boolean",
-                    "description": "Optional configuration for the Push factors. If true, include the date in the Challenge's response. Otherwise, the date is omitted from the response. See [Challenge](https://www.twilio.com/docs/verify/api/challenge) resource\u2019s details parameter for more info. Default: false. **Deprecated** do not use this parameter."
+                    "description": "Optional configuration for the Push factors. If true, include the date in the Challenge's response. Otherwise, the date is omitted from the response. See [Challenge](https://www.twilio.com/docs/verify/api/challenge) resource’s details parameter for more info. Default: false. **Deprecated** do not use this parameter."
                   },
                   "Push.ApnCredentialSid": {
                     "type": "string",
@@ -4549,7 +4666,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Services"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Verifications": {
@@ -4680,7 +4800,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Verifications"
+        ]
       }
     },
     "/v2/Services/{ServiceSid}/Verifications/{Sid}": {
@@ -4767,7 +4890,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Verifications"
+        ]
       },
       "get": {
         "description": "Fetch a specific Verification",
@@ -4814,6 +4940,9 @@
         "operationId": "FetchVerification",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Verifications"
         ]
       }
     },
@@ -4983,6 +5112,9 @@
         "operationId": "ListVerificationAttempt",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Attempts"
         ]
       }
     },
@@ -5040,6 +5172,9 @@
         "operationId": "FetchVerificationAttempt",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Attempts"
         ]
       }
     },
@@ -5139,6 +5274,9 @@
         "operationId": "FetchVerificationAttemptsSummary",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Summary"
         ]
       }
     },
@@ -5232,7 +5370,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "VerificationCheck"
+        ]
       }
     },
     "/v2/Templates": {
@@ -5330,6 +5471,9 @@
         "operationId": "ListVerificationTemplate",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Templates"
         ]
       }
     },
@@ -5432,7 +5576,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "get": {
         "description": "Retrieve a list of all Webhooks for a Service.",
@@ -5519,6 +5666,9 @@
         "operationId": "ListWebhook",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     },
@@ -5628,7 +5778,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Webhooks"
+        ]
       },
       "delete": {
         "description": "Delete a specific Webhook.",
@@ -5671,6 +5824,9 @@
         "operationId": "DeleteWebhook",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       },
       "get": {
@@ -5721,6 +5877,9 @@
         "operationId": "FetchWebhook",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Webhooks"
         ]
       }
     }

--- a/spec/json/twilio_video_v1.json
+++ b/spec/json/twilio_video_v1.json
@@ -1374,6 +1374,9 @@
         "operationId": "FetchComposition",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Compositions"
         ]
       },
       "delete": {
@@ -1405,6 +1408,9 @@
         "operationId": "DeleteComposition",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Compositions"
         ]
       }
     },
@@ -1535,6 +1541,9 @@
         "operationId": "ListComposition",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Compositions"
         ]
       },
       "post": {
@@ -1629,7 +1638,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Compositions"
+        ]
       }
     },
     "/v1/CompositionHooks/{Sid}": {
@@ -1683,6 +1695,9 @@
         "operationId": "FetchCompositionHook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CompositionHooks"
         ]
       },
       "delete": {
@@ -1714,6 +1729,9 @@
         "operationId": "DeleteCompositionHook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CompositionHooks"
         ]
       },
       "post": {
@@ -1823,7 +1841,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CompositionHooks"
+        ]
       }
     },
     "/v1/CompositionHooks": {
@@ -1948,6 +1969,9 @@
         "operationId": "ListCompositionHook",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "CompositionHooks"
         ]
       },
       "post": {
@@ -2043,7 +2067,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "CompositionHooks"
+        ]
       }
     },
     "/v1/CompositionSettings/Default": {
@@ -2084,6 +2111,9 @@
         "operationId": "FetchCompositionSettings",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Default"
         ]
       },
       "post": {
@@ -2154,7 +2184,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Default"
+        ]
       }
     },
     "/v1/Recordings/{Sid}": {
@@ -2211,6 +2244,9 @@
         "operationId": "FetchRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       },
       "delete": {
@@ -2242,6 +2278,9 @@
         "operationId": "DeleteRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -2397,6 +2436,9 @@
         "operationId": "ListRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -2438,6 +2480,9 @@
         "operationId": "FetchRecordingSettings",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Default"
         ]
       },
       "post": {
@@ -2508,7 +2553,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Default"
+        ]
       }
     },
     "/v1/Rooms/{Sid}": {
@@ -2559,6 +2607,9 @@
         "operationId": "FetchRoom",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Rooms"
         ]
       },
       "post": {
@@ -2614,7 +2665,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Rooms"
+        ]
       }
     },
     "/v1/Rooms": {
@@ -2740,7 +2794,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Rooms"
+        ]
       },
       "get": {
         "description": "",
@@ -2850,6 +2907,9 @@
         "operationId": "ListRoom",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Rooms"
         ]
       }
     },
@@ -2911,6 +2971,9 @@
         "operationId": "FetchRoomParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       },
       "post": {
@@ -2972,7 +3035,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Participants"
+        ]
       }
     },
     "/v1/Rooms/{RoomSid}/Participants": {
@@ -3108,6 +3174,9 @@
         "operationId": "ListRoomParticipant",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Participants"
         ]
       }
     },
@@ -3169,6 +3238,9 @@
         "operationId": "UpdateRoomParticipantAnonymize",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Anonymize"
         ]
       }
     },
@@ -3240,6 +3312,9 @@
         "operationId": "FetchRoomParticipantPublishedTrack",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PublishedTracks"
         ]
       }
     },
@@ -3351,6 +3426,9 @@
         "operationId": "ListRoomParticipantPublishedTrack",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "PublishedTracks"
         ]
       }
     },
@@ -3413,6 +3491,9 @@
         "operationId": "FetchRoomParticipantSubscribeRule",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SubscribeRules"
         ]
       },
       "post": {
@@ -3472,7 +3553,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SubscribeRules"
+        ]
       }
     },
     "/v1/Rooms/{RoomSid}/Participants/{ParticipantSid}/SubscribedTracks/{Sid}": {
@@ -3546,6 +3630,9 @@
         "operationId": "FetchRoomParticipantSubscribedTrack",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SubscribedTracks"
         ]
       }
     },
@@ -3657,6 +3744,9 @@
         "operationId": "ListRoomParticipantSubscribedTrack",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SubscribedTracks"
         ]
       }
     },
@@ -3728,6 +3818,9 @@
         "operationId": "FetchRoomRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       },
       "delete": {
@@ -3771,6 +3864,9 @@
         "operationId": "DeleteRoomRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -3917,6 +4013,9 @@
         "operationId": "ListRoomRecording",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Recordings"
         ]
       }
     },
@@ -3969,6 +4068,9 @@
         "operationId": "FetchRoomRecordingRule",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RecordingRules"
         ]
       },
       "post": {
@@ -4019,7 +4121,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "RecordingRules"
+        ]
       }
     }
   },

--- a/spec/json/twilio_voice_v1.json
+++ b/spec/json/twilio_voice_v1.json
@@ -608,6 +608,9 @@
         "operationId": "DeleteArchivedCall",
         "x-maturity": [
           "Beta"
+        ],
+        "tags": [
+          "Calls"
         ]
       }
     },
@@ -736,7 +739,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ByocTrunks"
+        ]
       },
       "get": {
         "description": "",
@@ -811,6 +817,9 @@
         "operationId": "ListByocTrunk",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ByocTrunks"
         ]
       }
     },
@@ -865,6 +874,9 @@
         "operationId": "FetchByocTrunk",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ByocTrunks"
         ]
       },
       "post": {
@@ -991,7 +1003,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ByocTrunks"
+        ]
       },
       "delete": {
         "description": "",
@@ -1022,6 +1037,9 @@
         "operationId": "DeleteByocTrunk",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ByocTrunks"
         ]
       }
     },
@@ -1077,7 +1095,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ConnectionPolicies"
+        ]
       },
       "get": {
         "description": "",
@@ -1152,6 +1173,9 @@
         "operationId": "ListConnectionPolicy",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ConnectionPolicies"
         ]
       }
     },
@@ -1205,6 +1229,9 @@
         "operationId": "FetchConnectionPolicy",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ConnectionPolicies"
         ]
       },
       "post": {
@@ -1259,7 +1286,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "ConnectionPolicies"
+        ]
       },
       "delete": {
         "description": "",
@@ -1290,6 +1320,9 @@
         "operationId": "DeleteConnectionPolicy",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "ConnectionPolicies"
         ]
       }
     },
@@ -1383,7 +1416,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Targets"
+        ]
       },
       "get": {
         "description": "",
@@ -1470,6 +1506,9 @@
         "operationId": "ListConnectionPolicyTarget",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Targets"
         ]
       }
     },
@@ -1539,6 +1578,9 @@
         "operationId": "FetchConnectionPolicyTarget",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Targets"
         ]
       },
       "post": {
@@ -1622,7 +1664,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Targets"
+        ]
       },
       "delete": {
         "description": "",
@@ -1665,6 +1710,9 @@
         "operationId": "DeleteConnectionPolicyTarget",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Targets"
         ]
       }
     },
@@ -1731,6 +1779,9 @@
         "operationId": "FetchDialingPermissionsCountry",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -1872,6 +1923,9 @@
         "operationId": "ListDialingPermissionsCountry",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Countries"
         ]
       }
     },
@@ -1931,7 +1985,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "BulkCountryUpdates"
+        ]
       }
     },
     "/v1/DialingPermissions/Countries/{IsoCode}/HighRiskSpecialPrefixes": {
@@ -2032,6 +2089,9 @@
         "operationId": "ListDialingPermissionsHrsPrefixes",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "HighRiskSpecialPrefixes"
         ]
       }
     },
@@ -2072,6 +2132,9 @@
         "operationId": "FetchDialingPermissionsSettings",
         "x-maturity": [
           "Preview"
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "post": {
@@ -2112,7 +2175,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Settings"
+        ]
       }
     },
     "/v1/IpRecords": {
@@ -2180,7 +2246,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpRecords"
+        ]
       },
       "get": {
         "description": "",
@@ -2255,6 +2324,9 @@
         "operationId": "ListIpRecord",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpRecords"
         ]
       }
     },
@@ -2310,6 +2382,9 @@
         "operationId": "FetchIpRecord",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpRecords"
         ]
       },
       "post": {
@@ -2364,7 +2439,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "IpRecords"
+        ]
       },
       "delete": {
         "description": "",
@@ -2395,6 +2473,9 @@
         "operationId": "DeleteIpRecord",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "IpRecords"
         ]
       }
     },
@@ -2465,7 +2546,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SourceIpMappings"
+        ]
       },
       "get": {
         "description": "",
@@ -2540,6 +2624,9 @@
         "operationId": "ListSourceIpMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SourceIpMappings"
         ]
       }
     },
@@ -2594,6 +2681,9 @@
         "operationId": "FetchSourceIpMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SourceIpMappings"
         ]
       },
       "post": {
@@ -2654,7 +2744,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "SourceIpMappings"
+        ]
       },
       "delete": {
         "description": "",
@@ -2685,6 +2778,9 @@
         "operationId": "DeleteSourceIpMapping",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "SourceIpMappings"
         ]
       }
     }

--- a/spec/json/twilio_wireless_v1.json
+++ b/spec/json/twilio_wireless_v1.json
@@ -725,6 +725,9 @@
         "operationId": "ListAccountUsageRecord",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "UsageRecords"
         ]
       }
     },
@@ -782,6 +785,9 @@
         "operationId": "FetchCommand",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Commands"
         ]
       },
       "delete": {
@@ -813,6 +819,9 @@
         "operationId": "DeleteCommand",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Commands"
         ]
       }
     },
@@ -942,6 +951,9 @@
         "operationId": "ListCommand",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Commands"
         ]
       },
       "post": {
@@ -1020,7 +1032,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Commands"
+        ]
       }
     },
     "/v1/Sims/{SimSid}/DataSessions": {
@@ -1123,6 +1138,9 @@
         "operationId": "ListDataSession",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "DataSessions"
         ]
       }
     },
@@ -1215,6 +1233,9 @@
         "operationId": "ListRatePlan",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RatePlans"
         ]
       },
       "post": {
@@ -1298,7 +1319,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "RatePlans"
+        ]
       }
     },
     "/v1/RatePlans/{Sid}": {
@@ -1350,6 +1374,9 @@
         "operationId": "FetchRatePlan",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RatePlans"
         ]
       },
       "post": {
@@ -1405,7 +1432,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "RatePlans"
+        ]
       },
       "delete": {
         "description": "",
@@ -1433,6 +1463,9 @@
         "operationId": "DeleteRatePlan",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "RatePlans"
         ]
       }
     },
@@ -1485,6 +1518,9 @@
         "operationId": "FetchSim",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Sims"
         ]
       },
       "post": {
@@ -1666,7 +1702,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Sims"
+        ]
       },
       "delete": {
         "description": "Delete a Sim resource on your Account.",
@@ -1694,6 +1733,9 @@
         "operationId": "DeleteSim",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Sims"
         ]
       }
     },
@@ -1827,6 +1869,9 @@
         "operationId": "ListSim",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "Sims"
         ]
       }
     },
@@ -1953,6 +1998,9 @@
         "operationId": "ListUsageRecord",
         "x-maturity": [
           "GA"
+        ],
+        "tags": [
+          "UsageRecords"
         ]
       }
     }


### PR DESCRIPTION
A tag has been added to each endpoint that matches the last path of the endpoint. This allows common APIs to be grouped by tag in Swagger UI.

For example, the following 5 endpoints are all grouped under the "Messages" tag:

```
POST    /2010-04-01/Accounts/{AccountSid}/Messages.json
GET     /2010-04-01/Accounts/{AccountSid}/Messages.json
DELETE  /2010-04-01/Accounts/{AccountSid}/Messages/{Sid}.json
GET     /2010-04-01/Accounts/{AccountSid}/Messages/{Sid}.json
POST    /2010-04-01/Accounts/{AccountSid}/Messages/{Sid}.json
```
You can view the spec + tags rendered in Swagger UI here:

https://johnchaffee.wiki/twilio-swagger/api/api_v2010/

Fixes #74 

I added these tags using [this script](https://github.com/johnchaffee/twilio-swagger/blob/main/add-tags.js), which you are welcome to clone. 
