### PR TITLE
fix: update parent logic for handling of parents vs. containers

### DIFF
--- a/spec/json/twilio_api_v2010.json
+++ b/spec/json/twilio_api_v2010.json
@@ -9790,7 +9790,7 @@
           "verified"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "post": {
         "description": "",
@@ -10013,7 +10013,7 @@
           "verified"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "delete": {
         "description": "",
@@ -10217,7 +10217,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "post": {
         "description": "Create a new application within your account",
@@ -10489,7 +10489,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "delete": {
         "description": "Delete the application by the specified application sid",
@@ -10772,7 +10772,7 @@
           "connect_app_friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of an authorized-connect-app",
@@ -10838,7 +10838,7 @@
           "connect_app_friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of authorized-connect-apps belonging to the account used to make the request",
@@ -10940,7 +10940,7 @@
           "beta"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json",
+        "parent": "/Accounts/{Sid}.json",
         "className": "available_phone_number_country"
       },
       "get": {
@@ -11043,7 +11043,7 @@
           "beta"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json",
+        "parent": "/Accounts/{Sid}.json",
         "className": "available_phone_number_country"
       },
       "get": {
@@ -11109,7 +11109,7 @@
           "beta"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json"
       },
       "get": {
         "description": "",
@@ -11366,7 +11366,7 @@
           "beta"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json"
       },
       "get": {
         "description": "",
@@ -11623,7 +11623,7 @@
           "beta"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json"
       },
       "get": {
         "description": "",
@@ -11880,7 +11880,7 @@
           "beta"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json"
       },
       "get": {
         "description": "",
@@ -12137,7 +12137,7 @@
           "beta"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json"
       },
       "get": {
         "description": "",
@@ -12394,7 +12394,7 @@
           "beta"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json"
       },
       "get": {
         "description": "",
@@ -12651,7 +12651,7 @@
           "beta"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json"
       },
       "get": {
         "description": "",
@@ -12908,7 +12908,7 @@
           "currency"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch the balance for an Account based on Account Sid. Balance changes may not be reflected immediately. Child accounts do not contain balance information",
@@ -12965,7 +12965,7 @@
           "start_time"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "post": {
         "description": "Create a new outgoing call to phones, SIP-enabled endpoints or Twilio Client connections",
@@ -13428,7 +13428,7 @@
           "start_time"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "delete": {
         "description": "Delete a Call record from your account. Once the record is deleted, it will no longer appear in the API and Account Portal logs.",
@@ -13667,7 +13667,7 @@
           "response"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of all events for a call.",
@@ -13781,7 +13781,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "get": {
         "description": "Fetch a Feedback resource from a call",
@@ -14137,7 +14137,7 @@
           "message_date"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "get": {
         "description": "",
@@ -14217,7 +14217,7 @@
           "message_date"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "get": {
         "description": "",
@@ -14368,7 +14368,7 @@
           "duration"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "post": {
         "description": "Create a recording for the call",
@@ -14610,7 +14610,7 @@
           "duration"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "post": {
         "description": "Changes the status of the recording to paused, stopped, or in-progress. Note: Pass `Twilio.CURRENT` instead of recording sid to reference current active recording.",
@@ -14827,7 +14827,7 @@
           "status"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of a conference",
@@ -14976,7 +14976,7 @@
           "status"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of conferences belonging to the account used to make the request",
@@ -15151,7 +15151,7 @@
           "duration"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Conferences.json"
+        "parent": "/Accounts/{AccountSid}/Conferences/{Sid}.json"
       },
       "post": {
         "description": "Changes the status of the recording to paused, stopped, or in-progress. Note: To use `Twilio.CURRENT`, pass it as recording sid.",
@@ -15370,7 +15370,7 @@
           "duration"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Conferences.json"
+        "parent": "/Accounts/{AccountSid}/Conferences/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of recordings belonging to the call used to make the request",
@@ -15510,7 +15510,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of a connect-app",
@@ -15729,7 +15729,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of connect-apps belonging to the account used to make the request",
@@ -15831,7 +15831,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Addresses.json"
+        "parent": "/Accounts/{AccountSid}/Addresses/{Sid}.json"
       },
       "get": {
         "description": "",
@@ -15945,7 +15945,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "post": {
         "description": "Update an incoming-phone-number instance.",
@@ -16285,7 +16285,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of incoming-phone-numbers belonging to the account used to make the request.",
@@ -16649,7 +16649,7 @@
           "description"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/IncomingPhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/IncomingPhoneNumbers/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of an Add-on installation currently assigned to this Number.",
@@ -16784,7 +16784,7 @@
           "description"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/IncomingPhoneNumbers.json"
+        "parent": "/Accounts/{AccountSid}/IncomingPhoneNumbers/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of Add-on installations currently assigned to this Number.",
@@ -16971,7 +16971,7 @@
           "product_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns.json",
+        "parent": "/Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns/{Sid}.json",
         "className": "assigned_add_on_extension"
       },
       "get": {
@@ -17064,7 +17064,7 @@
           "product_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns.json",
+        "parent": "/Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns/{Sid}.json",
         "className": "assigned_add_on_extension"
       },
       "get": {
@@ -18253,7 +18253,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "",
@@ -18429,7 +18429,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "",
@@ -18588,7 +18588,7 @@
           "content_type"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Messages.json"
+        "parent": "/Accounts/{AccountSid}/Messages/{Sid}.json"
       },
       "delete": {
         "description": "Delete media from your account. Once delete, you will no longer be billed",
@@ -18722,7 +18722,7 @@
           "content_type"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Messages.json"
+        "parent": "/Accounts/{AccountSid}/Messages/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of Media resources belonging to the account used to make the request",
@@ -18864,7 +18864,7 @@
           "wait_time"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Queues.json"
+        "parent": "/Accounts/{AccountSid}/Queues/{Sid}.json"
       },
       "get": {
         "description": "Fetch a specific member from the queue",
@@ -19033,7 +19033,7 @@
           "wait_time"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Queues.json"
+        "parent": "/Accounts/{AccountSid}/Queues/{Sid}.json"
       },
       "get": {
         "description": "Retrieve the members of the queue",
@@ -19150,7 +19150,7 @@
           "date_sent"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "post": {
         "description": "Send a message from the account used to make the request",
@@ -19465,7 +19465,7 @@
           "date_sent"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "delete": {
         "description": "Deletes a message record from your account",
@@ -19646,7 +19646,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Messages.json"
+        "parent": "/Accounts/{AccountSid}/Messages/{Sid}.json"
       },
       "post": {
         "description": "",
@@ -19730,7 +19730,7 @@
           "secret"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "post": {
         "description": "Create a new Signing Key for the account making the request.",
@@ -19890,7 +19890,7 @@
           "message_date"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch a notification belonging to the account used to make the request",
@@ -19958,7 +19958,7 @@
           "message_date"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of notifications belonging to the account used to make the request",
@@ -20095,7 +20095,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch an outgoing-caller-id belonging to the account used to make the request",
@@ -20271,7 +20271,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of outgoing-caller-ids belonging to the account used to make the request",
@@ -20483,7 +20483,7 @@
           "hold"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Conferences.json"
+        "parent": "/Accounts/{AccountSid}/Conferences/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of a participant",
@@ -20765,7 +20765,7 @@
           "hold"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Conferences.json"
+        "parent": "/Accounts/{AccountSid}/Conferences/{Sid}.json"
       },
       "post": {
         "description": "",
@@ -21228,7 +21228,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "post": {
         "description": "create an instance of payments. This will start a new payments session",
@@ -21376,7 +21376,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "post": {
         "description": "update an instance of payments with different phases of payment flows.",
@@ -21491,7 +21491,7 @@
           "average_wait_time"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of a queue identified by the QueueSid",
@@ -21672,7 +21672,7 @@
           "average_wait_time"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of queues belonging to the account used to make the request",
@@ -21837,7 +21837,7 @@
           "duration"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of a recording",
@@ -21957,7 +21957,7 @@
           "duration"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of recordings belonging to the account used to make the request",
@@ -22117,7 +22117,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Recordings.json"
+        "parent": "/Accounts/{AccountSid}/Recordings/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of an AddOnResult",
@@ -22252,7 +22252,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Recordings.json"
+        "parent": "/Accounts/{AccountSid}/Recordings/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of results belonging to the recording",
@@ -22366,7 +22366,7 @@
           "content_type"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Recordings/{ReferenceSid}/AddOnResults.json"
+        "parent": "/Accounts/{AccountSid}/Recordings/{ReferenceSid}/AddOnResults/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of a result payload",
@@ -22524,7 +22524,7 @@
           "content_type"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Recordings/{ReferenceSid}/AddOnResults.json"
+        "parent": "/Accounts/{AccountSid}/Recordings/{ReferenceSid}/AddOnResults/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of payloads belonging to the AddOnResult",
@@ -22651,7 +22651,7 @@
           "duration"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Recordings.json"
+        "parent": "/Accounts/{AccountSid}/Recordings/{Sid}.json"
       },
       "get": {
         "description": "",
@@ -22786,7 +22786,7 @@
           "duration"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Recordings.json"
+        "parent": "/Accounts/{AccountSid}/Recordings/{Sid}.json"
       },
       "get": {
         "description": "",
@@ -22900,7 +22900,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of a short code",
@@ -23073,7 +23073,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of short-codes belonging to the account used to make the request",
@@ -23190,7 +23190,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "",
@@ -23362,7 +23362,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/SIP/Domains/{DomainSid}/Auth.json": {
@@ -23375,7 +23375,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/SIP/Domains.json",
+        "parent": "/Accounts/{AccountSid}/SIP/Domains/{Sid}.json",
         "className": "auth_types"
       }
     },
@@ -24381,7 +24381,7 @@
           "credential_list_sid"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/SIP/CredentialLists.json"
+        "parent": "/Accounts/{AccountSid}/SIP/CredentialLists/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of credentials.",
@@ -24569,7 +24569,7 @@
           "credential_list_sid"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/SIP/CredentialLists.json"
+        "parent": "/Accounts/{AccountSid}/SIP/CredentialLists/{Sid}.json"
       },
       "get": {
         "description": "Fetch a single credential.",
@@ -25116,7 +25116,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/SIP/Domains.json"
+        "parent": "/Accounts/{AccountSid}/SIP/Domains/{Sid}.json"
       },
       "post": {
         "description": "Create a CredentialListMapping resource for an account.",
@@ -25301,7 +25301,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/SIP/Domains.json"
+        "parent": "/Accounts/{AccountSid}/SIP/Domains/{Sid}.json"
       },
       "get": {
         "description": "Fetch a single CredentialListMapping resource from an account.",
@@ -26273,7 +26273,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/SIP/Domains.json"
+        "parent": "/Accounts/{AccountSid}/SIP/Domains/{Sid}.json"
       },
       "get": {
         "description": "Fetch an IpAccessControlListMapping resource.",
@@ -26406,7 +26406,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/SIP/Domains.json"
+        "parent": "/Accounts/{AccountSid}/SIP/Domains/{Sid}.json"
       },
       "post": {
         "description": "Create a new IpAccessControlListMapping resource.",
@@ -26592,7 +26592,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/SIP/IpAccessControlLists.json"
+        "parent": "/Accounts/{AccountSid}/SIP/IpAccessControlLists/{Sid}.json"
       },
       "get": {
         "description": "Read multiple IpAddress resources.",
@@ -26784,7 +26784,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/SIP/IpAccessControlLists.json"
+        "parent": "/Accounts/{AccountSid}/SIP/IpAccessControlLists/{Sid}.json"
       },
       "get": {
         "description": "Read one IpAddress resource.",
@@ -27003,7 +27003,7 @@
           "name"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "post": {
         "description": "Create a Siprec",
@@ -27904,7 +27904,7 @@
           "name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "post": {
         "description": "Stop a Siprec using either the SID of the Siprec resource or the `name` used when creating the resource",
@@ -27999,7 +27999,7 @@
           "name"
         ],
         "pathType": "list",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "post": {
         "description": "Create a Stream",
@@ -28904,7 +28904,7 @@
           "name"
         ],
         "pathType": "instance",
-        "parent": "/Accounts/{AccountSid}/Calls.json"
+        "parent": "/Accounts/{AccountSid}/Calls/{Sid}.json"
       },
       "post": {
         "description": "Stop a Stream using either the SID of the Stream resource or the `name` used when creating the resource",
@@ -28999,7 +28999,7 @@
           "ice_servers"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "post": {
         "description": "Create a new token for ICE servers",
@@ -29071,7 +29071,7 @@
           "duration"
         ],
         "pathType": "instance",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Fetch an instance of a Transcription",
@@ -29182,7 +29182,7 @@
           "duration"
         ],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       },
       "get": {
         "description": "Retrieve a list of transcriptions belonging to the account used to make the request",
@@ -29280,7 +29280,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Accounts.json"
+        "parent": "/Accounts/{Sid}.json"
       }
     },
     "/2010-04-01/Accounts/{AccountSid}/Usage/Records.json": {

--- a/spec/json/twilio_autopilot_v1.json
+++ b/spec/json/twilio_autopilot_v1.json
@@ -1281,7 +1281,7 @@
           "data"
         ],
         "pathType": "instance",
-        "parent": "/Assistants",
+        "parent": "/Assistants/{Sid}",
         "className": "defaults"
       },
       "get": {
@@ -1383,7 +1383,7 @@
           "data"
         ],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -1443,7 +1443,7 @@
           "data"
         ],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       }
     },
     "/v1/Assistants/{AssistantSid}/Tasks/{TaskSid}/Fields/{Sid}": {
@@ -1460,7 +1460,7 @@
           "field_type"
         ],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/Tasks"
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -1576,7 +1576,7 @@
           "field_type"
         ],
         "pathType": "list",
-        "parent": "/Assistants/{AssistantSid}/Tasks"
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -1754,7 +1754,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -1916,7 +1916,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -2075,7 +2075,7 @@
           "language"
         ],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/FieldTypes"
+        "parent": "/Assistants/{AssistantSid}/FieldTypes/{Sid}"
       },
       "get": {
         "description": "",
@@ -2191,7 +2191,7 @@
           "language"
         ],
         "pathType": "list",
-        "parent": "/Assistants/{AssistantSid}/FieldTypes"
+        "parent": "/Assistants/{AssistantSid}/FieldTypes/{Sid}"
       },
       "get": {
         "description": "",
@@ -2382,7 +2382,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -2541,7 +2541,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -2699,7 +2699,7 @@
           "language"
         ],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -2865,7 +2865,7 @@
           "language"
         ],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -3130,7 +3130,7 @@
           "source_channel"
         ],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/Tasks"
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -3333,7 +3333,7 @@
           "source_channel"
         ],
         "pathType": "list",
-        "parent": "/Assistants/{AssistantSid}/Tasks"
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -3521,7 +3521,7 @@
           "data"
         ],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "Returns Style sheet JSON object for the Assistant",
@@ -3623,7 +3623,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -3793,7 +3793,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -3958,7 +3958,7 @@
           "data"
         ],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/Tasks",
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}",
         "mountName": "task_actions",
         "className": "task_actions"
       },
@@ -4079,7 +4079,7 @@
           "fields_count"
         ],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/Tasks",
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}",
         "className": "task_statistics"
       },
       "get": {
@@ -4143,7 +4143,7 @@
           "webhook_method"
         ],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -4316,7 +4316,7 @@
           "webhook_method"
         ],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",

--- a/spec/json/twilio_bulkexports_v1.json
+++ b/spec/json/twilio_bulkexports_v1.json
@@ -292,7 +292,7 @@
           "redirectTo"
         ],
         "pathType": "instance",
-        "parent": "/Exports"
+        "parent": "/Exports/{ResourceType}"
       },
       "get": {
         "description": "Fetch a specific Day.",
@@ -356,7 +356,7 @@
           "redirectTo"
         ],
         "pathType": "list",
-        "parent": "/Exports"
+        "parent": "/Exports/{ResourceType}"
       },
       "get": {
         "description": "Retrieve a list of all Days for a resource.",
@@ -638,7 +638,7 @@
           "webhook_url"
         ],
         "pathType": "list",
-        "parent": "/Exports",
+        "parent": "/Exports/{ResourceType}",
         "mountName": "export_custom_jobs"
       },
       "get": {

--- a/spec/json/twilio_chat_v1.json
+++ b/spec/json/twilio_chat_v1.json
@@ -806,7 +806,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -981,7 +981,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -1482,7 +1482,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -1610,7 +1610,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -1807,7 +1807,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2018,7 +2018,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -2216,7 +2216,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2433,7 +2433,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -2635,7 +2635,7 @@
           "type"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -2817,7 +2817,7 @@
           "type"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -3660,7 +3660,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -3838,7 +3838,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -4013,7 +4013,7 @@
           "status"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_channels"
       },
       "get": {

--- a/spec/json/twilio_chat_v2.json
+++ b/spec/json/twilio_chat_v2.json
@@ -1164,7 +1164,7 @@
           "identity"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -1291,7 +1291,7 @@
           "identity"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -1401,7 +1401,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -1608,7 +1608,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -1813,7 +1813,7 @@
           "configuration"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2026,7 +2026,7 @@
           "configuration"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2577,7 +2577,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2705,7 +2705,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -2902,7 +2902,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -3141,7 +3141,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -3372,7 +3372,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -3616,7 +3616,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -3839,7 +3839,7 @@
           "type"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -4021,7 +4021,7 @@
           "type"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -4613,7 +4613,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -4801,7 +4801,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -4987,7 +4987,7 @@
           "binding_type"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_bindings"
       },
       "get": {
@@ -5114,7 +5114,7 @@
           "binding_type"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_bindings"
       },
       "get": {
@@ -5242,7 +5242,7 @@
           "status"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_channels"
       },
       "get": {
@@ -5355,7 +5355,7 @@
           "status"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_channels"
       },
       "get": {

--- a/spec/json/twilio_conversations_v1.json
+++ b/spec/json/twilio_conversations_v1.json
@@ -3291,7 +3291,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Conversations"
+        "parent": "/Conversations/{Sid}"
       },
       "post": {
         "description": "Add a new message to the conversation",
@@ -3487,7 +3487,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Conversations"
+        "parent": "/Conversations/{Sid}"
       },
       "post": {
         "description": "Update an existing message in the conversation",
@@ -3691,7 +3691,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Conversations/{ConversationSid}/Messages",
+        "parent": "/Conversations/{ConversationSid}/Messages/{Sid}",
         "mountName": "delivery_receipts"
       },
       "get": {
@@ -3769,7 +3769,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Conversations/{ConversationSid}/Messages",
+        "parent": "/Conversations/{ConversationSid}/Messages/{Sid}",
         "mountName": "delivery_receipts"
       },
       "get": {
@@ -3882,7 +3882,7 @@
           "messaging_binding"
         ],
         "pathType": "list",
-        "parent": "/Conversations"
+        "parent": "/Conversations/{Sid}"
       },
       "post": {
         "description": "Add a new participant to the conversation",
@@ -4075,7 +4075,7 @@
           "messaging_binding"
         ],
         "pathType": "instance",
-        "parent": "/Conversations"
+        "parent": "/Conversations/{Sid}"
       },
       "post": {
         "description": "Update an existing participant in the conversation",
@@ -4288,7 +4288,7 @@
           "target"
         ],
         "pathType": "list",
-        "parent": "/Conversations"
+        "parent": "/Conversations/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all webhooks scoped to the conversation",
@@ -4477,7 +4477,7 @@
           "target"
         ],
         "pathType": "instance",
