### PR TITLE
Remove Beta Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ From the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification):
 
 > The OpenAPI Specification (OAS) defines a standard, programming language-agnostic interface document for HTTP APIs, which allows both humans and computers to discover and understand the capabilities of a service without requiring access to source code, additional documentation, or inspection of network traffic. When properly defined via OpenAPI, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interface documentation have done for lower-level programming, the OpenAPI Specification removes guesswork in calling a service.
 
-## Project Status
-
-This project is currently in **BETA**. We expect the spec to be accurate, but it is currently in **active development** and **unsupported**. If you've identified a mismatch between Twilio's API behavior and this specification, [please open an issue](https://github.com/twilio/twilio-oai/issues/new).
-
 ## Contributing
 
 Because this document is used across Twilio's whole API development experience, these documents are automatically kept up to date and used to validate Twilio API requests.


### PR DESCRIPTION
Removes Beta notice per https://www.twilio.com/blog/introducing-twilios-openapi-specification-ga