-        "parent": "/Conversations"
+        "parent": "/Conversations/{Sid}"
       },
       "get": {
         "description": "Fetch the configuration of a conversation-scoped webhook",
@@ -5610,7 +5610,7 @@
           "identity"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "delete": {
         "description": "Remove a push notification binding from the conversation service",
@@ -5720,7 +5720,7 @@
           "identity"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all push notification bindings in the conversation service",
@@ -5845,7 +5845,7 @@
           "chat_service_sid"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Fetch the configuration of a conversation service",
@@ -5976,7 +5976,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Create a new conversation in your service",
@@ -6182,7 +6182,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Update an existing conversation in your service",
@@ -6406,7 +6406,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ChatServiceSid}/Conversations"
+        "parent": "/Services/{ChatServiceSid}/Conversations/{Sid}"
       },
       "post": {
         "description": "Add a new message to the conversation in a specific service",
@@ -6626,7 +6626,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ChatServiceSid}/Conversations"
+        "parent": "/Services/{ChatServiceSid}/Conversations/{Sid}"
       },
       "post": {
         "description": "Update an existing message in the conversation",
@@ -6866,7 +6866,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ChatServiceSid}/Conversations/{ConversationSid}/Messages",
+        "parent": "/Services/{ChatServiceSid}/Conversations/{ConversationSid}/Messages/{Sid}",
         "mountName": "delivery_receipts"
       },
       "get": {
@@ -6956,7 +6956,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ChatServiceSid}/Conversations/{ConversationSid}/Messages",
+        "parent": "/Services/{ChatServiceSid}/Conversations/{ConversationSid}/Messages/{Sid}",
         "mountName": "delivery_receipts"
       },
       "get": {
@@ -7081,7 +7081,7 @@
           "messaging_binding"
         ],
         "pathType": "list",
-        "parent": "/Services/{ChatServiceSid}/Conversations"
+        "parent": "/Services/{ChatServiceSid}/Conversations/{Sid}"
       },
       "post": {
         "description": "Add a new participant to the conversation in a specific service",
@@ -7298,7 +7298,7 @@
           "messaging_binding"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ChatServiceSid}/Conversations"
+        "parent": "/Services/{ChatServiceSid}/Conversations/{Sid}"
       },
       "post": {
         "description": "Update an existing participant in the conversation",
@@ -7547,7 +7547,7 @@
           "target"
         ],
         "pathType": "list",
-        "parent": "/Services/{ChatServiceSid}/Conversations"
+        "parent": "/Services/{ChatServiceSid}/Conversations/{Sid}"
       },
       "post": {
         "description": "Create a new webhook scoped to the conversation in a specific service",
@@ -7760,7 +7760,7 @@
           "target"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ChatServiceSid}/Conversations"
+        "parent": "/Services/{ChatServiceSid}/Conversations/{Sid}"
       },
       "post": {
         "description": "Update an existing conversation-scoped webhook",
@@ -8144,7 +8144,7 @@
           "conversation_sid"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Conversations that this Participant belongs to by identity or by address. Only one parameter should be specified.",
@@ -8264,7 +8264,7 @@
           "type"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Create a new user role in your service",
@@ -8439,7 +8439,7 @@
           "type"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Update an existing user role in your service",
@@ -8620,7 +8620,7 @@
           "identity"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Add a new conversation user to your service",
@@ -8804,7 +8804,7 @@
           "identity"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Update an existing conversation user in your service",
@@ -9002,7 +9002,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ChatServiceSid}/Users",
+        "parent": "/Services/{ChatServiceSid}/Users/{Sid}",
         "mountName": "user_conversations"
       },
       "post": {
@@ -9210,7 +9210,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ChatServiceSid}/Users",
+        "parent": "/Services/{ChatServiceSid}/Users/{Sid}",
         "mountName": "user_conversations"
       },
       "get": {
@@ -9767,7 +9767,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Users",
+        "parent": "/Users/{Sid}",
         "mountName": "user_conversations"
       },
       "post": {
@@ -9939,7 +9939,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Users",
+        "parent": "/Users/{Sid}",
         "mountName": "user_conversations"
       },
       "get": {

--- a/spec/json/twilio_events_v1.json
+++ b/spec/json/twilio_events_v1.json
@@ -553,7 +553,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Schemas",
+        "parent": "/Schemas/{Id}",
         "className": "schema_version"
       },
       "get": {
@@ -655,7 +655,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Schemas",
+        "parent": "/Schemas/{Id}",
         "className": "schema_version"
       },
       "get": {
@@ -1025,7 +1025,7 @@
           "result"
         ],
         "pathType": "list",
-        "parent": "/Sinks",
+        "parent": "/Sinks/{Sid}",
         "mountName": "sink_test"
       },
       "post": {
@@ -1079,7 +1079,7 @@
           "result"
         ],
         "pathType": "list",
-        "parent": "/Sinks",
+        "parent": "/Sinks/{Sid}",
         "mountName": "sink_validate"
       },
       "post": {
@@ -1155,7 +1155,7 @@
           "subscription_sid"
         ],
         "pathType": "list",
-        "parent": "/Subscriptions"
+        "parent": "/Subscriptions/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Subscribed Event types for a Subscription.",
@@ -1321,7 +1321,7 @@
           "subscription_sid"
         ],
         "pathType": "instance",
-        "parent": "/Subscriptions"
+        "parent": "/Subscriptions/{Sid}"
       },
       "get": {
         "description": "Read an Event for a Subscription.",

--- a/spec/json/twilio_flex_v1.json
+++ b/spec/json/twilio_flex_v1.json
@@ -1626,7 +1626,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/Interactions",
+        "parent": "/Interactions/{Sid}",
         "className": "interaction_channel"
       },
       "get": {
@@ -1765,7 +1765,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/Interactions",
+        "parent": "/Interactions/{Sid}",
         "className": "interaction_channel"
       },
       "get": {
@@ -1868,7 +1868,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/Interactions/{InteractionSid}/Channels",
+        "parent": "/Interactions/{InteractionSid}/Channels/{Sid}",
         "className": "interaction_channel_invite"
       },
       "post": {
@@ -2051,7 +2051,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/Interactions/{InteractionSid}/Channels",
+        "parent": "/Interactions/{InteractionSid}/Channels/{Sid}",
         "className": "interaction_channel_participant"
       },
       "post": {
@@ -2240,7 +2240,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/Interactions/{InteractionSid}/Channels",
+        "parent": "/Interactions/{InteractionSid}/Channels/{Sid}",
         "className": "interaction_channel_participant"
       },
       "post": {

--- a/spec/json/twilio_insights_v1.json
+++ b/spec/json/twilio_insights_v1.json
@@ -2178,7 +2178,7 @@
           "account_sid"
         ],
         "pathType": "instance",
-        "parent": "/Conferences",
+        "parent": "/Conferences/{ConferenceSid}",
         "mountName": "conference_participants"
       },
       "get": {
@@ -2263,7 +2263,7 @@
           "account_sid"
         ],
         "pathType": "list",
-        "parent": "/Conferences",
+        "parent": "/Conferences/{ConferenceSid}",
         "mountName": "conference_participants"
       },
       "get": {
@@ -2695,7 +2695,7 @@
           "participant_sid"
         ],
         "pathType": "instance",
-        "parent": "/Video/Rooms"
+        "parent": "/Video/Rooms/{RoomSid}"
       },
       "get": {
         "description": "Get Video Log Analyzer data for a Room Participant.",
@@ -2754,7 +2754,7 @@
           "participant_sid"
         ],
         "pathType": "list",
-        "parent": "/Video/Rooms"
+        "parent": "/Video/Rooms/{RoomSid}"
       },
       "get": {
         "description": "Get a list of room participants.",

--- a/spec/json/twilio_ip_messaging_v1.json
+++ b/spec/json/twilio_ip_messaging_v1.json
@@ -698,7 +698,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -873,7 +873,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -1374,7 +1374,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -1502,7 +1502,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -1699,7 +1699,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -1910,7 +1910,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -2108,7 +2108,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2325,7 +2325,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -2527,7 +2527,7 @@
           "type"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -2709,7 +2709,7 @@
           "type"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -3552,7 +3552,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -3730,7 +3730,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -3905,7 +3905,7 @@
           "status"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_channels"
       },
       "get": {

--- a/spec/json/twilio_ip_messaging_v2.json
+++ b/spec/json/twilio_ip_messaging_v2.json
@@ -1007,7 +1007,7 @@
           "identity"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -1134,7 +1134,7 @@
           "identity"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -1244,7 +1244,7 @@
           "friendly_name"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -1451,7 +1451,7 @@
           "friendly_name"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -1656,7 +1656,7 @@
           "configuration"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -1869,7 +1869,7 @@
           "configuration"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2420,7 +2420,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2548,7 +2548,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -2745,7 +2745,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -2984,7 +2984,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -3215,7 +3215,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "get": {
         "description": "",
@@ -3459,7 +3459,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Channels"
+        "parent": "/Services/{ServiceSid}/Channels/{Sid}"
       },
       "post": {
         "description": "",
@@ -3682,7 +3682,7 @@
           "type"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -3864,7 +3864,7 @@
           "type"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -4456,7 +4456,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -4644,7 +4644,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -4830,7 +4830,7 @@
           "binding_type"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_bindings"
       },
       "get": {
@@ -4957,7 +4957,7 @@
           "binding_type"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_bindings"
       },
       "get": {
@@ -5085,7 +5085,7 @@
           "status"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_channels"
       },
       "get": {
@@ -5198,7 +5198,7 @@
           "status"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Users",
+        "parent": "/Services/{ServiceSid}/Users/{Sid}",
         "mountName": "user_channels"
       },
       "get": {

--- a/spec/json/twilio_media_v1.json
+++ b/spec/json/twilio_media_v1.json
@@ -1226,7 +1226,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/PlayerStreamers"
+        "parent": "/PlayerStreamers/{Sid}"
       },
       "post": {
         "description": "",

--- a/spec/json/twilio_messaging_v1.json
+++ b/spec/json/twilio_messaging_v1.json
@@ -1007,7 +1007,7 @@
           "alpha_sender"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -1167,7 +1167,7 @@
           "alpha_sender"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -1522,7 +1522,7 @@
           "vetting_class"
         ],
         "pathType": "list",
-        "parent": "/a2p/BrandRegistrations",
+        "parent": "/a2p/BrandRegistrations/{Sid}",
         "mountName": "brand_vettings"
       },
       "post": {
@@ -1702,7 +1702,7 @@
           "vetting_class"
         ],
         "pathType": "instance",
-        "parent": "/a2p/BrandRegistrations",
+        "parent": "/a2p/BrandRegistrations/{Sid}",
         "mountName": "brand_vettings"
       },
       "get": {
@@ -1887,7 +1887,7 @@
           "country_code"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -2051,7 +2051,7 @@
           "country_code"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "delete": {
         "description": "",
@@ -2592,7 +2592,7 @@
           "country_code"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -2756,7 +2756,7 @@
           "country_code"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "delete": {
         "description": "",
@@ -3175,7 +3175,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "us_app_to_person"
       },
       "post": {
@@ -3368,7 +3368,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "us_app_to_person"
       },
       "delete": {
@@ -3477,7 +3477,7 @@
           "us_app_to_person_usecases"
         ],
         "pathType": "list",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "us_app_to_person_usecases"
       },
       "get": {

--- a/spec/json/twilio_notify_v1.json
+++ b/spec/json/twilio_notify_v1.json
@@ -462,7 +462,7 @@
           "address"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -574,7 +574,7 @@
           "address"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -1126,7 +1126,7 @@
           "title"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",

--- a/spec/json/twilio_numbers_v2.json
+++ b/spec/json/twilio_numbers_v2.json
@@ -1120,7 +1120,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/RegulatoryCompliance/Bundles",
+        "parent": "/RegulatoryCompliance/Bundles/{Sid}",
         "mountName": "bundle_copies"
       },
       "post": {
@@ -1704,7 +1704,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/RegulatoryCompliance/Bundles"
+        "parent": "/RegulatoryCompliance/Bundles/{Sid}"
       },
       "post": {
         "description": "Creates an evaluation for a bundle",
@@ -1844,7 +1844,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/RegulatoryCompliance/Bundles"
+        "parent": "/RegulatoryCompliance/Bundles/{Sid}"
       },
       "get": {
         "description": "Fetch specific Evaluation Instance.",
@@ -1909,7 +1909,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/RegulatoryCompliance/Bundles"
+        "parent": "/RegulatoryCompliance/Bundles/{Sid}"
       },
       "post": {
         "description": "Create a new Assigned Item.",
@@ -2071,7 +2071,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/RegulatoryCompliance/Bundles"
+        "parent": "/RegulatoryCompliance/Bundles/{Sid}"
       },
       "get": {
         "description": "Fetch specific Assigned Item Instance.",
@@ -2359,7 +2359,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/RegulatoryCompliance/Bundles",
+        "parent": "/RegulatoryCompliance/Bundles/{Sid}",
         "className": "replace_items"
       },
       "post": {

--- a/spec/json/twilio_preview.json
+++ b/spec/json/twilio_preview.json
@@ -2868,7 +2868,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Fleets"
+        "parent": "/Fleets/{Sid}"
       },
       "get": {
         "description": "Fetch information about a specific Certificate credential in the Fleet.",
@@ -3038,7 +3038,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Fleets"
+        "parent": "/Fleets/{Sid}"
       },
       "post": {
         "description": "Enroll a new Certificate credential to the Fleet, optionally giving it a friendly name and assigning to a Device.",
@@ -3211,7 +3211,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Fleets"
+        "parent": "/Fleets/{Sid}"
       },
       "get": {
         "description": "Fetch information about a specific Deployment in the Fleet.",
@@ -3381,7 +3381,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Fleets"
+        "parent": "/Fleets/{Sid}"
       },
       "post": {
         "description": "Create a new Deployment in the Fleet, optionally giving it a friendly name and linking to a specific Twilio Sync service instance.",
@@ -3536,7 +3536,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Fleets"
+        "parent": "/Fleets/{Sid}"
       },
       "get": {
         "description": "Fetch information about a specific Device in the Fleet.",
@@ -3705,7 +3705,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Fleets"
+        "parent": "/Fleets/{Sid}"
       },
       "post": {
         "description": "Create a new Device in the Fleet, optionally giving it a unique name, friendly name, and assigning to a Deployment and/or human identity.",
@@ -4143,7 +4143,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Fleets"
+        "parent": "/Fleets/{Sid}"
       },
       "get": {
         "description": "Fetch information about a specific Key credential in the Fleet.",
@@ -4313,7 +4313,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Fleets"
+        "parent": "/Fleets/{Sid}"
       },
       "post": {
         "description": "Create a new Key credential in the Fleet, optionally giving it a friendly name and assigning to a Device.",
@@ -4797,7 +4797,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/AuthorizationDocuments"
+        "parent": "/AuthorizationDocuments/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of dependent HostedNumberOrders belonging to the AuthorizationDocument.",
@@ -5545,7 +5545,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/AvailableAddOns",
+        "parent": "/AvailableAddOns/{Sid}",
         "className": "available_add_on_extension"
       },
       "get": {
@@ -5609,7 +5609,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/AvailableAddOns",
+        "parent": "/AvailableAddOns/{Sid}",
         "className": "available_add_on_extension"
       },
       "get": {
@@ -5993,7 +5993,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/InstalledAddOns",
+        "parent": "/InstalledAddOns/{Sid}",
         "className": "installed_add_on_extension"
       },
       "get": {
@@ -6126,7 +6126,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/InstalledAddOns",
+        "parent": "/InstalledAddOns/{Sid}",
         "className": "installed_add_on_extension"
       },
       "get": {
@@ -6227,7 +6227,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -6400,7 +6400,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -6557,7 +6557,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Documents",
+        "parent": "/Services/{ServiceSid}/Documents/{Sid}",
         "mountName": "document_permissions"
       },
       "get": {
@@ -6761,7 +6761,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Documents",
+        "parent": "/Services/{ServiceSid}/Documents/{Sid}",
         "mountName": "document_permissions"
       },
       "get": {
@@ -7159,7 +7159,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_lists"
       },
       "get": {
@@ -7260,7 +7260,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_lists"
       },
       "post": {
@@ -7415,7 +7415,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Lists",
+        "parent": "/Services/{ServiceSid}/Lists/{Sid}",
         "mountName": "sync_list_items"
       },
       "get": {
@@ -7624,7 +7624,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Lists",
+        "parent": "/Services/{ServiceSid}/Lists/{Sid}",
         "mountName": "sync_list_items"
       },
       "post": {
@@ -7825,7 +7825,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Lists",
+        "parent": "/Services/{ServiceSid}/Lists/{Sid}",
         "mountName": "sync_list_permissions"
       },
       "get": {
@@ -8029,7 +8029,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Lists",
+        "parent": "/Services/{ServiceSid}/Lists/{Sid}",
         "mountName": "sync_list_permissions"
       },
       "get": {
@@ -8139,7 +8139,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_maps"
       },
       "get": {
@@ -8240,7 +8240,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_maps"
       },
       "post": {
@@ -8395,7 +8395,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Maps",
+        "parent": "/Services/{ServiceSid}/Maps/{Sid}",
         "mountName": "sync_map_items"
       },
       "get": {
@@ -8604,7 +8604,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Maps",
+        "parent": "/Services/{ServiceSid}/Maps/{Sid}",
         "mountName": "sync_map_items"
       },
       "post": {
@@ -8810,7 +8810,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Maps",
+        "parent": "/Services/{ServiceSid}/Maps/{Sid}",
         "mountName": "sync_map_permissions"
       },
       "get": {
@@ -9014,7 +9014,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Maps",
+        "parent": "/Services/{ServiceSid}/Maps/{Sid}",
         "mountName": "sync_map_permissions"
       },
       "get": {
@@ -9429,7 +9429,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants",
+        "parent": "/Assistants/{Sid}",
         "mountName": "assistant_fallback_actions",
         "className": "assistant_fallback_actions"
       },
@@ -9529,7 +9529,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants",
+        "parent": "/Assistants/{Sid}",
         "mountName": "assistant_initiation_actions",
         "className": "assistant_initiation_actions"
       },
@@ -9629,7 +9629,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -9686,7 +9686,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       }
     },
     "/understand/Assistants/{AssistantSid}/Tasks/{TaskSid}/Fields/{Sid}": {
@@ -9699,7 +9699,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/Tasks"
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -9811,7 +9811,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Assistants/{AssistantSid}/Tasks"
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -9985,7 +9985,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -10143,7 +10143,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -10298,7 +10298,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/FieldTypes"
+        "parent": "/Assistants/{AssistantSid}/FieldTypes/{Sid}"
       },
       "get": {
         "description": "",
@@ -10410,7 +10410,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Assistants/{AssistantSid}/FieldTypes"
+        "parent": "/Assistants/{AssistantSid}/FieldTypes/{Sid}"
       },
       "get": {
         "description": "",
@@ -10596,7 +10596,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -10750,7 +10750,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -10903,7 +10903,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -11064,7 +11064,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -11256,7 +11256,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/Tasks"
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -11454,7 +11454,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Assistants/{AssistantSid}/Tasks"
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -11640,7 +11640,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "Returns Style sheet JSON object for this Assistant",
@@ -11738,7 +11738,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -11904,7 +11904,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Assistants"
+        "parent": "/Assistants/{Sid}"
       },
       "get": {
         "description": "",
@@ -12067,7 +12067,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/Tasks",
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}",
         "mountName": "task_actions",
         "className": "task_actions"
       },
@@ -12185,7 +12185,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Assistants/{AssistantSid}/Tasks",
+        "parent": "/Assistants/{AssistantSid}/Tasks/{Sid}",
         "className": "task_statistics"
       },
       "get": {
@@ -13112,7 +13112,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Sims"
+        "parent": "/Sims/{Sid}"
       },
       "get": {
         "description": "",
@@ -13311,7 +13311,7 @@
           "url"
         ],
         "pathType": "list",
-        "parent": "/BrandedChannels"
+        "parent": "/BrandedChannels/{Sid}"
       },
       "post": {
         "description": "Associate a channel to a branded channel",

--- a/spec/json/twilio_proxy_v1.json
+++ b/spec/json/twilio_proxy_v1.json
@@ -876,7 +876,7 @@
           "data"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Sessions"
+        "parent": "/Services/{ServiceSid}/Sessions/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of Interactions for a given [Session](https://www.twilio.com/docs/proxy/api/session).",
@@ -1010,7 +1010,7 @@
           "data"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Sessions"
+        "parent": "/Services/{ServiceSid}/Sessions/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Interactions for a Session. A maximum of 100 records will be returned per page.",
@@ -1126,7 +1126,7 @@
           "data"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Sessions/{SessionSid}/Participants"
+        "parent": "/Services/{ServiceSid}/Sessions/{SessionSid}/Participants/{Sid}"
       },
       "post": {
         "description": "Create a new message Interaction to send directly from your system to one [Participant](https://www.twilio.com/docs/proxy/api/participant).  The `inbound` properties for the Interaction will always be empty.",
@@ -1348,7 +1348,7 @@
           "data"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Sessions/{SessionSid}/Participants"
+        "parent": "/Services/{ServiceSid}/Sessions/{SessionSid}/Participants/{Sid}"
       },
       "get": {
         "description": "",
@@ -1440,7 +1440,7 @@
           "proxy_identifier"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Sessions"
+        "parent": "/Services/{ServiceSid}/Sessions/{Sid}"
       },
       "get": {
         "description": "Fetch a specific Participant.",
@@ -1575,7 +1575,7 @@
           "proxy_identifier"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Sessions"
+        "parent": "/Services/{ServiceSid}/Sessions/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Participants in a Session.",
@@ -1779,7 +1779,7 @@
           "phone_number"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Add a Phone Number to a Service's Proxy Number Pool.",
@@ -1949,7 +1949,7 @@
           "phone_number"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "delete": {
         "description": "Delete a specific Phone Number from a Service.",
@@ -2468,7 +2468,7 @@
           "date_ended"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Fetch a specific Session.",
@@ -2656,7 +2656,7 @@
           "date_ended"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Sessions for the Service. A maximum of 100 records will be returned per page.",
@@ -2842,7 +2842,7 @@
           "iso_country"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Add a Short Code to the Proxy Number Pool for the Service.",
@@ -3006,7 +3006,7 @@
           "iso_country"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "delete": {
         "description": "Delete a specific Short Code from a Service.",

--- a/spec/json/twilio_serverless_v1.json
+++ b/spec/json/twilio_serverless_v1.json
@@ -866,7 +866,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Assets.",
@@ -1021,7 +1021,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a specific Asset resource.",
@@ -1192,7 +1192,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Assets",
+        "parent": "/Services/{ServiceSid}/Assets/{Sid}",
         "mountName": "asset_versions"
       },
       "get": {
@@ -1307,7 +1307,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Assets",
+        "parent": "/Services/{ServiceSid}/Assets/{Sid}",
         "mountName": "asset_versions"
       },
       "get": {
@@ -1384,7 +1384,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Builds.",
@@ -1560,7 +1560,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a specific Build resource.",
@@ -1663,7 +1663,7 @@
           "status"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Builds",
+        "parent": "/Services/{ServiceSid}/Builds/{Sid}",
         "mountName": "build_status"
       },
       "get": {
@@ -1728,7 +1728,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Environments"
+        "parent": "/Services/{ServiceSid}/Environments/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Deployments.",
@@ -1907,7 +1907,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Environments"
+        "parent": "/Services/{ServiceSid}/Environments/{Sid}"
       },
       "get": {
         "description": "Retrieve a specific Deployment.",
@@ -1984,7 +1984,7 @@
           "build_sid"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all environments.",
@@ -2144,7 +2144,7 @@
           "build_sid"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a specific environment.",
@@ -2248,7 +2248,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Functions.",
@@ -2403,7 +2403,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Retrieve a specific Function resource.",
@@ -2574,7 +2574,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Functions",
+        "parent": "/Services/{ServiceSid}/Functions/{Sid}",
         "mountName": "function_versions"
       },
       "get": {
@@ -2689,7 +2689,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Functions",
+        "parent": "/Services/{ServiceSid}/Functions/{Sid}",
         "mountName": "function_versions"
       },
       "get": {
@@ -2765,7 +2765,7 @@
           "content"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Functions/{FunctionSid}/Versions",
+        "parent": "/Services/{ServiceSid}/Functions/{FunctionSid}/Versions/{Sid}",
         "mountName": "function_version_content"
       },
       "get": {
@@ -2838,7 +2838,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Environments"
+        "parent": "/Services/{ServiceSid}/Environments/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all logs.",
@@ -2976,7 +2976,7 @@
       "x-twilio": {
         "defaultOutputProperties": [],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Environments"
+        "parent": "/Services/{ServiceSid}/Environments/{Sid}"
       },
       "get": {
         "description": "Retrieve a specific log.",
@@ -3337,7 +3337,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Environments"
+        "parent": "/Services/{ServiceSid}/Environments/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Variables.",
@@ -3521,7 +3521,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Environments"
+        "parent": "/Services/{ServiceSid}/Environments/{Sid}"
       },
       "get": {
         "description": "Retrieve a specific Variable.",

--- a/spec/json/twilio_studio_v1.json
+++ b/spec/json/twilio_studio_v1.json
@@ -607,7 +607,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Flows"
+        "parent": "/Flows/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Engagements for the Flow.",
@@ -779,7 +779,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Flows"
+        "parent": "/Flows/{Sid}"
       },
       "get": {
         "description": "Retrieve an Engagement",
@@ -887,7 +887,7 @@
           "context"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Engagements",
+        "parent": "/Flows/{FlowSid}/Engagements/{Sid}",
         "mountName": "engagement_context"
       },
       "get": {
@@ -956,7 +956,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Flows"
+        "parent": "/Flows/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Executions for the Flow.",
@@ -1146,7 +1146,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Flows"
+        "parent": "/Flows/{Sid}"
       },
       "get": {
         "description": "Retrieve an Execution",
@@ -1324,7 +1324,7 @@
           "context"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Executions",
+        "parent": "/Flows/{FlowSid}/Executions/{Sid}",
         "mountName": "execution_context"
       },
       "get": {
@@ -1392,7 +1392,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Flows/{FlowSid}/Executions",
+        "parent": "/Flows/{FlowSid}/Executions/{Sid}",
         "className": "execution_step"
       },
       "get": {
@@ -1509,7 +1509,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Executions",
+        "parent": "/Flows/{FlowSid}/Executions/{Sid}",
         "className": "execution_step"
       },
       "get": {
@@ -1587,7 +1587,7 @@
           "context"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Executions/{ExecutionSid}/Steps",
+        "parent": "/Flows/{FlowSid}/Executions/{ExecutionSid}/Steps/{Sid}",
         "mountName": "step_context",
         "className": "execution_step_context"
       },
@@ -1847,7 +1847,7 @@
           "transitioned_to"
         ],
         "pathType": "list",
-        "parent": "/Flows/{FlowSid}/Engagements"
+        "parent": "/Flows/{FlowSid}/Engagements/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Steps for an Engagement.",
@@ -1964,7 +1964,7 @@
           "transitioned_to"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Engagements"
+        "parent": "/Flows/{FlowSid}/Engagements/{Sid}"
       },
       "get": {
         "description": "Retrieve a Step.",
@@ -2041,7 +2041,7 @@
           "context"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Engagements/{EngagementSid}/Steps",
+        "parent": "/Flows/{FlowSid}/Engagements/{EngagementSid}/Steps/{Sid}",
         "mountName": "step_context"
       },
       "get": {

--- a/spec/json/twilio_studio_v2.json
+++ b/spec/json/twilio_studio_v2.json
@@ -506,7 +506,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Flows"
+        "parent": "/Flows/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of all Executions for the Flow.",
@@ -695,7 +695,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Flows"
+        "parent": "/Flows/{Sid}"
       },
       "get": {
         "description": "Retrieve an Execution",
@@ -873,7 +873,7 @@
           "context"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Executions",
+        "parent": "/Flows/{FlowSid}/Executions/{Sid}",
         "mountName": "execution_context"
       },
       "get": {
@@ -941,7 +941,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Flows/{FlowSid}/Executions",
+        "parent": "/Flows/{FlowSid}/Executions/{Sid}",
         "className": "execution_step"
       },
       "get": {
@@ -1058,7 +1058,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Executions",
+        "parent": "/Flows/{FlowSid}/Executions/{Sid}",
         "className": "execution_step"
       },
       "get": {
@@ -1136,7 +1136,7 @@
           "context"
         ],
         "pathType": "instance",
-        "parent": "/Flows/{FlowSid}/Executions/{ExecutionSid}/Steps",
+        "parent": "/Flows/{FlowSid}/Executions/{ExecutionSid}/Steps/{Sid}",
         "mountName": "step_context",
         "className": "execution_step_context"
       },
@@ -1522,7 +1522,7 @@
           "revision"
         ],
         "pathType": "list",
-        "parent": "/Flows",
+        "parent": "/Flows/{Sid}",
         "className": "flow_revision"
       },
       "get": {
@@ -1628,7 +1628,7 @@
           "revision"
         ],
         "pathType": "instance",
-        "parent": "/Flows",
+        "parent": "/Flows/{Sid}",
         "className": "flow_revision"
       },
       "get": {
@@ -1763,7 +1763,7 @@
           "test_users"
         ],
         "pathType": "instance",
-        "parent": "/Flows",
+        "parent": "/Flows/{Sid}",
         "className": "flow_test_user"
       },
       "get": {

--- a/spec/json/twilio_supersim_v1.json
+++ b/spec/json/twilio_supersim_v1.json
@@ -906,7 +906,7 @@
           "period_type"
         ],
         "pathType": "list",
-        "parent": "/Sims"
+        "parent": "/Sims/{Sid}"
       },
       "get": {
         "description": "Retrieve a list of Billing Periods for a Super SIM.",
@@ -2227,7 +2227,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/NetworkAccessProfiles",
+        "parent": "/NetworkAccessProfiles/{Sid}",
         "className": "network_access_profile_network"
       },
       "get": {
@@ -2384,7 +2384,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/NetworkAccessProfiles",
+        "parent": "/NetworkAccessProfiles/{Sid}",
         "className": "network_access_profile_network"
       },
       "delete": {
@@ -2898,7 +2898,7 @@
           "ip_address_version"
         ],
         "pathType": "list",
-        "parent": "/Sims",
+        "parent": "/Sims/{Sid}",
         "mountName": "sim_ip_addresses"
       },
       "get": {

--- a/spec/json/twilio_sync_v1.json
+++ b/spec/json/twilio_sync_v1.json
@@ -775,7 +775,7 @@
           "revision"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "",
@@ -944,7 +944,7 @@
           "revision"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",
@@ -1104,7 +1104,7 @@
           "manage"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Documents",
+        "parent": "/Services/{ServiceSid}/Documents/{Sid}",
         "mountName": "document_permissions"
       },
       "get": {
@@ -1304,7 +1304,7 @@
           "manage"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Documents",
+        "parent": "/Services/{ServiceSid}/Documents/{Sid}",
         "mountName": "document_permissions"
       },
       "get": {
@@ -1724,7 +1724,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Streams",
+        "parent": "/Services/{ServiceSid}/Streams/{Sid}",
         "mountName": "stream_messages"
       },
       "post": {
@@ -1804,7 +1804,7 @@
           "revision"
         ],
         "pathType": "instance",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_lists"
       },
       "get": {
@@ -1967,7 +1967,7 @@
           "revision"
         ],
         "pathType": "list",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_lists"
       },
       "post": {
@@ -2128,7 +2128,7 @@
           "created_by"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Lists",
+        "parent": "/Services/{ServiceSid}/Lists/{Sid}",
         "mountName": "sync_list_items"
       },
       "get": {
@@ -2341,7 +2341,7 @@
           "created_by"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Lists",
+        "parent": "/Services/{ServiceSid}/Lists/{Sid}",
         "mountName": "sync_list_items"
       },
       "post": {
@@ -2553,7 +2553,7 @@
           "manage"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Lists",
+        "parent": "/Services/{ServiceSid}/Lists/{Sid}",
         "mountName": "sync_list_permissions"
       },
       "get": {
@@ -2753,7 +2753,7 @@
           "manage"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Lists",
+        "parent": "/Services/{ServiceSid}/Lists/{Sid}",
         "mountName": "sync_list_permissions"
       },
       "get": {
@@ -2864,7 +2864,7 @@
           "revision"
         ],
         "pathType": "instance",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_maps"
       },
       "get": {
@@ -3027,7 +3027,7 @@
           "revision"
         ],
         "pathType": "list",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_maps"
       },
       "post": {
@@ -3188,7 +3188,7 @@
           "created_by"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Maps",
+        "parent": "/Services/{ServiceSid}/Maps/{Sid}",
         "mountName": "sync_map_items"
       },
       "get": {
@@ -3401,7 +3401,7 @@
           "created_by"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Maps",
+        "parent": "/Services/{ServiceSid}/Maps/{Sid}",
         "mountName": "sync_map_items"
       },
       "post": {
@@ -3618,7 +3618,7 @@
           "manage"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Maps",
+        "parent": "/Services/{ServiceSid}/Maps/{Sid}",
         "mountName": "sync_map_permissions"
       },
       "get": {
@@ -3818,7 +3818,7 @@
           "manage"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Maps",
+        "parent": "/Services/{ServiceSid}/Maps/{Sid}",
         "mountName": "sync_map_permissions"
       },
       "get": {
@@ -3929,7 +3929,7 @@
           "created_by"
         ],
         "pathType": "instance",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_streams"
       },
       "get": {
@@ -4088,7 +4088,7 @@
           "created_by"
         ],
         "pathType": "list",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "sync_streams"
       },
       "post": {

--- a/spec/json/twilio_taskrouter_v1.json
+++ b/spec/json/twilio_taskrouter_v1.json
@@ -2055,7 +2055,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -2231,7 +2231,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -2412,7 +2412,7 @@
           "event_date"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -2479,7 +2479,7 @@
           "event_date"
         ],
         "pathType": "list",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -2693,7 +2693,7 @@
           "reason"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -2904,7 +2904,7 @@
           "reason"
         ],
         "pathType": "list",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -3162,7 +3162,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -3333,7 +3333,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -3503,7 +3503,7 @@
           "task_order"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -3706,7 +3706,7 @@
           "task_order"
         ],
         "pathType": "list",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -3922,7 +3922,7 @@
           "tasks_completed"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/TaskQueues",
+        "parent": "/Workspaces/{WorkspaceSid}/TaskQueues/{Sid}",
         "className": "task_queue_cumulative_statistics"
       },
       "get": {
@@ -4032,7 +4032,7 @@
           "total_tasks"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/TaskQueues",
+        "parent": "/Workspaces/{WorkspaceSid}/TaskQueues/{Sid}",
         "className": "task_queue_real_time_statistics"
       },
       "get": {
@@ -4106,7 +4106,7 @@
           "cumulative"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/TaskQueues",
+        "parent": "/Workspaces/{WorkspaceSid}/TaskQueues/{Sid}",
         "className": "task_queue_statistics"
       },
       "get": {
@@ -4370,7 +4370,7 @@
           "worker_sid"
         ],
         "pathType": "list",
-        "parent": "/Workspaces/{WorkspaceSid}/Tasks"
+        "parent": "/Workspaces/{WorkspaceSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -4496,7 +4496,7 @@
           "worker_sid"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Tasks"
+        "parent": "/Workspaces/{WorkspaceSid}/Tasks/{Sid}"
       },
       "get": {
         "description": "",
@@ -4948,7 +4948,7 @@
           "available"
         ],
         "pathType": "list",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -5182,7 +5182,7 @@
           "available"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -5389,7 +5389,7 @@
           "task_channel_unique_name"
         ],
         "pathType": "list",
-        "parent": "/Workspaces/{WorkspaceSid}/Workers",
+        "parent": "/Workspaces/{WorkspaceSid}/Workers/{Sid}",
         "mountName": "worker_channels"
       },
       "get": {
@@ -5506,7 +5506,7 @@
           "task_channel_unique_name"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Workers",
+        "parent": "/Workspaces/{WorkspaceSid}/Workers/{Sid}",
         "mountName": "worker_channels"
       },
       "get": {
@@ -5660,7 +5660,7 @@
           "cumulative"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Workers",
+        "parent": "/Workspaces/{WorkspaceSid}/Workers/{Sid}",
         "className": "worker_statistics"
       },
       "get": {
@@ -5762,7 +5762,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Workspaces/{WorkspaceSid}/Workers"
+        "parent": "/Workspaces/{WorkspaceSid}/Workers/{Sid}"
       },
       "get": {
         "description": "",
@@ -5887,7 +5887,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Workers"
+        "parent": "/Workspaces/{WorkspaceSid}/Workers/{Sid}"
       },
       "get": {
         "description": "",
@@ -6448,7 +6448,7 @@
           "reservations_rescinded"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Workers",
+        "parent": "/Workspaces/{WorkspaceSid}/Workers/{Sid}",
         "className": "workers_cumulative_statistics"
       },
       "get": {
@@ -6536,7 +6536,7 @@
           "total_workers"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Workers",
+        "parent": "/Workspaces/{WorkspaceSid}/Workers/{Sid}",
         "className": "workers_real_time_statistics"
       },
       "get": {
@@ -6600,7 +6600,7 @@
           "document_content_type"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -6798,7 +6798,7 @@
           "document_content_type"
         ],
         "pathType": "list",
-        "parent": "/Workspaces"
+        "parent": "/Workspaces/{Sid}"
       },
       "get": {
         "description": "",
@@ -6987,7 +6987,7 @@
           "tasks_completed"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Workflows",
+        "parent": "/Workspaces/{WorkspaceSid}/Workflows/{Sid}",
         "className": "workflow_cumulative_statistics"
       },
       "get": {
@@ -7097,7 +7097,7 @@
           "total_tasks"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Workflows",
+        "parent": "/Workspaces/{WorkspaceSid}/Workflows/{Sid}",
         "className": "workflow_real_time_statistics"
       },
       "get": {
@@ -7171,7 +7171,7 @@
           "cumulative"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces/{WorkspaceSid}/Workflows",
+        "parent": "/Workspaces/{WorkspaceSid}/Workflows/{Sid}",
         "className": "workflow_statistics"
       },
       "get": {
@@ -7617,7 +7617,7 @@
           "tasks_completed"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces",
+        "parent": "/Workspaces/{Sid}",
         "className": "workspace_cumulative_statistics"
       },
       "get": {
@@ -7715,7 +7715,7 @@
           "total_tasks"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces",
+        "parent": "/Workspaces/{Sid}",
         "className": "workspace_real_time_statistics"
       },
       "get": {
@@ -7777,7 +7777,7 @@
           "cumulative"
         ],
         "pathType": "instance",
-        "parent": "/Workspaces",
+        "parent": "/Workspaces/{Sid}",
         "className": "workspace_statistics"
       },
       "get": {

--- a/spec/json/twilio_trunking_v1.json
+++ b/spec/json/twilio_trunking_v1.json
@@ -596,7 +596,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Trunks",
+        "parent": "/Trunks/{Sid}",
         "mountName": "credentials_lists",
         "className": "credential_list"
       },
@@ -708,7 +708,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Trunks",
+        "parent": "/Trunks/{Sid}",
         "mountName": "credentials_lists",
         "className": "credential_list"
       },
@@ -874,7 +874,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Trunks"
+        "parent": "/Trunks/{Sid}"
       },
       "get": {
         "description": "",
@@ -984,7 +984,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Trunks"
+        "parent": "/Trunks/{Sid}"
       },
       "post": {
         "description": "Associate an IP Access Control List with a Trunk",
@@ -1150,7 +1150,7 @@
           "weight"
         ],
         "pathType": "instance",
-        "parent": "/Trunks"
+        "parent": "/Trunks/{Sid}"
       },
       "get": {
         "description": "",
@@ -1345,7 +1345,7 @@
           "weight"
         ],
         "pathType": "list",
-        "parent": "/Trunks"
+        "parent": "/Trunks/{Sid}"
       },
       "post": {
         "description": "",
@@ -1527,7 +1527,7 @@
           "phone_number"
         ],
         "pathType": "instance",
-        "parent": "/Trunks"
+        "parent": "/Trunks/{Sid}"
       },
       "get": {
         "description": "",
@@ -1637,7 +1637,7 @@
           "phone_number"
         ],
         "pathType": "list",
-        "parent": "/Trunks"
+        "parent": "/Trunks/{Sid}"
       },
       "post": {
         "description": "",
@@ -1800,7 +1800,7 @@
           "trim"
         ],
         "pathType": "instance",
-        "parent": "/Trunks",
+        "parent": "/Trunks/{Sid}",
         "mountName": "recordings"
       },
       "get": {

--- a/spec/json/twilio_trusthub_v1.json
+++ b/spec/json/twilio_trusthub_v1.json
@@ -1140,7 +1140,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/CustomerProfiles",
+        "parent": "/CustomerProfiles/{Sid}",
         "mountName": "customer_profiles_channel_endpoint_assignment"
       },
       "post": {
@@ -1327,7 +1327,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/CustomerProfiles",
+        "parent": "/CustomerProfiles/{Sid}",
         "mountName": "customer_profiles_channel_endpoint_assignment"
       },
       "get": {
@@ -1436,7 +1436,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/CustomerProfiles",
+        "parent": "/CustomerProfiles/{Sid}",
         "mountName": "customer_profiles_entity_assignments",
         "className": "customer_profiles_entity_assignments"
       },
@@ -1600,7 +1600,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/CustomerProfiles",
+        "parent": "/CustomerProfiles/{Sid}",
         "mountName": "customer_profiles_entity_assignments",
         "className": "customer_profiles_entity_assignments"
       },
@@ -1710,7 +1710,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/CustomerProfiles",
+        "parent": "/CustomerProfiles/{Sid}",
         "mountName": "customer_profiles_evaluations",
         "className": "customer_profiles_evaluations"
       },
@@ -1874,7 +1874,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/CustomerProfiles",
+        "parent": "/CustomerProfiles/{Sid}",
         "mountName": "customer_profiles_evaluations",
         "className": "customer_profiles_evaluations"
       },
@@ -3265,7 +3265,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/TrustProducts",
+        "parent": "/TrustProducts/{Sid}",
         "mountName": "trust_products_channel_endpoint_assignment"
       },
       "post": {
@@ -3452,7 +3452,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/TrustProducts",
+        "parent": "/TrustProducts/{Sid}",
         "mountName": "trust_products_channel_endpoint_assignment"
       },
       "get": {
@@ -3561,7 +3561,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/TrustProducts",
+        "parent": "/TrustProducts/{Sid}",
         "mountName": "trust_products_entity_assignments",
         "className": "trust_products_entity_assignments"
       },
@@ -3725,7 +3725,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/TrustProducts",
+        "parent": "/TrustProducts/{Sid}",
         "mountName": "trust_products_entity_assignments",
         "className": "trust_products_entity_assignments"
       },
@@ -3835,7 +3835,7 @@
           "sid"
         ],
         "pathType": "list",
-        "parent": "/TrustProducts",
+        "parent": "/TrustProducts/{Sid}",
         "mountName": "trust_products_evaluations",
         "className": "trust_products_evaluations"
       },
@@ -3999,7 +3999,7 @@
           "sid"
         ],
         "pathType": "instance",
-        "parent": "/TrustProducts",
+        "parent": "/TrustProducts/{Sid}",
         "mountName": "trust_products_evaluations",
         "className": "trust_products_evaluations"
       },

--- a/spec/json/twilio_verify_v2.json
+++ b/spec/json/twilio_verify_v2.json
@@ -1471,7 +1471,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Create a new enrollment Access Token for the Entity",
@@ -1565,7 +1565,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "get": {
         "description": "Fetch an Access Token for the Entity",
@@ -1637,7 +1637,7 @@
           "date_updated"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/RateLimits"
+        "parent": "/Services/{ServiceSid}/RateLimits/{Sid}"
       },
       "post": {
         "description": "Create a new Bucket for a Rate Limit",
@@ -1832,7 +1832,7 @@
           "date_updated"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/RateLimits"
+        "parent": "/Services/{ServiceSid}/RateLimits/{Sid}"
       },
       "post": {
         "description": "Update a specific Bucket.",
@@ -2049,7 +2049,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Entities"
+        "parent": "/Services/{ServiceSid}/Entities/{Identity}"
       },
       "post": {
         "description": "Create a new Challenge for the Factor",
@@ -2282,7 +2282,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Entities"
+        "parent": "/Services/{ServiceSid}/Entities/{Identity}"
       },
       "get": {
         "description": "Fetch a specific Challenge.",
@@ -2436,7 +2436,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Create a new Entity for the Service",
@@ -2597,7 +2597,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "delete": {
         "description": "Delete a specific Entity.",
@@ -2702,7 +2702,7 @@
           "factor_type"
         ],
         "pathType": "instance",
-        "parent": "/Services/{ServiceSid}/Entities"
+        "parent": "/Services/{ServiceSid}/Entities/{Identity}"
       },
       "delete": {
         "description": "Delete a specific Factor.",
@@ -2939,7 +2939,7 @@
           "factor_type"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Entities"
+        "parent": "/Services/{ServiceSid}/Entities/{Identity}"
       },
       "get": {
         "description": "Retrieve a list of all Factors for an Entity.",
@@ -3229,7 +3229,7 @@
           "date_updated"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Create a new MessagingConfiguration for a service.",
@@ -3401,7 +3401,7 @@
           "date_updated"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Update a specific MessagingConfiguration",
@@ -3575,7 +3575,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services/{ServiceSid}/Entities/{Identity}/Challenges"
+        "parent": "/Services/{ServiceSid}/Entities/{Identity}/Challenges/{Sid}"
       },
       "post": {
         "description": "Create a new Notification for the corresponding Challenge",
@@ -3671,7 +3671,7 @@
           "date_updated"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Create a new Rate Limit for a Service",
@@ -3840,7 +3840,7 @@
           "date_updated"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Update a specific Rate Limit.",
@@ -4576,7 +4576,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Create a new Verification using a Service",
@@ -4707,7 +4707,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Update a Verification status",
@@ -5166,7 +5166,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services",
+        "parent": "/Services/{Sid}",
         "mountName": "verification_checks"
       },
       "post": {
@@ -5360,7 +5360,7 @@
           "date_created"
         ],
         "pathType": "list",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "Create a new Webhook for the Service",
@@ -5549,7 +5549,7 @@
           "date_created"
         ],
         "pathType": "instance",
-        "parent": "/Services"
+        "parent": "/Services/{Sid}"
       },
       "post": {
         "description": "",

--- a/spec/json/twilio_video_v1.json
+++ b/spec/json/twilio_video_v1.json
@@ -2869,7 +2869,7 @@
           "status"
         ],
         "pathType": "instance",
-        "parent": "/Rooms"
+        "parent": "/Rooms/{Sid}"
       },
       "get": {
         "description": "",
@@ -2991,7 +2991,7 @@
           "status"
         ],
         "pathType": "list",
-        "parent": "/Rooms"
+        "parent": "/Rooms/{Sid}"
       },
       "get": {
         "description": "",
@@ -3127,7 +3127,7 @@
           "status"
         ],
         "pathType": "instance",
-        "parent": "/Rooms/{RoomSid}/Participants"
+        "parent": "/Rooms/{RoomSid}/Participants/{Sid}"
       },
       "post": {
         "description": "",
@@ -3189,7 +3189,7 @@
           "kind"
         ],
         "pathType": "instance",
-        "parent": "/Rooms/{RoomSid}/Participants"
+        "parent": "/Rooms/{RoomSid}/Participants/{Sid}"
       },
       "get": {
         "description": "Returns a single Track resource represented by TrackName or SID.",
@@ -3260,7 +3260,7 @@
           "kind"
         ],
         "pathType": "list",
-        "parent": "/Rooms/{RoomSid}/Participants"
+        "parent": "/Rooms/{RoomSid}/Participants/{Sid}"
       },
       "get": {
         "description": "Returns a list of tracks associated with a given Participant. Only `currently` Published Tracks are in the list resource.",
@@ -3370,7 +3370,7 @@
           "rules"
         ],
         "pathType": "list",
-        "parent": "/Rooms/{RoomSid}/Participants",
+        "parent": "/Rooms/{RoomSid}/Participants/{Sid}",
         "className": "subscribe_rules"
       },
       "get": {
@@ -3492,7 +3492,7 @@
           "kind"
         ],
         "pathType": "instance",
-        "parent": "/Rooms/{RoomSid}/Participants"
+        "parent": "/Rooms/{RoomSid}/Participants/{Sid}"
       },
       "get": {
         "description": "Returns a single Track resource represented by `track_sid`.  Note: This is one resource with the Video API that requires a SID, be Track Name on the subscriber side is not guaranteed to be unique.",
@@ -3566,7 +3566,7 @@
           "kind"
         ],
         "pathType": "list",
-        "parent": "/Rooms/{RoomSid}/Participants"
+        "parent": "/Rooms/{RoomSid}/Participants/{Sid}"
       },
       "get": {
         "description": "Returns a list of tracks that are subscribed for the participant.",
@@ -3679,7 +3679,7 @@
           "codec"
         ],
         "pathType": "instance",
-        "parent": "/Rooms",
+        "parent": "/Rooms/{Sid}",
         "className": "room_recording"
       },
       "get": {
@@ -3793,7 +3793,7 @@
           "codec"
         ],
         "pathType": "list",
-        "parent": "/Rooms",
+        "parent": "/Rooms/{Sid}",
         "className": "room_recording"
       },
       "get": {
@@ -3935,7 +3935,7 @@
           "rules"
         ],
         "pathType": "list",
-        "parent": "/Rooms",
+        "parent": "/Rooms/{Sid}",
         "className": "recording_rules"
       },
       "get": {

--- a/spec/json/twilio_voice_v1.json
+++ b/spec/json/twilio_voice_v1.json
@@ -1308,7 +1308,7 @@
           "enabled"
         ],
         "pathType": "list",
-        "parent": "/ConnectionPolicies",
+        "parent": "/ConnectionPolicies/{Sid}",
         "className": "connection_policy_target"
       },
       "post": {
@@ -1488,7 +1488,7 @@
           "enabled"
         ],
         "pathType": "instance",
-        "parent": "/ConnectionPolicies",
+        "parent": "/ConnectionPolicies/{Sid}",
         "className": "connection_policy_target"
       },
       "get": {
@@ -1946,7 +1946,7 @@
           "prefix"
         ],
         "pathType": "list",
-        "parent": "/DialingPermissions/Countries",
+        "parent": "/DialingPermissions/Countries/{IsoCode}",
         "className": "highrisk_special_prefix"
       },
       "get": {

--- a/spec/json/twilio_wireless_v1.json
+++ b/spec/json/twilio_wireless_v1.json
@@ -1039,7 +1039,7 @@
           "end"
         ],
         "pathType": "list",
-        "parent": "/Sims"
+        "parent": "/Sims/{Sid}"
       },
       "get": {
         "description": "",
@@ -1842,7 +1842,7 @@
           "period"
         ],
         "pathType": "list",
-        "parent": "/Sims"
+        "parent": "/Sims/{Sid}"
       },
       "get": {
         "description": "",

--- a/spec/yaml/twilio_api_v2010.yaml
+++ b/spec/yaml/twilio_api_v2010.yaml
@@ -8501,7 +8501,7 @@ paths:
       - validated
       - verified
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     post:
       description: ''
       parameters:
@@ -8663,7 +8663,7 @@ paths:
       - validated
       - verified
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     delete:
       description: ''
       parameters:
@@ -8814,7 +8814,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     post:
       description: Create a new application within your account
       parameters:
@@ -9034,7 +9034,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     delete:
       description: Delete the application by the specified application sid
       parameters:
@@ -9263,7 +9263,7 @@ paths:
       - connect_app_sid
       - connect_app_friendly_name
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch an instance of an authorized-connect-app
       parameters:
@@ -9307,7 +9307,7 @@ paths:
       - connect_app_sid
       - connect_app_friendly_name
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of authorized-connect-apps belonging to the account
         used to make the request
@@ -9378,7 +9378,7 @@ paths:
       - country
       - beta
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
       className: available_phone_number_country
     get:
       description: ''
@@ -9449,7 +9449,7 @@ paths:
       - country
       - beta
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
       className: available_phone_number_country
     get:
       description: ''
@@ -9495,7 +9495,7 @@ paths:
       - region
       - beta
       pathType: list
-      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers.json
+      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json
     get:
       description: ''
       parameters:
@@ -9692,7 +9692,7 @@ paths:
       - region
       - beta
       pathType: list
-      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers.json
+      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json
     get:
       description: ''
       parameters:
@@ -9889,7 +9889,7 @@ paths:
       - region
       - beta
       pathType: list
-      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers.json
+      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json
     get:
       description: ''
       parameters:
@@ -10086,7 +10086,7 @@ paths:
       - region
       - beta
       pathType: list
-      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers.json
+      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json
     get:
       description: ''
       parameters:
@@ -10283,7 +10283,7 @@ paths:
       - region
       - beta
       pathType: list
-      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers.json
+      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json
     get:
       description: ''
       parameters:
@@ -10480,7 +10480,7 @@ paths:
       - region
       - beta
       pathType: list
-      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers.json
+      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json
     get:
       description: ''
       parameters:
@@ -10677,7 +10677,7 @@ paths:
       - region
       - beta
       pathType: list
-      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers.json
+      parent: /Accounts/{AccountSid}/AvailablePhoneNumbers/{CountryCode}.json
     get:
       description: ''
       parameters:
@@ -10874,7 +10874,7 @@ paths:
       - balance
       - currency
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch the balance for an Account based on Account Sid. Balance
         changes may not be reflected immediately. Child accounts do not contain balance
@@ -10914,7 +10914,7 @@ paths:
       - status
       - start_time
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     post:
       description: Create a new outgoing call to phones, SIP-enabled endpoints or
         Twilio Client connections
@@ -11380,7 +11380,7 @@ paths:
       - status
       - start_time
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     delete:
       description: Delete a Call record from your account. Once the record is deleted,
         it will no longer appear in the API and Account Portal logs.
@@ -11579,7 +11579,7 @@ paths:
       - request
       - response
       pathType: list
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     get:
       description: Retrieve a list of all events for a call.
       parameters:
@@ -11658,7 +11658,7 @@ paths:
       - quality_score
       - date_created
       pathType: instance
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     get:
       description: Fetch a Feedback resource from a call
       parameters:
@@ -11918,7 +11918,7 @@ paths:
       - error_code
       - message_date
       pathType: instance
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     get:
       description: ''
       parameters:
@@ -11975,7 +11975,7 @@ paths:
       - error_code
       - message_date
       pathType: list
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     get:
       description: ''
       parameters:
@@ -12092,7 +12092,7 @@ paths:
       - start_time
       - duration
       pathType: list
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     post:
       description: Create a recording for the call
       parameters:
@@ -12294,7 +12294,7 @@ paths:
       - start_time
       - duration
       pathType: instance
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     post:
       description: 'Changes the status of the recording to paused, stopped, or in-progress.
         Note: Pass `Twilio.CURRENT` instead of recording sid to reference current
@@ -12456,7 +12456,7 @@ paths:
       - friendly_name
       - status
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch an instance of a conference
       parameters:
@@ -12566,7 +12566,7 @@ paths:
       - friendly_name
       - status
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of conferences belonging to the account used to
         make the request
@@ -12705,7 +12705,7 @@ paths:
       - start_time
       - duration
       pathType: instance
-      parent: /Accounts/{AccountSid}/Conferences.json
+      parent: /Accounts/{AccountSid}/Conferences/{Sid}.json
     post:
       description: 'Changes the status of the recording to paused, stopped, or in-progress.
         Note: To use `Twilio.CURRENT`, pass it as recording sid.'
@@ -12869,7 +12869,7 @@ paths:
       - start_time
       - duration
       pathType: list
-      parent: /Accounts/{AccountSid}/Conferences.json
+      parent: /Accounts/{AccountSid}/Conferences/{Sid}.json
     get:
       description: Retrieve a list of recordings belonging to the call used to make
         the request
@@ -12979,7 +12979,7 @@ paths:
       - sid
       - friendly_name
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch an instance of a connect-app
       parameters:
@@ -13141,7 +13141,7 @@ paths:
       - sid
       - friendly_name
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of connect-apps belonging to the account used to
         make the request
@@ -13212,7 +13212,7 @@ paths:
       - phone_number
       - friendly_name
       pathType: list
-      parent: /Accounts/{AccountSid}/Addresses.json
+      parent: /Accounts/{AccountSid}/Addresses/{Sid}.json
     get:
       description: ''
       parameters:
@@ -13291,7 +13291,7 @@ paths:
       - phone_number
       - friendly_name
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     post:
       description: Update an incoming-phone-number instance.
       parameters:
@@ -13592,7 +13592,7 @@ paths:
       - phone_number
       - friendly_name
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of incoming-phone-numbers belonging to the account
         used to make the request.
@@ -13911,7 +13911,7 @@ paths:
       - friendly_name
       - description
       pathType: instance
-      parent: /Accounts/{AccountSid}/IncomingPhoneNumbers.json
+      parent: /Accounts/{AccountSid}/IncomingPhoneNumbers/{Sid}.json
     get:
       description: Fetch an instance of an Add-on installation currently assigned
         to this Number.
@@ -14009,7 +14009,7 @@ paths:
       - friendly_name
       - description
       pathType: list
-      parent: /Accounts/{AccountSid}/IncomingPhoneNumbers.json
+      parent: /Accounts/{AccountSid}/IncomingPhoneNumbers/{Sid}.json
     get:
       description: Retrieve a list of Add-on installations currently assigned to this
         Number.
@@ -14139,7 +14139,7 @@ paths:
       - friendly_name
       - product_name
       pathType: instance
-      parent: /Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns.json
+      parent: /Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns/{Sid}.json
       className: assigned_add_on_extension
     get:
       description: Fetch an instance of an Extension for the Assigned Add-on.
@@ -14205,7 +14205,7 @@ paths:
       - friendly_name
       - product_name
       pathType: list
-      parent: /Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns.json
+      parent: /Accounts/{AccountSid}/IncomingPhoneNumbers/{ResourceSid}/AssignedAddOns/{Sid}.json
       className: assigned_add_on_extension
     get:
       description: Retrieve a list of Extensions for the Assigned Add-on.
@@ -15213,7 +15213,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: ''
       parameters:
@@ -15336,7 +15336,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: ''
       parameters:
@@ -15445,7 +15445,7 @@ paths:
       - parent_sid
       - content_type
       pathType: instance
-      parent: /Accounts/{AccountSid}/Messages.json
+      parent: /Accounts/{AccountSid}/Messages/{Sid}.json
     delete:
       description: Delete media from your account. Once delete, you will no longer
         be billed
@@ -15545,7 +15545,7 @@ paths:
       - parent_sid
       - content_type
       pathType: list
-      parent: /Accounts/{AccountSid}/Messages.json
+      parent: /Accounts/{AccountSid}/Messages/{Sid}.json
     get:
       description: Retrieve a list of Media resources belonging to the account used
         to make the request
@@ -15657,7 +15657,7 @@ paths:
       - position
       - wait_time
       pathType: instance
-      parent: /Accounts/{AccountSid}/Queues.json
+      parent: /Accounts/{AccountSid}/Queues/{Sid}.json
     get:
       description: Fetch a specific member from the queue
       parameters:
@@ -15778,7 +15778,7 @@ paths:
       - position
       - wait_time
       pathType: list
-      parent: /Accounts/{AccountSid}/Queues.json
+      parent: /Accounts/{AccountSid}/Queues/{Sid}.json
     get:
       description: Retrieve the members of the queue
       parameters:
@@ -15860,7 +15860,7 @@ paths:
       - direction
       - date_sent
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     post:
       description: Send a message from the account used to make the request
       parameters:
@@ -16161,7 +16161,7 @@ paths:
       - direction
       - date_sent
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     delete:
       description: Deletes a message record from your account
       parameters:
@@ -16290,7 +16290,7 @@ paths:
       - outcome
       - date_created
       pathType: list
-      parent: /Accounts/{AccountSid}/Messages.json
+      parent: /Accounts/{AccountSid}/Messages/{Sid}.json
     post:
       description: ''
       parameters:
@@ -16350,7 +16350,7 @@ paths:
       - friendly_name
       - secret
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     post:
       description: Create a new Signing Key for the account making the request.
       parameters:
@@ -16458,7 +16458,7 @@ paths:
       - error_code
       - message_date
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch a notification belonging to the account used to make the
         request
@@ -16506,7 +16506,7 @@ paths:
       - error_code
       - message_date
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of notifications belonging to the account used
         to make the request
@@ -16613,7 +16613,7 @@ paths:
       - phone_number
       - friendly_name
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch an outgoing-caller-id belonging to the account used to make
         the request
@@ -16739,7 +16739,7 @@ paths:
       - phone_number
       - friendly_name
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of outgoing-caller-ids belonging to the account
         used to make the request
@@ -16898,7 +16898,7 @@ paths:
       - muted
       - hold
       pathType: instance
-      parent: /Accounts/{AccountSid}/Conferences.json
+      parent: /Accounts/{AccountSid}/Conferences/{Sid}.json
     get:
       description: Fetch an instance of a participant
       parameters:
@@ -17136,7 +17136,7 @@ paths:
       - muted
       - hold
       pathType: list
-      parent: /Accounts/{AccountSid}/Conferences.json
+      parent: /Accounts/{AccountSid}/Conferences/{Sid}.json
     post:
       description: ''
       parameters:
@@ -17594,7 +17594,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     post:
       description: create an instance of payments. This will start a new payments
         session
@@ -17738,7 +17738,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     post:
       description: update an instance of payments with different phases of payment
         flows.
@@ -17831,7 +17831,7 @@ paths:
       - current_size
       - average_wait_time
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch an instance of a queue identified by the QueueSid
       parameters:
@@ -17959,7 +17959,7 @@ paths:
       - current_size
       - average_wait_time
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of queues belonging to the account used to make
         the request
@@ -18074,7 +18074,7 @@ paths:
       - start_time
       - duration
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch an instance of a recording
       parameters:
@@ -18160,7 +18160,7 @@ paths:
       - start_time
       - duration
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of recordings belonging to the account used to
         make the request
@@ -18290,7 +18290,7 @@ paths:
       - add_on_sid
       - date_created
       pathType: instance
-      parent: /Accounts/{AccountSid}/Recordings.json
+      parent: /Accounts/{AccountSid}/Recordings/{Sid}.json
     get:
       description: Fetch an instance of an AddOnResult
       parameters:
@@ -18386,7 +18386,7 @@ paths:
       - add_on_sid
       - date_created
       pathType: list
-      parent: /Accounts/{AccountSid}/Recordings.json
+      parent: /Accounts/{AccountSid}/Recordings/{Sid}.json
     get:
       description: Retrieve a list of results belonging to the recording
       parameters:
@@ -18465,7 +18465,7 @@ paths:
       - label
       - content_type
       pathType: instance
-      parent: /Accounts/{AccountSid}/Recordings/{ReferenceSid}/AddOnResults.json
+      parent: /Accounts/{AccountSid}/Recordings/{ReferenceSid}/AddOnResults/{Sid}.json
     get:
       description: Fetch an instance of a result payload
       parameters:
@@ -18580,7 +18580,7 @@ paths:
       - label
       - content_type
       pathType: list
-      parent: /Accounts/{AccountSid}/Recordings/{ReferenceSid}/AddOnResults.json
+      parent: /Accounts/{AccountSid}/Recordings/{ReferenceSid}/AddOnResults/{Sid}.json
     get:
       description: Retrieve a list of payloads belonging to the AddOnResult
       parameters:
@@ -18670,7 +18670,7 @@ paths:
       - status
       - duration
       pathType: instance
-      parent: /Accounts/{AccountSid}/Recordings.json
+      parent: /Accounts/{AccountSid}/Recordings/{Sid}.json
     get:
       description: ''
       parameters:
@@ -18768,7 +18768,7 @@ paths:
       - status
       - duration
       pathType: list
-      parent: /Accounts/{AccountSid}/Recordings.json
+      parent: /Accounts/{AccountSid}/Recordings/{Sid}.json
     get:
       description: ''
       parameters:
@@ -18848,7 +18848,7 @@ paths:
       - short_code
       - friendly_name
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch an instance of a short code
       parameters:
@@ -18979,7 +18979,7 @@ paths:
       - short_code
       - friendly_name
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of short-codes belonging to the account used to
         make the request
@@ -19060,7 +19060,7 @@ paths:
       - sid
       - friendly_name
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: ''
       parameters:
@@ -19173,7 +19173,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
   /2010-04-01/Accounts/{AccountSid}/SIP/Domains/{DomainSid}/Auth.json:
     servers:
     - url: https://api.twilio.com
@@ -19181,7 +19181,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Accounts/{AccountSid}/SIP/Domains.json
+      parent: /Accounts/{AccountSid}/SIP/Domains/{Sid}.json
       className: auth_types
   /2010-04-01/Accounts/{AccountSid}/SIP/Domains/{DomainSid}/Auth/Calls.json:
     servers:
@@ -19886,7 +19886,7 @@ paths:
       - username
       - credential_list_sid
       pathType: list
-      parent: /Accounts/{AccountSid}/SIP/CredentialLists.json
+      parent: /Accounts/{AccountSid}/SIP/CredentialLists/{Sid}.json
     get:
       description: Retrieve a list of credentials.
       parameters:
@@ -20020,7 +20020,7 @@ paths:
       - username
       - credential_list_sid
       pathType: instance
-      parent: /Accounts/{AccountSid}/SIP/CredentialLists.json
+      parent: /Accounts/{AccountSid}/SIP/CredentialLists/{Sid}.json
     get:
       description: Fetch a single credential.
       parameters:
@@ -20390,7 +20390,7 @@ paths:
       - sid
       - friendly_name
       pathType: list
-      parent: /Accounts/{AccountSid}/SIP/Domains.json
+      parent: /Accounts/{AccountSid}/SIP/Domains/{Sid}.json
     post:
       description: Create a CredentialListMapping resource for an account.
       parameters:
@@ -20520,7 +20520,7 @@ paths:
       - sid
       - friendly_name
       pathType: instance
-      parent: /Accounts/{AccountSid}/SIP/Domains.json
+      parent: /Accounts/{AccountSid}/SIP/Domains/{Sid}.json
     get:
       description: Fetch a single CredentialListMapping resource from an account.
       parameters:
@@ -21251,7 +21251,7 @@ paths:
       - sid
       - friendly_name
       pathType: instance
-      parent: /Accounts/{AccountSid}/SIP/Domains.json
+      parent: /Accounts/{AccountSid}/SIP/Domains/{Sid}.json
     get:
       description: Fetch an IpAccessControlListMapping resource.
       parameters:
@@ -21343,7 +21343,7 @@ paths:
       - sid
       - friendly_name
       pathType: list
-      parent: /Accounts/{AccountSid}/SIP/Domains.json
+      parent: /Accounts/{AccountSid}/SIP/Domains/{Sid}.json
     post:
       description: Create a new IpAccessControlListMapping resource.
       parameters:
@@ -21470,7 +21470,7 @@ paths:
       - ip_address
       - friendly_name
       pathType: list
-      parent: /Accounts/{AccountSid}/SIP/IpAccessControlLists.json
+      parent: /Accounts/{AccountSid}/SIP/IpAccessControlLists/{Sid}.json
     get:
       description: Read multiple IpAddress resources.
       parameters:
@@ -21609,7 +21609,7 @@ paths:
       - ip_address
       - friendly_name
       pathType: instance
-      parent: /Accounts/{AccountSid}/SIP/IpAccessControlLists.json
+      parent: /Accounts/{AccountSid}/SIP/IpAccessControlLists/{Sid}.json
     get:
       description: Read one IpAddress resource.
       parameters:
@@ -21771,7 +21771,7 @@ paths:
       - call_sid
       - name
       pathType: list
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     post:
       description: Create a Siprec
       parameters:
@@ -22446,7 +22446,7 @@ paths:
       - call_sid
       - name
       pathType: instance
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     post:
       description: Stop a Siprec using either the SID of the Siprec resource or the
         `name` used when creating the resource
@@ -22512,7 +22512,7 @@ paths:
       - call_sid
       - name
       pathType: list
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     post:
       description: Create a Stream
       parameters:
@@ -23190,7 +23190,7 @@ paths:
       - call_sid
       - name
       pathType: instance
-      parent: /Accounts/{AccountSid}/Calls.json
+      parent: /Accounts/{AccountSid}/Calls/{Sid}.json
     post:
       description: Stop a Stream using either the SID of the Stream resource or the
         `name` used when creating the resource
@@ -23256,7 +23256,7 @@ paths:
       - username
       - ice_servers
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     post:
       description: Create a new token for ICE servers
       parameters:
@@ -23304,7 +23304,7 @@ paths:
       - status
       - duration
       pathType: instance
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Fetch an instance of a Transcription
       parameters:
@@ -23382,7 +23382,7 @@ paths:
       - status
       - duration
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
     get:
       description: Retrieve a list of transcriptions belonging to the account used
         to make the request
@@ -23450,7 +23450,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Accounts.json
+      parent: /Accounts/{Sid}.json
   /2010-04-01/Accounts/{AccountSid}/Usage/Records.json:
     servers:
     - url: https://api.twilio.com

--- a/spec/yaml/twilio_autopilot_v1.yaml
+++ b/spec/yaml/twilio_autopilot_v1.yaml
@@ -1052,7 +1052,7 @@ paths:
       defaultOutputProperties:
       - data
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
       className: defaults
     get:
       description: ''
@@ -1117,7 +1117,7 @@ paths:
       - sid
       - data
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -1156,7 +1156,7 @@ paths:
       - sid
       - data
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
   /v1/Assistants/{AssistantSid}/Tasks/{TaskSid}/Fields/{Sid}:
     servers:
     - url: https://autopilot.twilio.com
@@ -1167,7 +1167,7 @@ paths:
       - unique_name
       - field_type
       pathType: instance
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -1246,7 +1246,7 @@ paths:
       - unique_name
       - field_type
       pathType: list
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -1371,7 +1371,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -1482,7 +1482,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -1592,7 +1592,7 @@ paths:
       - value
       - language
       pathType: instance
-      parent: /Assistants/{AssistantSid}/FieldTypes
+      parent: /Assistants/{AssistantSid}/FieldTypes/{Sid}
     get:
       description: ''
       parameters:
@@ -1671,7 +1671,7 @@ paths:
       - value
       - language
       pathType: list
-      parent: /Assistants/{AssistantSid}/FieldTypes
+      parent: /Assistants/{AssistantSid}/FieldTypes/{Sid}
     get:
       description: ''
       parameters:
@@ -1804,7 +1804,7 @@ paths:
       - status
       - date_created
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -1912,7 +1912,7 @@ paths:
       - status
       - date_created
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -2021,7 +2021,7 @@ paths:
       - status
       - language
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -2134,7 +2134,7 @@ paths:
       - status
       - language
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -2321,7 +2321,7 @@ paths:
       - language
       - source_channel
       pathType: instance
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -2467,7 +2467,7 @@ paths:
       - language
       - source_channel
       pathType: list
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -2599,7 +2599,7 @@ paths:
       defaultOutputProperties:
       - data
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: Returns Style sheet JSON object for the Assistant
       parameters:
@@ -2663,7 +2663,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -2781,7 +2781,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -2897,7 +2897,7 @@ paths:
       defaultOutputProperties:
       - data
       pathType: instance
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
       mountName: task_actions
       className: task_actions
     get:
@@ -2979,7 +2979,7 @@ paths:
       - samples_count
       - fields_count
       pathType: instance
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
       className: task_statistics
     get:
       description: ''
@@ -3022,7 +3022,7 @@ paths:
       - wehbook_url
       - webhook_method
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -3142,7 +3142,7 @@ paths:
       - wehbook_url
       - webhook_method
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:

--- a/spec/yaml/twilio_bulkexports_v1.yaml
+++ b/spec/yaml/twilio_bulkexports_v1.yaml
@@ -251,7 +251,7 @@ paths:
       - size
       - redirectTo
       pathType: instance
-      parent: /Exports
+      parent: /Exports/{ResourceType}
     get:
       description: Fetch a specific Day.
       parameters:
@@ -294,7 +294,7 @@ paths:
       - size
       - redirectTo
       pathType: list
-      parent: /Exports
+      parent: /Exports/{ResourceType}
     get:
       description: Retrieve a list of all Days for a resource.
       parameters:
@@ -484,7 +484,7 @@ paths:
       - webhook_method
       - webhook_url
       pathType: list
-      parent: /Exports
+      parent: /Exports/{ResourceType}
       mountName: export_custom_jobs
     get:
       description: ''

--- a/spec/yaml/twilio_chat_v1.yaml
+++ b/spec/yaml/twilio_chat_v1.yaml
@@ -680,7 +680,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -804,7 +804,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -1177,7 +1177,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1268,7 +1268,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -1410,7 +1410,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1565,7 +1565,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -1710,7 +1710,7 @@ paths:
       - to
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1871,7 +1871,7 @@ paths:
       - to
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -2017,7 +2017,7 @@ paths:
       - friendly_name
       - type
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -2147,7 +2147,7 @@ paths:
       - friendly_name
       - type
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -2830,7 +2830,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -2955,7 +2955,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -3081,7 +3081,7 @@ paths:
       - channel_sid
       - status
       pathType: list
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_channels
     get:
       description: List all Channels for a given User.

--- a/spec/yaml/twilio_chat_v2.yaml
+++ b/spec/yaml/twilio_chat_v2.yaml
@@ -979,7 +979,7 @@ paths:
       - endpoint
       - identity
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -1069,7 +1069,7 @@ paths:
       - endpoint
       - identity
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -1144,7 +1144,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -1297,7 +1297,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -1453,7 +1453,7 @@ paths:
       - sid
       - configuration
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1616,7 +1616,7 @@ paths:
       - sid
       - configuration
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -2033,7 +2033,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -2124,7 +2124,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -2268,7 +2268,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -2450,7 +2450,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -2635,7 +2635,7 @@ paths:
       - to
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -2818,7 +2818,7 @@ paths:
       - to
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -2987,7 +2987,7 @@ paths:
       - friendly_name
       - type
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -3116,7 +3116,7 @@ paths:
       - friendly_name
       - type
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -3578,7 +3578,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -3710,7 +3710,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -3844,7 +3844,7 @@ paths:
       - identity
       - binding_type
       pathType: list
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_bindings
     get:
       description: ''
@@ -3935,7 +3935,7 @@ paths:
       - identity
       - binding_type
       pathType: instance
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_bindings
     get:
       description: ''
@@ -4026,7 +4026,7 @@ paths:
       - channel_sid
       - status
       pathType: list
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_channels
     get:
       description: List all Channels for a given User.
@@ -4105,7 +4105,7 @@ paths:
       - channel_sid
       - status
       pathType: instance
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_channels
     get:
       description: ''

--- a/spec/yaml/twilio_conversations_v1.yaml
+++ b/spec/yaml/twilio_conversations_v1.yaml
@@ -2686,7 +2686,7 @@ paths:
       - author
       - date_created
       pathType: list
-      parent: /Conversations
+      parent: /Conversations/{Sid}
     post:
       description: Add a new message to the conversation
       parameters:
@@ -2826,7 +2826,7 @@ paths:
       - author
       - date_created
       pathType: instance
-      parent: /Conversations
+      parent: /Conversations/{Sid}
     post:
       description: Update an existing message in the conversation
       parameters:
@@ -2970,7 +2970,7 @@ paths:
       - status
       - date_created
       pathType: instance
-      parent: /Conversations/{ConversationSid}/Messages
+      parent: /Conversations/{ConversationSid}/Messages/{Sid}
       mountName: delivery_receipts
     get:
       description: Fetch the delivery and read receipts of the conversation message
@@ -3025,7 +3025,7 @@ paths:
       - status
       - date_created
       pathType: list
-      parent: /Conversations/{ConversationSid}/Messages
+      parent: /Conversations/{ConversationSid}/Messages/{Sid}
       mountName: delivery_receipts
     get:
       description: Retrieve a list of all delivery and read receipts of the conversation
@@ -3104,7 +3104,7 @@ paths:
       - sid
       - messaging_binding
       pathType: list
-      parent: /Conversations
+      parent: /Conversations/{Sid}
     post:
       description: Add a new participant to the conversation
       parameters:
@@ -3251,7 +3251,7 @@ paths:
       - sid
       - messaging_binding
       pathType: instance
-      parent: /Conversations
+      parent: /Conversations/{Sid}
     post:
       description: Update an existing participant in the conversation
       parameters:
@@ -3406,7 +3406,7 @@ paths:
       - sid
       - target
       pathType: list
-      parent: /Conversations
+      parent: /Conversations/{Sid}
     get:
       description: Retrieve a list of all webhooks scoped to the conversation
       parameters:
@@ -3539,7 +3539,7 @@ paths:
       - sid
       - target
       pathType: instance
-      parent: /Conversations
+      parent: /Conversations/{Sid}
     get:
       description: Fetch the configuration of a conversation-scoped webhook
       parameters:
@@ -4339,7 +4339,7 @@ paths:
       - endpoint
       - identity
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     delete:
       description: Remove a push notification binding from the conversation service
       parameters:
@@ -4415,7 +4415,7 @@ paths:
       - endpoint
       - identity
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a list of all push notification bindings in the conversation
         service
@@ -4505,7 +4505,7 @@ paths:
       defaultOutputProperties:
       - chat_service_sid
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Fetch the configuration of a conversation service
       parameters:
@@ -4602,7 +4602,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Create a new conversation in your service
       parameters:
@@ -4756,7 +4756,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Update an existing conversation in your service
       parameters:
@@ -4923,7 +4923,7 @@ paths:
       - author
       - date_created
       pathType: list
-      parent: /Services/{ChatServiceSid}/Conversations
+      parent: /Services/{ChatServiceSid}/Conversations/{Sid}
     post:
       description: Add a new message to the conversation in a specific service
       parameters:
@@ -5084,7 +5084,7 @@ paths:
       - author
       - date_created
       pathType: instance
-      parent: /Services/{ChatServiceSid}/Conversations
+      parent: /Services/{ChatServiceSid}/Conversations/{Sid}
     post:
       description: Update an existing message in the conversation
       parameters:
@@ -5258,7 +5258,7 @@ paths:
       - status
       - date_created
       pathType: instance
-      parent: /Services/{ChatServiceSid}/Conversations/{ConversationSid}/Messages
+      parent: /Services/{ChatServiceSid}/Conversations/{ConversationSid}/Messages/{Sid}
       mountName: delivery_receipts
     get:
       description: Fetch the delivery and read receipts of the conversation message
@@ -5323,7 +5323,7 @@ paths:
       - status
       - date_created
       pathType: list
-      parent: /Services/{ChatServiceSid}/Conversations/{ConversationSid}/Messages
+      parent: /Services/{ChatServiceSid}/Conversations/{ConversationSid}/Messages/{Sid}
       mountName: delivery_receipts
     get:
       description: Retrieve a list of all delivery and read receipts of the conversation
@@ -5413,7 +5413,7 @@ paths:
       - sid
       - messaging_binding
       pathType: list
-      parent: /Services/{ChatServiceSid}/Conversations
+      parent: /Services/{ChatServiceSid}/Conversations/{Sid}
     post:
       description: Add a new participant to the conversation in a specific service
       parameters:
@@ -5581,7 +5581,7 @@ paths:
       - sid
       - messaging_binding
       pathType: instance
-      parent: /Services/{ChatServiceSid}/Conversations
+      parent: /Services/{ChatServiceSid}/Conversations/{Sid}
     post:
       description: Update an existing participant in the conversation
       parameters:
@@ -5766,7 +5766,7 @@ paths:
       - sid
       - target
       pathType: list
-      parent: /Services/{ChatServiceSid}/Conversations
+      parent: /Services/{ChatServiceSid}/Conversations/{Sid}
     post:
       description: Create a new webhook scoped to the conversation in a specific service
       parameters:
@@ -5919,7 +5919,7 @@ paths:
       - sid
       - target
       pathType: instance
-      parent: /Services/{ChatServiceSid}/Conversations
+      parent: /Services/{ChatServiceSid}/Conversations/{Sid}
     post:
       description: Update an existing conversation-scoped webhook
       parameters:
@@ -6208,7 +6208,7 @@ paths:
       - participant_sid
       - conversation_sid
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a list of all Conversations that this Participant belongs
         to by identity or by address. Only one parameter should be specified.
@@ -6296,7 +6296,7 @@ paths:
       - friendly_name
       - type
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Create a new user role in your service
       parameters:
@@ -6422,7 +6422,7 @@ paths:
       - friendly_name
       - type
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Update an existing user role in your service
       parameters:
@@ -6551,7 +6551,7 @@ paths:
       - sid
       - identity
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Add a new conversation user to your service
       parameters:
@@ -6681,7 +6681,7 @@ paths:
       - sid
       - identity
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Update an existing conversation user in your service
       parameters:
@@ -6820,7 +6820,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Services/{ChatServiceSid}/Users
+      parent: /Services/{ChatServiceSid}/Users/{Sid}
       mountName: user_conversations
     post:
       description: Update a specific User Conversation.
@@ -6970,7 +6970,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Services/{ChatServiceSid}/Users
+      parent: /Services/{ChatServiceSid}/Users/{Sid}
       mountName: user_conversations
     get:
       description: Retrieve a list of all User Conversations for the User.
@@ -7363,7 +7363,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Users
+      parent: /Users/{Sid}
       mountName: user_conversations
     post:
       description: Update a specific User Conversation.
@@ -7483,7 +7483,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Users
+      parent: /Users/{Sid}
       mountName: user_conversations
     get:
       description: Retrieve a list of all User Conversations for the User.

--- a/spec/yaml/twilio_events_v1.yaml
+++ b/spec/yaml/twilio_events_v1.yaml
@@ -402,7 +402,7 @@ paths:
       - schema_version
       - date_created
       pathType: list
-      parent: /Schemas
+      parent: /Schemas/{Id}
       className: schema_version
     get:
       description: Retrieve a paginated list of versions of the schema.
@@ -471,7 +471,7 @@ paths:
       - schema_version
       - date_created
       pathType: instance
-      parent: /Schemas
+      parent: /Schemas/{Id}
       className: schema_version
     get:
       description: Fetch a specific schema and version.
@@ -717,7 +717,7 @@ paths:
       defaultOutputProperties:
       - result
       pathType: list
-      parent: /Sinks
+      parent: /Sinks/{Sid}
       mountName: sink_test
     post:
       description: Create a new Sink Test Event for the given Sink.
@@ -752,7 +752,7 @@ paths:
       defaultOutputProperties:
       - result
       pathType: list
-      parent: /Sinks
+      parent: /Sinks/{Sid}
       mountName: sink_validate
     post:
       description: Validate that a test event for a Sink was received.
@@ -803,7 +803,7 @@ paths:
       - account_sid
       - subscription_sid
       pathType: list
-      parent: /Subscriptions
+      parent: /Subscriptions/{Sid}
     get:
       description: Retrieve a list of all Subscribed Event types for a Subscription.
       parameters:
@@ -913,7 +913,7 @@ paths:
       - account_sid
       - subscription_sid
       pathType: instance
-      parent: /Subscriptions
+      parent: /Subscriptions/{Sid}
     get:
       description: Read an Event for a Subscription.
       parameters:

--- a/spec/yaml/twilio_flex_v1.yaml
+++ b/spec/yaml/twilio_flex_v1.yaml
@@ -1276,7 +1276,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /Interactions
+      parent: /Interactions/{Sid}
       className: interaction_channel
     get:
       description: Fetch a Channel for an Interaction.
@@ -1375,7 +1375,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /Interactions
+      parent: /Interactions/{Sid}
       className: interaction_channel
     get:
       description: List all Channels for an Interaction.
@@ -1445,7 +1445,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /Interactions/{InteractionSid}/Channels
+      parent: /Interactions/{InteractionSid}/Channels/{Sid}
       className: interaction_channel_invite
     post:
       description: Invite an Agent or a TaskQueue to a Channel.
@@ -1567,7 +1567,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /Interactions/{InteractionSid}/Channels
+      parent: /Interactions/{InteractionSid}/Channels/{Sid}
       className: interaction_channel_participant
     post:
       description: Add a Participant to a Channel.
@@ -1696,7 +1696,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /Interactions/{InteractionSid}/Channels
+      parent: /Interactions/{InteractionSid}/Channels/{Sid}
       className: interaction_channel_participant
     post:
       description: Update an existing Channel Participant.

--- a/spec/yaml/twilio_insights_v1.yaml
+++ b/spec/yaml/twilio_insights_v1.yaml
@@ -1654,7 +1654,7 @@ paths:
       - call_sid
       - account_sid
       pathType: instance
-      parent: /Conferences
+      parent: /Conferences/{ConferenceSid}
       mountName: conference_participants
     get:
       description: Fetch a specific Conference Participant Summary.
@@ -1711,7 +1711,7 @@ paths:
       - call_sid
       - account_sid
       pathType: list
-      parent: /Conferences
+      parent: /Conferences/{ConferenceSid}
       mountName: conference_participants
     get:
       description: List Conference Participants.
@@ -2001,7 +2001,7 @@ paths:
       defaultOutputProperties:
       - participant_sid
       pathType: instance
-      parent: /Video/Rooms
+      parent: /Video/Rooms/{RoomSid}
     get:
       description: Get Video Log Analyzer data for a Room Participant.
       parameters:
@@ -2037,7 +2037,7 @@ paths:
       defaultOutputProperties:
       - participant_sid
       pathType: list
-      parent: /Video/Rooms
+      parent: /Video/Rooms/{RoomSid}
     get:
       description: Get a list of room participants.
       parameters:

--- a/spec/yaml/twilio_ip_messaging_v1.yaml
+++ b/spec/yaml/twilio_ip_messaging_v1.yaml
@@ -548,7 +548,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -661,7 +661,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -991,7 +991,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1076,7 +1076,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -1207,7 +1207,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1348,7 +1348,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -1480,7 +1480,7 @@ paths:
       - to
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1627,7 +1627,7 @@ paths:
       - to
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -1763,7 +1763,7 @@ paths:
       - friendly_name
       - type
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -1883,7 +1883,7 @@ paths:
       - friendly_name
       - type
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -2498,7 +2498,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -2614,7 +2614,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -2731,7 +2731,7 @@ paths:
       - channel_sid
       - status
       pathType: list
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_channels
     get:
       description: ''

--- a/spec/yaml/twilio_ip_messaging_v2.yaml
+++ b/spec/yaml/twilio_ip_messaging_v2.yaml
@@ -789,7 +789,7 @@ paths:
       - endpoint
       - identity
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -874,7 +874,7 @@ paths:
       - endpoint
       - identity
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -947,7 +947,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -1083,7 +1083,7 @@ paths:
       - unique_name
       - friendly_name
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -1221,7 +1221,7 @@ paths:
       - sid
       - configuration
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1365,7 +1365,7 @@ paths:
       - sid
       - configuration
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1730,7 +1730,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -1815,7 +1815,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -1946,7 +1946,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -2105,7 +2105,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -2262,7 +2262,7 @@ paths:
       - to
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     get:
       description: ''
       parameters:
@@ -2426,7 +2426,7 @@ paths:
       - to
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Channels
+      parent: /Services/{ServiceSid}/Channels/{Sid}
     post:
       description: ''
       parameters:
@@ -2577,7 +2577,7 @@ paths:
       - friendly_name
       - type
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -2697,7 +2697,7 @@ paths:
       - friendly_name
       - type
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -3100,7 +3100,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -3223,7 +3223,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -3348,7 +3348,7 @@ paths:
       - identity
       - binding_type
       pathType: list
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_bindings
     get:
       description: ''
@@ -3434,7 +3434,7 @@ paths:
       - identity
       - binding_type
       pathType: instance
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_bindings
     get:
       description: ''
@@ -3519,7 +3519,7 @@ paths:
       - channel_sid
       - status
       pathType: list
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_channels
     get:
       description: ''
@@ -3595,7 +3595,7 @@ paths:
       - channel_sid
       - status
       pathType: instance
-      parent: /Services/{ServiceSid}/Users
+      parent: /Services/{ServiceSid}/Users/{Sid}
       mountName: user_channels
     get:
       description: ''

--- a/spec/yaml/twilio_media_v1.yaml
+++ b/spec/yaml/twilio_media_v1.yaml
@@ -912,7 +912,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /PlayerStreamers
+      parent: /PlayerStreamers/{Sid}
     post:
       description: ''
       parameters:

--- a/spec/yaml/twilio_messaging_v1.yaml
+++ b/spec/yaml/twilio_messaging_v1.yaml
@@ -860,7 +860,7 @@ paths:
       - sid
       - alpha_sender
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -971,7 +971,7 @@ paths:
       - sid
       - alpha_sender
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -1210,7 +1210,7 @@ paths:
       - vetting_status
       - vetting_class
       pathType: list
-      parent: /a2p/BrandRegistrations
+      parent: /a2p/BrandRegistrations/{Sid}
       mountName: brand_vettings
     post:
       description: ''
@@ -1334,7 +1334,7 @@ paths:
       - vetting_status
       - vetting_class
       pathType: instance
-      parent: /a2p/BrandRegistrations
+      parent: /a2p/BrandRegistrations/{Sid}
       mountName: brand_vettings
     get:
       description: ''
@@ -1459,7 +1459,7 @@ paths:
       - phone_number
       - country_code
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -1571,7 +1571,7 @@ paths:
       - phone_number
       - country_code
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     delete:
       description: ''
       parameters:
@@ -2003,7 +2003,7 @@ paths:
       - short_code
       - country_code
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -2116,7 +2116,7 @@ paths:
       - short_code
       - country_code
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     delete:
       description: ''
       parameters:
@@ -2422,7 +2422,7 @@ paths:
       - campaign_status
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: us_app_to_person
     post:
       description: ''
@@ -2561,7 +2561,7 @@ paths:
       - campaign_status
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: us_app_to_person
     delete:
       description: ''
@@ -2638,7 +2638,7 @@ paths:
       defaultOutputProperties:
       - us_app_to_person_usecases
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: us_app_to_person_usecases
     get:
       description: ''

--- a/spec/yaml/twilio_notify_v1.yaml
+++ b/spec/yaml/twilio_notify_v1.yaml
@@ -378,7 +378,7 @@ paths:
       - binding_type
       - address
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -457,7 +457,7 @@ paths:
       - binding_type
       - address
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -871,7 +871,7 @@ paths:
       - priority
       - title
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:

--- a/spec/yaml/twilio_numbers_v2.yaml
+++ b/spec/yaml/twilio_numbers_v2.yaml
@@ -877,7 +877,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /RegulatoryCompliance/Bundles
+      parent: /RegulatoryCompliance/Bundles/{Sid}
       mountName: bundle_copies
     post:
       description: Creates a new copy of a Bundle. It will internally create copies
@@ -1262,7 +1262,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /RegulatoryCompliance/Bundles
+      parent: /RegulatoryCompliance/Bundles/{Sid}
     post:
       description: Creates an evaluation for a bundle
       parameters:
@@ -1354,7 +1354,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /RegulatoryCompliance/Bundles
+      parent: /RegulatoryCompliance/Bundles/{Sid}
     get:
       description: Fetch specific Evaluation Instance.
       parameters:
@@ -1396,7 +1396,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /RegulatoryCompliance/Bundles
+      parent: /RegulatoryCompliance/Bundles/{Sid}
     post:
       description: Create a new Assigned Item.
       parameters:
@@ -1504,7 +1504,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /RegulatoryCompliance/Bundles
+      parent: /RegulatoryCompliance/Bundles/{Sid}
     get:
       description: Fetch specific Assigned Item Instance.
       parameters:
@@ -1692,7 +1692,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /RegulatoryCompliance/Bundles
+      parent: /RegulatoryCompliance/Bundles/{Sid}
       className: replace_items
     post:
       description: Replaces all bundle items in the target bundle (specified in the

--- a/spec/yaml/twilio_preview.yaml
+++ b/spec/yaml/twilio_preview.yaml
@@ -2348,7 +2348,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Fleets
+      parent: /Fleets/{Sid}
     get:
       description: Fetch information about a specific Certificate credential in the
         Fleet.
@@ -2466,7 +2466,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Fleets
+      parent: /Fleets/{Sid}
     post:
       description: Enroll a new Certificate credential to the Fleet, optionally giving
         it a friendly name and assigning to a Device.
@@ -2586,7 +2586,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Fleets
+      parent: /Fleets/{Sid}
     get:
       description: Fetch information about a specific Deployment in the Fleet.
       parameters:
@@ -2705,7 +2705,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Fleets
+      parent: /Fleets/{Sid}
     post:
       description: Create a new Deployment in the Fleet, optionally giving it a friendly
         name and linking to a specific Twilio Sync service instance.
@@ -2810,7 +2810,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Fleets
+      parent: /Fleets/{Sid}
     get:
       description: Fetch information about a specific Device in the Fleet.
       parameters:
@@ -2926,7 +2926,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Fleets
+      parent: /Fleets/{Sid}
     post:
       description: Create a new Device in the Fleet, optionally giving it a unique
         name, friendly name, and assigning to a Deployment and/or human identity.
@@ -3223,7 +3223,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Fleets
+      parent: /Fleets/{Sid}
     get:
       description: Fetch information about a specific Key credential in the Fleet.
       parameters:
@@ -3340,7 +3340,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Fleets
+      parent: /Fleets/{Sid}
     post:
       description: Create a new Key credential in the Fleet, optionally giving it
         a friendly name and assigning to a Device.
@@ -3686,7 +3686,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /AuthorizationDocuments
+      parent: /AuthorizationDocuments/{Sid}
     get:
       description: Retrieve a list of dependent HostedNumberOrders belonging to the
         AuthorizationDocument.
@@ -4250,7 +4250,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /AvailableAddOns
+      parent: /AvailableAddOns/{Sid}
       className: available_add_on_extension
     get:
       description: Fetch an instance of an Extension for the Available Add-on.
@@ -4293,7 +4293,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /AvailableAddOns
+      parent: /AvailableAddOns/{Sid}
       className: available_add_on_extension
     get:
       description: Retrieve a list of Extensions for the Available Add-on.
@@ -4549,7 +4549,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /InstalledAddOns
+      parent: /InstalledAddOns/{Sid}
       className: installed_add_on_extension
     get:
       description: Fetch an instance of an Extension for the Installed Add-on.
@@ -4638,7 +4638,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /InstalledAddOns
+      parent: /InstalledAddOns/{Sid}
       className: installed_add_on_extension
     get:
       description: Retrieve a list of Extensions for the Installed Add-on.
@@ -4707,7 +4707,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -4817,7 +4817,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -4920,7 +4920,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services/{ServiceSid}/Documents
+      parent: /Services/{ServiceSid}/Documents/{Sid}
       mountName: document_permissions
     get:
       description: Fetch a specific Sync Document Permission.
@@ -5059,7 +5059,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services/{ServiceSid}/Documents
+      parent: /Services/{ServiceSid}/Documents/{Sid}
       mountName: document_permissions
     get:
       description: Retrieve a list of all Permissions applying to a Sync Document.
@@ -5319,7 +5319,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_lists
     get:
       description: ''
@@ -5384,7 +5384,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_lists
     post:
       description: ''
@@ -5486,7 +5486,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services/{ServiceSid}/Lists
+      parent: /Services/{ServiceSid}/Lists/{Sid}
       mountName: sync_list_items
     get:
       description: ''
@@ -5620,7 +5620,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services/{ServiceSid}/Lists
+      parent: /Services/{ServiceSid}/Lists/{Sid}
       mountName: sync_list_items
     post:
       description: ''
@@ -5752,7 +5752,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services/{ServiceSid}/Lists
+      parent: /Services/{ServiceSid}/Lists/{Sid}
       mountName: sync_list_permissions
     get:
       description: Fetch a specific Sync List Permission.
@@ -5891,7 +5891,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services/{ServiceSid}/Lists
+      parent: /Services/{ServiceSid}/Lists/{Sid}
       mountName: sync_list_permissions
     get:
       description: Retrieve a list of all Permissions applying to a Sync List.
@@ -5965,7 +5965,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_maps
     get:
       description: ''
@@ -6030,7 +6030,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_maps
     post:
       description: ''
@@ -6132,7 +6132,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services/{ServiceSid}/Maps
+      parent: /Services/{ServiceSid}/Maps/{Sid}
       mountName: sync_map_items
     get:
       description: ''
@@ -6266,7 +6266,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services/{ServiceSid}/Maps
+      parent: /Services/{ServiceSid}/Maps/{Sid}
       mountName: sync_map_items
     post:
       description: ''
@@ -6402,7 +6402,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services/{ServiceSid}/Maps
+      parent: /Services/{ServiceSid}/Maps/{Sid}
       mountName: sync_map_permissions
     get:
       description: Fetch a specific Sync Map Permission.
@@ -6541,7 +6541,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services/{ServiceSid}/Maps
+      parent: /Services/{ServiceSid}/Maps/{Sid}
       mountName: sync_map_permissions
     get:
       description: Retrieve a list of all Permissions applying to a Sync Map.
@@ -6830,7 +6830,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
       mountName: assistant_fallback_actions
       className: assistant_fallback_actions
     get:
@@ -6891,7 +6891,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
       mountName: assistant_initiation_actions
       className: assistant_initiation_actions
     get:
@@ -6952,7 +6952,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -6987,7 +6987,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
   /understand/Assistants/{AssistantSid}/Tasks/{TaskSid}/Fields/{Sid}:
     servers:
     - url: https://preview.twilio.com
@@ -6995,7 +6995,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -7065,7 +7065,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -7182,7 +7182,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -7283,7 +7283,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -7386,7 +7386,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants/{AssistantSid}/FieldTypes
+      parent: /Assistants/{AssistantSid}/FieldTypes/{Sid}
     get:
       description: ''
       parameters:
@@ -7456,7 +7456,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Assistants/{AssistantSid}/FieldTypes
+      parent: /Assistants/{AssistantSid}/FieldTypes/{Sid}
     get:
       description: ''
       parameters:
@@ -7580,7 +7580,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -7677,7 +7677,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -7778,7 +7778,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -7881,7 +7881,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -8014,7 +8014,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -8145,7 +8145,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -8269,7 +8269,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: Returns Style sheet JSON object for this Assistant
       parameters:
@@ -8329,7 +8329,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -8438,7 +8438,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Assistants
+      parent: /Assistants/{Sid}
     get:
       description: ''
       parameters:
@@ -8549,7 +8549,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
       mountName: task_actions
       className: task_actions
     get:
@@ -8623,7 +8623,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Assistants/{AssistantSid}/Tasks
+      parent: /Assistants/{AssistantSid}/Tasks/{Sid}
       className: task_statistics
     get:
       description: ''
@@ -9233,7 +9233,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Sims
+      parent: /Sims/{Sid}
     get:
       description: ''
       parameters:
@@ -9361,7 +9361,7 @@ paths:
       - phone_number
       - url
       pathType: list
-      parent: /BrandedChannels
+      parent: /BrandedChannels/{Sid}
     post:
       description: Associate a channel to a branded channel
       parameters:

--- a/spec/yaml/twilio_proxy_v1.yaml
+++ b/spec/yaml/twilio_proxy_v1.yaml
@@ -734,7 +734,7 @@ paths:
       - type
       - data
       pathType: instance
-      parent: /Services/{ServiceSid}/Sessions
+      parent: /Services/{ServiceSid}/Sessions/{Sid}
     get:
       description: Retrieve a list of Interactions for a given [Session](https://www.twilio.com/docs/proxy/api/session).
       parameters:
@@ -831,7 +831,7 @@ paths:
       - type
       - data
       pathType: list
-      parent: /Services/{ServiceSid}/Sessions
+      parent: /Services/{ServiceSid}/Sessions/{Sid}
     get:
       description: Retrieve a list of all Interactions for a Session. A maximum of
         100 records will be returned per page.
@@ -913,7 +913,7 @@ paths:
       - type
       - data
       pathType: list
-      parent: /Services/{ServiceSid}/Sessions/{SessionSid}/Participants
+      parent: /Services/{ServiceSid}/Sessions/{SessionSid}/Participants/{Sid}
     post:
       description: Create a new message Interaction to send directly from your system
         to one [Participant](https://www.twilio.com/docs/proxy/api/participant).  The
@@ -1071,7 +1071,7 @@ paths:
       - type
       - data
       pathType: instance
-      parent: /Services/{ServiceSid}/Sessions/{SessionSid}/Participants
+      parent: /Services/{ServiceSid}/Sessions/{SessionSid}/Participants/{Sid}
     get:
       description: ''
       parameters:
@@ -1138,7 +1138,7 @@ paths:
       - identifier
       - proxy_identifier
       pathType: instance
-      parent: /Services/{ServiceSid}/Sessions
+      parent: /Services/{ServiceSid}/Sessions/{Sid}
     get:
       description: Fetch a specific Participant.
       parameters:
@@ -1239,7 +1239,7 @@ paths:
       - identifier
       - proxy_identifier
       pathType: list
-      parent: /Services/{ServiceSid}/Sessions
+      parent: /Services/{ServiceSid}/Sessions/{Sid}
     get:
       description: Retrieve a list of all Participants in a Session.
       parameters:
@@ -1397,7 +1397,7 @@ paths:
       - friendly_name
       - phone_number
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Add a Phone Number to a Service's Proxy Number Pool.
       parameters:
@@ -1522,7 +1522,7 @@ paths:
       - friendly_name
       - phone_number
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     delete:
       description: Delete a specific Phone Number from a Service.
       parameters:
@@ -1941,7 +1941,7 @@ paths:
       - date_started
       - date_ended
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Fetch a specific Session.
       parameters:
@@ -2088,7 +2088,7 @@ paths:
       - date_started
       - date_ended
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a list of all Sessions for the Service. A maximum of 100
         records will be returned per page.
@@ -2238,7 +2238,7 @@ paths:
       - short_code
       - iso_country
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Add a Short Code to the Proxy Number Pool for the Service.
       parameters:
@@ -2352,7 +2352,7 @@ paths:
       - short_code
       - iso_country
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     delete:
       description: Delete a specific Short Code from a Service.
       parameters:

--- a/spec/yaml/twilio_serverless_v1.yaml
+++ b/spec/yaml/twilio_serverless_v1.yaml
@@ -755,7 +755,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a list of all Assets.
       parameters:
@@ -857,7 +857,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a specific Asset resource.
       parameters:
@@ -968,7 +968,7 @@ paths:
       - visibility
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Assets
+      parent: /Services/{ServiceSid}/Assets/{Sid}
       mountName: asset_versions
     get:
       description: Retrieve a list of all Asset Versions.
@@ -1047,7 +1047,7 @@ paths:
       - visibility
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Assets
+      parent: /Services/{ServiceSid}/Assets/{Sid}
       mountName: asset_versions
     get:
       description: Retrieve a specific Asset Version.
@@ -1100,7 +1100,7 @@ paths:
       - status
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a list of all Builds.
       parameters:
@@ -1224,7 +1224,7 @@ paths:
       - status
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a specific Build resource.
       parameters:
@@ -1290,7 +1290,7 @@ paths:
       - sid
       - status
       pathType: instance
-      parent: /Services/{ServiceSid}/Builds
+      parent: /Services/{ServiceSid}/Builds/{Sid}
       mountName: build_status
     get:
       description: Retrieve a specific Build resource.
@@ -1333,7 +1333,7 @@ paths:
       - build_sid
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Environments
+      parent: /Services/{ServiceSid}/Environments/{Sid}
     get:
       description: Retrieve a list of all Deployments.
       parameters:
@@ -1454,7 +1454,7 @@ paths:
       - build_sid
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Environments
+      parent: /Services/{ServiceSid}/Environments/{Sid}
     get:
       description: Retrieve a specific Deployment.
       parameters:
@@ -1506,7 +1506,7 @@ paths:
       - domain_name
       - build_sid
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a list of all environments.
       parameters:
@@ -1613,7 +1613,7 @@ paths:
       - domain_name
       - build_sid
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a specific environment.
       parameters:
@@ -1681,7 +1681,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a list of all Functions.
       parameters:
@@ -1783,7 +1783,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Retrieve a specific Function resource.
       parameters:
@@ -1894,7 +1894,7 @@ paths:
       - visibility
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Functions
+      parent: /Services/{ServiceSid}/Functions/{Sid}
       mountName: function_versions
     get:
       description: Retrieve a list of all Function Version resources.
@@ -1974,7 +1974,7 @@ paths:
       - visibility
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Functions
+      parent: /Services/{ServiceSid}/Functions/{Sid}
       mountName: function_versions
     get:
       description: Retrieve a specific Function Version resource.
@@ -2026,7 +2026,7 @@ paths:
       - sid
       - content
       pathType: instance
-      parent: /Services/{ServiceSid}/Functions/{FunctionSid}/Versions
+      parent: /Services/{ServiceSid}/Functions/{FunctionSid}/Versions/{Sid}
       mountName: function_version_content
     get:
       description: Retrieve a the content of a specific Function Version resource.
@@ -2076,7 +2076,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: list
-      parent: /Services/{ServiceSid}/Environments
+      parent: /Services/{ServiceSid}/Environments/{Sid}
     get:
       description: Retrieve a list of all logs.
       parameters:
@@ -2172,7 +2172,7 @@ paths:
     x-twilio:
       defaultOutputProperties: []
       pathType: instance
-      parent: /Services/{ServiceSid}/Environments
+      parent: /Services/{ServiceSid}/Environments/{Sid}
     get:
       description: Retrieve a specific log.
       parameters:
@@ -2414,7 +2414,7 @@ paths:
       - key
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Environments
+      parent: /Services/{ServiceSid}/Environments/{Sid}
     get:
       description: Retrieve a list of all Variables.
       parameters:
@@ -2538,7 +2538,7 @@ paths:
       - key
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Environments
+      parent: /Services/{ServiceSid}/Environments/{Sid}
     get:
       description: Retrieve a specific Variable.
       parameters:

--- a/spec/yaml/twilio_studio_v1.yaml
+++ b/spec/yaml/twilio_studio_v1.yaml
@@ -501,7 +501,7 @@ paths:
       - status
       - date_created
       pathType: list
-      parent: /Flows
+      parent: /Flows/{Sid}
     get:
       description: Retrieve a list of all Engagements for the Flow.
       parameters:
@@ -625,7 +625,7 @@ paths:
       - status
       - date_created
       pathType: instance
-      parent: /Flows
+      parent: /Flows/{Sid}
     get:
       description: Retrieve an Engagement
       parameters:
@@ -696,7 +696,7 @@ paths:
       defaultOutputProperties:
       - context
       pathType: instance
-      parent: /Flows/{FlowSid}/Engagements
+      parent: /Flows/{FlowSid}/Engagements/{Sid}
       mountName: engagement_context
     get:
       description: Retrieve the most recent context for an Engagement.
@@ -742,7 +742,7 @@ paths:
       - status
       - date_created
       pathType: list
-      parent: /Flows
+      parent: /Flows/{Sid}
     get:
       description: Retrieve a list of all Executions for the Flow.
       parameters:
@@ -881,7 +881,7 @@ paths:
       - status
       - date_created
       pathType: instance
-      parent: /Flows
+      parent: /Flows/{Sid}
     get:
       description: Retrieve an Execution
       parameters:
@@ -998,7 +998,7 @@ paths:
       defaultOutputProperties:
       - context
       pathType: instance
-      parent: /Flows/{FlowSid}/Executions
+      parent: /Flows/{FlowSid}/Executions/{Sid}
       mountName: execution_context
     get:
       description: Retrieve the most recent context for an Execution.
@@ -1043,7 +1043,7 @@ paths:
       - name
       - date_created
       pathType: list
-      parent: /Flows/{FlowSid}/Executions
+      parent: /Flows/{FlowSid}/Executions/{Sid}
       className: execution_step
     get:
       description: Retrieve a list of all Steps for an Execution.
@@ -1123,7 +1123,7 @@ paths:
       - name
       - date_created
       pathType: instance
-      parent: /Flows/{FlowSid}/Executions
+      parent: /Flows/{FlowSid}/Executions/{Sid}
       className: execution_step
     get:
       description: Retrieve a Step.
@@ -1175,7 +1175,7 @@ paths:
       defaultOutputProperties:
       - context
       pathType: instance
-      parent: /Flows/{FlowSid}/Executions/{ExecutionSid}/Steps
+      parent: /Flows/{FlowSid}/Executions/{ExecutionSid}/Steps/{Sid}
       mountName: step_context
       className: execution_step_context
     get:
@@ -1347,7 +1347,7 @@ paths:
       - transitioned_from
       - transitioned_to
       pathType: list
-      parent: /Flows/{FlowSid}/Engagements
+      parent: /Flows/{FlowSid}/Engagements/{Sid}
     get:
       description: Retrieve a list of all Steps for an Engagement.
       parameters:
@@ -1427,7 +1427,7 @@ paths:
       - transitioned_from
       - transitioned_to
       pathType: instance
-      parent: /Flows/{FlowSid}/Engagements
+      parent: /Flows/{FlowSid}/Engagements/{Sid}
     get:
       description: Retrieve a Step.
       parameters:
@@ -1478,7 +1478,7 @@ paths:
       defaultOutputProperties:
       - context
       pathType: instance
-      parent: /Flows/{FlowSid}/Engagements/{EngagementSid}/Steps
+      parent: /Flows/{FlowSid}/Engagements/{EngagementSid}/Steps/{Sid}
       mountName: step_context
     get:
       description: Retrieve the context for an Engagement Step.

--- a/spec/yaml/twilio_studio_v2.yaml
+++ b/spec/yaml/twilio_studio_v2.yaml
@@ -411,7 +411,7 @@ paths:
       - status
       - date_created
       pathType: list
-      parent: /Flows
+      parent: /Flows/{Sid}
     get:
       description: Retrieve a list of all Executions for the Flow.
       parameters:
@@ -549,7 +549,7 @@ paths:
       - status
       - date_created
       pathType: instance
-      parent: /Flows
+      parent: /Flows/{Sid}
     get:
       description: Retrieve an Execution
       parameters:
@@ -666,7 +666,7 @@ paths:
       defaultOutputProperties:
       - context
       pathType: instance
-      parent: /Flows/{FlowSid}/Executions
+      parent: /Flows/{FlowSid}/Executions/{Sid}
       mountName: execution_context
     get:
       description: Retrieve the most recent context for an Execution.
@@ -711,7 +711,7 @@ paths:
       - name
       - date_created
       pathType: list
-      parent: /Flows/{FlowSid}/Executions
+      parent: /Flows/{FlowSid}/Executions/{Sid}
       className: execution_step
     get:
       description: Retrieve a list of all Steps for an Execution.
@@ -791,7 +791,7 @@ paths:
       - name
       - date_created
       pathType: instance
-      parent: /Flows/{FlowSid}/Executions
+      parent: /Flows/{FlowSid}/Executions/{Sid}
       className: execution_step
     get:
       description: Retrieve a Step.
@@ -843,7 +843,7 @@ paths:
       defaultOutputProperties:
       - context
       pathType: instance
-      parent: /Flows/{FlowSid}/Executions/{ExecutionSid}/Steps
+      parent: /Flows/{FlowSid}/Executions/{ExecutionSid}/Steps/{Sid}
       mountName: step_context
       className: execution_step_context
     get:
@@ -1097,7 +1097,7 @@ paths:
       - status
       - revision
       pathType: list
-      parent: /Flows
+      parent: /Flows/{Sid}
       className: flow_revision
     get:
       description: Retrieve a list of all Flows revisions.
@@ -1169,7 +1169,7 @@ paths:
       - status
       - revision
       pathType: instance
-      parent: /Flows
+      parent: /Flows/{Sid}
       className: flow_revision
     get:
       description: Retrieve a specific Flow revision.
@@ -1255,7 +1255,7 @@ paths:
       defaultOutputProperties:
       - test_users
       pathType: instance
-      parent: /Flows
+      parent: /Flows/{Sid}
       className: flow_test_user
     get:
       description: Fetch flow test users

--- a/spec/yaml/twilio_supersim_v1.yaml
+++ b/spec/yaml/twilio_supersim_v1.yaml
@@ -764,7 +764,7 @@ paths:
       - end_time
       - period_type
       pathType: list
-      parent: /Sims
+      parent: /Sims/{Sid}
     get:
       description: Retrieve a list of Billing Periods for a Super SIM.
       parameters:
@@ -1694,7 +1694,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /NetworkAccessProfiles
+      parent: /NetworkAccessProfiles/{Sid}
       className: network_access_profile_network
     get:
       description: Retrieve a list of Network Access Profile resource's Network resource.
@@ -1800,7 +1800,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /NetworkAccessProfiles
+      parent: /NetworkAccessProfiles/{Sid}
       className: network_access_profile_network
     delete:
       description: Remove a Network resource from the Network Access Profile resource's.
@@ -2155,7 +2155,7 @@ paths:
       - ip_address
       - ip_address_version
       pathType: list
-      parent: /Sims
+      parent: /Sims/{Sid}
       mountName: sim_ip_addresses
     get:
       description: Retrieve a list of IP Addresses for the given Super SIM.

--- a/spec/yaml/twilio_sync_v1.yaml
+++ b/spec/yaml/twilio_sync_v1.yaml
@@ -655,7 +655,7 @@ paths:
       - unique_name
       - revision
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: ''
       parameters:
@@ -768,7 +768,7 @@ paths:
       - unique_name
       - revision
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:
@@ -878,7 +878,7 @@ paths:
       - write
       - manage
       pathType: instance
-      parent: /Services/{ServiceSid}/Documents
+      parent: /Services/{ServiceSid}/Documents/{Sid}
       mountName: document_permissions
     get:
       description: Fetch a specific Sync Document Permission.
@@ -1018,7 +1018,7 @@ paths:
       - write
       - manage
       pathType: list
-      parent: /Services/{ServiceSid}/Documents
+      parent: /Services/{ServiceSid}/Documents/{Sid}
       mountName: document_permissions
     get:
       description: Retrieve a list of all Permissions applying to a Sync Document.
@@ -1323,7 +1323,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /Services/{ServiceSid}/Streams
+      parent: /Services/{ServiceSid}/Streams/{Sid}
       mountName: stream_messages
     post:
       description: Create a new Stream Message.
@@ -1377,7 +1377,7 @@ paths:
       - unique_name
       - revision
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_lists
     get:
       description: ''
@@ -1487,7 +1487,7 @@ paths:
       - unique_name
       - revision
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_lists
     post:
       description: ''
@@ -1600,7 +1600,7 @@ paths:
       - revision
       - created_by
       pathType: instance
-      parent: /Services/{ServiceSid}/Lists
+      parent: /Services/{ServiceSid}/Lists/{Sid}
       mountName: sync_list_items
     get:
       description: ''
@@ -1753,7 +1753,7 @@ paths:
       - revision
       - created_by
       pathType: list
-      parent: /Services/{ServiceSid}/Lists
+      parent: /Services/{ServiceSid}/Lists/{Sid}
       mountName: sync_list_items
     post:
       description: ''
@@ -1905,7 +1905,7 @@ paths:
       - write
       - manage
       pathType: instance
-      parent: /Services/{ServiceSid}/Lists
+      parent: /Services/{ServiceSid}/Lists/{Sid}
       mountName: sync_list_permissions
     get:
       description: Fetch a specific Sync List Permission.
@@ -2045,7 +2045,7 @@ paths:
       - write
       - manage
       pathType: list
-      parent: /Services/{ServiceSid}/Lists
+      parent: /Services/{ServiceSid}/Lists/{Sid}
       mountName: sync_list_permissions
     get:
       description: Retrieve a list of all Permissions applying to a Sync List.
@@ -2121,7 +2121,7 @@ paths:
       - unique_name
       - revision
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_maps
     get:
       description: ''
@@ -2231,7 +2231,7 @@ paths:
       - unique_name
       - revision
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_maps
     post:
       description: ''
@@ -2342,7 +2342,7 @@ paths:
       - revision
       - created_by
       pathType: instance
-      parent: /Services/{ServiceSid}/Maps
+      parent: /Services/{ServiceSid}/Maps/{Sid}
       mountName: sync_map_items
     get:
       description: ''
@@ -2495,7 +2495,7 @@ paths:
       - revision
       - created_by
       pathType: list
-      parent: /Services/{ServiceSid}/Maps
+      parent: /Services/{ServiceSid}/Maps/{Sid}
       mountName: sync_map_items
     post:
       description: ''
@@ -2654,7 +2654,7 @@ paths:
       - write
       - manage
       pathType: instance
-      parent: /Services/{ServiceSid}/Maps
+      parent: /Services/{ServiceSid}/Maps/{Sid}
       mountName: sync_map_permissions
     get:
       description: Fetch a specific Sync Map Permission.
@@ -2797,7 +2797,7 @@ paths:
       - write
       - manage
       pathType: list
-      parent: /Services/{ServiceSid}/Maps
+      parent: /Services/{ServiceSid}/Maps/{Sid}
       mountName: sync_map_permissions
     get:
       description: Retrieve a list of all Permissions applying to a Sync Map.
@@ -2874,7 +2874,7 @@ paths:
       - unique_name
       - created_by
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_streams
     get:
       description: Fetch a specific Stream.
@@ -2977,7 +2977,7 @@ paths:
       - unique_name
       - created_by
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: sync_streams
     post:
       description: Create a new Stream.

--- a/spec/yaml/twilio_taskrouter_v1.yaml
+++ b/spec/yaml/twilio_taskrouter_v1.yaml
@@ -1734,7 +1734,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -1854,7 +1854,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -1984,7 +1984,7 @@ paths:
       - description
       - event_date
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -2028,7 +2028,7 @@ paths:
       - description
       - event_date
       pathType: list
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -2187,7 +2187,7 @@ paths:
       - priority
       - reason
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -2342,7 +2342,7 @@ paths:
       - priority
       - reason
       pathType: list
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -2547,7 +2547,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -2660,7 +2660,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -2777,7 +2777,7 @@ paths:
       - friendly_name
       - task_order
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -2927,7 +2927,7 @@ paths:
       - friendly_name
       - task_order
       pathType: list
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -3088,7 +3088,7 @@ paths:
       - avg_task_acceptance_time
       - tasks_completed
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/TaskQueues
+      parent: /Workspaces/{WorkspaceSid}/TaskQueues/{Sid}
       className: task_queue_cumulative_statistics
     get:
       description: ''
@@ -3170,7 +3170,7 @@ paths:
       - longest_task_waiting_sid
       - total_tasks
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/TaskQueues
+      parent: /Workspaces/{WorkspaceSid}/TaskQueues/{Sid}
       className: task_queue_real_time_statistics
     get:
       description: ''
@@ -3219,7 +3219,7 @@ paths:
       defaultOutputProperties:
       - cumulative
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/TaskQueues
+      parent: /Workspaces/{WorkspaceSid}/TaskQueues/{Sid}
       className: task_queue_statistics
     get:
       description: ''
@@ -3410,7 +3410,7 @@ paths:
       - worker_name
       - worker_sid
       pathType: list
-      parent: /Workspaces/{WorkspaceSid}/Tasks
+      parent: /Workspaces/{WorkspaceSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -3499,7 +3499,7 @@ paths:
       - worker_name
       - worker_sid
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Tasks
+      parent: /Workspaces/{WorkspaceSid}/Tasks/{Sid}
     get:
       description: ''
       parameters:
@@ -3906,7 +3906,7 @@ paths:
       - friendly_name
       - available
       pathType: list
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -4075,7 +4075,7 @@ paths:
       - friendly_name
       - available
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -4221,7 +4221,7 @@ paths:
       - task_channel_sid
       - task_channel_unique_name
       pathType: list
-      parent: /Workspaces/{WorkspaceSid}/Workers
+      parent: /Workspaces/{WorkspaceSid}/Workers/{Sid}
       mountName: worker_channels
     get:
       description: ''
@@ -4301,7 +4301,7 @@ paths:
       - task_channel_sid
       - task_channel_unique_name
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Workers
+      parent: /Workspaces/{WorkspaceSid}/Workers/{Sid}
       mountName: worker_channels
     get:
       description: ''
@@ -4407,7 +4407,7 @@ paths:
       defaultOutputProperties:
       - cumulative
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Workers
+      parent: /Workspaces/{WorkspaceSid}/Workers/{Sid}
       className: worker_statistics
     get:
       description: ''
@@ -4480,7 +4480,7 @@ paths:
       - reservation_status
       - date_created
       pathType: list
-      parent: /Workspaces/{WorkspaceSid}/Workers
+      parent: /Workspaces/{WorkspaceSid}/Workers/{Sid}
     get:
       description: ''
       parameters:
@@ -4569,7 +4569,7 @@ paths:
       - reservation_status
       - date_created
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Workers
+      parent: /Workspaces/{WorkspaceSid}/Workers/{Sid}
     get:
       description: ''
       parameters:
@@ -5056,7 +5056,7 @@ paths:
       - reservations_canceled
       - reservations_rescinded
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Workers
+      parent: /Workspaces/{WorkspaceSid}/Workers/{Sid}
       className: workers_cumulative_statistics
     get:
       description: ''
@@ -5119,7 +5119,7 @@ paths:
       defaultOutputProperties:
       - total_workers
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Workers
+      parent: /Workspaces/{WorkspaceSid}/Workers/{Sid}
       className: workers_real_time_statistics
     get:
       description: ''
@@ -5162,7 +5162,7 @@ paths:
       - friendly_name
       - document_content_type
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -5306,7 +5306,7 @@ paths:
       - friendly_name
       - document_content_type
       pathType: list
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
     get:
       description: ''
       parameters:
@@ -5443,7 +5443,7 @@ paths:
       - avg_task_acceptance_time
       - tasks_completed
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Workflows
+      parent: /Workspaces/{WorkspaceSid}/Workflows/{Sid}
       className: workflow_cumulative_statistics
     get:
       description: ''
@@ -5530,7 +5530,7 @@ paths:
       - longest_task_waiting_sid
       - total_tasks
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Workflows
+      parent: /Workspaces/{WorkspaceSid}/Workflows/{Sid}
       className: workflow_real_time_statistics
     get:
       description: ''
@@ -5581,7 +5581,7 @@ paths:
       defaultOutputProperties:
       - cumulative
       pathType: instance
-      parent: /Workspaces/{WorkspaceSid}/Workflows
+      parent: /Workspaces/{WorkspaceSid}/Workflows/{Sid}
       className: workflow_statistics
     get:
       description: ''
@@ -5939,7 +5939,7 @@ paths:
       - avg_task_acceptance_time
       - tasks_completed
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
       className: workspace_cumulative_statistics
     get:
       description: ''
@@ -6016,7 +6016,7 @@ paths:
       - longest_task_waiting_sid
       - total_tasks
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
       className: workspace_real_time_statistics
     get:
       description: ''
@@ -6057,7 +6057,7 @@ paths:
       defaultOutputProperties:
       - cumulative
       pathType: instance
-      parent: /Workspaces
+      parent: /Workspaces/{Sid}
       className: workspace_statistics
     get:
       description: ''

--- a/spec/yaml/twilio_trunking_v1.yaml
+++ b/spec/yaml/twilio_trunking_v1.yaml
@@ -499,7 +499,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Trunks
+      parent: /Trunks/{Sid}
       mountName: credentials_lists
       className: credential_list
     get:
@@ -576,7 +576,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Trunks
+      parent: /Trunks/{Sid}
       mountName: credentials_lists
       className: credential_list
     post:
@@ -689,7 +689,7 @@ paths:
       - friendly_name
       - date_created
       pathType: instance
-      parent: /Trunks
+      parent: /Trunks/{Sid}
     get:
       description: ''
       parameters:
@@ -766,7 +766,7 @@ paths:
       - friendly_name
       - date_created
       pathType: list
-      parent: /Trunks
+      parent: /Trunks/{Sid}
     post:
       description: Associate an IP Access Control List with a Trunk
       parameters:
@@ -880,7 +880,7 @@ paths:
       - priority
       - weight
       pathType: instance
-      parent: /Trunks
+      parent: /Trunks/{Sid}
     get:
       description: ''
       parameters:
@@ -1022,7 +1022,7 @@ paths:
       - priority
       - weight
       pathType: list
-      parent: /Trunks
+      parent: /Trunks/{Sid}
     post:
       description: ''
       parameters:
@@ -1153,7 +1153,7 @@ paths:
       - friendly_name
       - phone_number
       pathType: instance
-      parent: /Trunks
+      parent: /Trunks/{Sid}
     get:
       description: ''
       parameters:
@@ -1228,7 +1228,7 @@ paths:
       - friendly_name
       - phone_number
       pathType: list
-      parent: /Trunks
+      parent: /Trunks/{Sid}
     post:
       description: ''
       parameters:
@@ -1337,7 +1337,7 @@ paths:
       - mode
       - trim
       pathType: instance
-      parent: /Trunks
+      parent: /Trunks/{Sid}
       mountName: recordings
     get:
       description: ''

--- a/spec/yaml/twilio_trusthub_v1.yaml
+++ b/spec/yaml/twilio_trusthub_v1.yaml
@@ -893,7 +893,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /CustomerProfiles
+      parent: /CustomerProfiles/{Sid}
       mountName: customer_profiles_channel_endpoint_assignment
     post:
       description: Create a new Assigned Item.
@@ -1020,7 +1020,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /CustomerProfiles
+      parent: /CustomerProfiles/{Sid}
       mountName: customer_profiles_channel_endpoint_assignment
     get:
       description: Fetch specific Assigned Item Instance.
@@ -1094,7 +1094,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /CustomerProfiles
+      parent: /CustomerProfiles/{Sid}
       mountName: customer_profiles_entity_assignments
       className: customer_profiles_entity_assignments
     post:
@@ -1206,7 +1206,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /CustomerProfiles
+      parent: /CustomerProfiles/{Sid}
       mountName: customer_profiles_entity_assignments
       className: customer_profiles_entity_assignments
     get:
@@ -1281,7 +1281,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /CustomerProfiles
+      parent: /CustomerProfiles/{Sid}
       mountName: customer_profiles_evaluations
       className: customer_profiles_evaluations
     post:
@@ -1394,7 +1394,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /CustomerProfiles
+      parent: /CustomerProfiles/{Sid}
       mountName: customer_profiles_evaluations
       className: customer_profiles_evaluations
     get:
@@ -2315,7 +2315,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /TrustProducts
+      parent: /TrustProducts/{Sid}
       mountName: trust_products_channel_endpoint_assignment
     post:
       description: Create a new Assigned Item.
@@ -2442,7 +2442,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /TrustProducts
+      parent: /TrustProducts/{Sid}
       mountName: trust_products_channel_endpoint_assignment
     get:
       description: Fetch specific Assigned Item Instance.
@@ -2516,7 +2516,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /TrustProducts
+      parent: /TrustProducts/{Sid}
       mountName: trust_products_entity_assignments
       className: trust_products_entity_assignments
     post:
@@ -2628,7 +2628,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /TrustProducts
+      parent: /TrustProducts/{Sid}
       mountName: trust_products_entity_assignments
       className: trust_products_entity_assignments
     get:
@@ -2703,7 +2703,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: list
-      parent: /TrustProducts
+      parent: /TrustProducts/{Sid}
       mountName: trust_products_evaluations
       className: trust_products_evaluations
     post:
@@ -2816,7 +2816,7 @@ paths:
       defaultOutputProperties:
       - sid
       pathType: instance
-      parent: /TrustProducts
+      parent: /TrustProducts/{Sid}
       mountName: trust_products_evaluations
       className: trust_products_evaluations
     get:

--- a/spec/yaml/twilio_verify_v2.yaml
+++ b/spec/yaml/twilio_verify_v2.yaml
@@ -1200,7 +1200,7 @@ paths:
       - ttl
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Create a new enrollment Access Token for the Entity
       parameters:
@@ -1268,7 +1268,7 @@ paths:
       - ttl
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     get:
       description: Fetch an Access Token for the Entity
       parameters:
@@ -1317,7 +1317,7 @@ paths:
       - date_created
       - date_updated
       pathType: list
-      parent: /Services/{ServiceSid}/RateLimits
+      parent: /Services/{ServiceSid}/RateLimits/{Sid}
     post:
       description: Create a new Bucket for a Rate Limit
       parameters:
@@ -1456,7 +1456,7 @@ paths:
       - date_created
       - date_updated
       pathType: instance
-      parent: /Services/{ServiceSid}/RateLimits
+      parent: /Services/{ServiceSid}/RateLimits/{Sid}
     post:
       description: Update a specific Bucket.
       parameters:
@@ -1611,7 +1611,7 @@ paths:
       - responded_reason
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Entities
+      parent: /Services/{ServiceSid}/Entities/{Identity}
     post:
       description: Create a new Challenge for the Factor
       parameters:
@@ -1792,7 +1792,7 @@ paths:
       - responded_reason
       - date_created
       pathType: instance
-      parent: /Services/{ServiceSid}/Entities
+      parent: /Services/{ServiceSid}/Entities/{Identity}
     get:
       description: Fetch a specific Challenge.
       parameters:
@@ -1906,7 +1906,7 @@ paths:
       - identity
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Create a new Entity for the Service
       parameters:
@@ -2016,7 +2016,7 @@ paths:
       - identity
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     delete:
       description: Delete a specific Entity.
       parameters:
@@ -2090,7 +2090,7 @@ paths:
       - status
       - factor_type
       pathType: instance
-      parent: /Services/{ServiceSid}/Entities
+      parent: /Services/{ServiceSid}/Entities/{Identity}
     delete:
       description: Delete a specific Factor.
       parameters:
@@ -2274,7 +2274,7 @@ paths:
       - status
       - factor_type
       pathType: list
-      parent: /Services/{ServiceSid}/Entities
+      parent: /Services/{ServiceSid}/Entities/{Identity}
     get:
       description: Retrieve a list of all Factors for an Entity.
       parameters:
@@ -2537,7 +2537,7 @@ paths:
       - date_created
       - date_updated
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Create a new MessagingConfiguration for a service.
       parameters:
@@ -2659,7 +2659,7 @@ paths:
       - date_created
       - date_updated
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Update a specific MessagingConfiguration
       parameters:
@@ -2782,7 +2782,7 @@ paths:
       - challenge_sid
       - date_created
       pathType: list
-      parent: /Services/{ServiceSid}/Entities/{Identity}/Challenges
+      parent: /Services/{ServiceSid}/Entities/{Identity}/Challenges/{Sid}
     post:
       description: Create a new Notification for the corresponding Challenge
       parameters:
@@ -2853,7 +2853,7 @@ paths:
       - date_created
       - date_updated
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Create a new Rate Limit for a Service
       parameters:
@@ -2970,7 +2970,7 @@ paths:
       - date_created
       - date_updated
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Update a specific Rate Limit.
       parameters:
@@ -3541,7 +3541,7 @@ paths:
       - valid
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Create a new Verification using a Service
       parameters:
@@ -3659,7 +3659,7 @@ paths:
       - valid
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Update a Verification status
       parameters:
@@ -3983,7 +3983,7 @@ paths:
       - valid
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
       mountName: verification_checks
     post:
       description: challenge a specific Verification Check.
@@ -4120,7 +4120,7 @@ paths:
       - status
       - date_created
       pathType: list
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: Create a new Webhook for the Service
       parameters:
@@ -4255,7 +4255,7 @@ paths:
       - status
       - date_created
       pathType: instance
-      parent: /Services
+      parent: /Services/{Sid}
     post:
       description: ''
       parameters:

--- a/spec/yaml/twilio_video_v1.yaml
+++ b/spec/yaml/twilio_video_v1.yaml
@@ -2328,7 +2328,7 @@ paths:
       - identity
       - status
       pathType: instance
-      parent: /Rooms
+      parent: /Rooms/{Sid}
     get:
       description: ''
       parameters:
@@ -2407,7 +2407,7 @@ paths:
       - identity
       - status
       pathType: list
-      parent: /Rooms
+      parent: /Rooms/{Sid}
     get:
       description: ''
       parameters:
@@ -2502,7 +2502,7 @@ paths:
       - identity
       - status
       pathType: instance
-      parent: /Rooms/{RoomSid}/Participants
+      parent: /Rooms/{RoomSid}/Participants/{Sid}
     post:
       description: ''
       parameters:
@@ -2541,7 +2541,7 @@ paths:
       - enabled
       - kind
       pathType: instance
-      parent: /Rooms/{RoomSid}/Participants
+      parent: /Rooms/{RoomSid}/Participants/{Sid}
     get:
       description: Returns a single Track resource represented by TrackName or SID.
       parameters:
@@ -2588,7 +2588,7 @@ paths:
       - enabled
       - kind
       pathType: list
-      parent: /Rooms/{RoomSid}/Participants
+      parent: /Rooms/{RoomSid}/Participants/{Sid}
     get:
       description: Returns a list of tracks associated with a given Participant. Only
         `currently` Published Tracks are in the list resource.
@@ -2664,7 +2664,7 @@ paths:
       - room_sid
       - rules
       pathType: list
-      parent: /Rooms/{RoomSid}/Participants
+      parent: /Rooms/{RoomSid}/Participants/{Sid}
       className: subscribe_rules
     get:
       description: Returns a list of Subscribe Rules for the Participant.
@@ -2745,7 +2745,7 @@ paths:
       - enabled
       - kind
       pathType: instance
-      parent: /Rooms/{RoomSid}/Participants
+      parent: /Rooms/{RoomSid}/Participants/{Sid}
     get:
       description: 'Returns a single Track resource represented by `track_sid`.  Note:
         This is one resource with the Video API that requires a SID, be Track Name
@@ -2796,7 +2796,7 @@ paths:
       - enabled
       - kind
       pathType: list
-      parent: /Rooms/{RoomSid}/Participants
+      parent: /Rooms/{RoomSid}/Participants/{Sid}
     get:
       description: Returns a list of tracks that are subscribed for the participant.
       parameters:
@@ -2873,7 +2873,7 @@ paths:
       - duration
       - codec
       pathType: instance
-      parent: /Rooms
+      parent: /Rooms/{Sid}
       className: room_recording
     get:
       description: ''
@@ -2950,7 +2950,7 @@ paths:
       - duration
       - codec
       pathType: list
-      parent: /Rooms
+      parent: /Rooms/{Sid}
       className: room_recording
     get:
       description: ''
@@ -3049,7 +3049,7 @@ paths:
       - room_sid
       - rules
       pathType: list
-      parent: /Rooms
+      parent: /Rooms/{Sid}
       className: recording_rules
     get:
       description: Returns a list of Recording Rules for the Room.

--- a/spec/yaml/twilio_voice_v1.yaml
+++ b/spec/yaml/twilio_voice_v1.yaml
@@ -1013,7 +1013,7 @@ paths:
       - target
       - enabled
       pathType: list
-      parent: /ConnectionPolicies
+      parent: /ConnectionPolicies/{Sid}
       className: connection_policy_target
     post:
       description: ''
@@ -1142,7 +1142,7 @@ paths:
       - target
       - enabled
       pathType: instance
-      parent: /ConnectionPolicies
+      parent: /ConnectionPolicies/{Sid}
       className: connection_policy_target
     get:
       description: ''
@@ -1461,7 +1461,7 @@ paths:
       defaultOutputProperties:
       - prefix
       pathType: list
-      parent: /DialingPermissions/Countries
+      parent: /DialingPermissions/Countries/{IsoCode}
       className: highrisk_special_prefix
     get:
       description: Fetch the high-risk special services prefixes from the country

--- a/spec/yaml/twilio_wireless_v1.yaml
+++ b/spec/yaml/twilio_wireless_v1.yaml
@@ -833,7 +833,7 @@ paths:
       - start
       - end
       pathType: list
-      parent: /Sims
+      parent: /Sims/{Sid}
     get:
       description: ''
       parameters:
@@ -1426,7 +1426,7 @@ paths:
       defaultOutputProperties:
       - period
       pathType: list
-      parent: /Sims
+      parent: /Sims/{Sid}
     get:
       description: ''
       parameters:


### PR DESCRIPTION
This is needed in order to differentiate parents and containers in fluent-style languages.