### PR TITLE
fix: pin spectral-rulesets to 1.22.2 to fix Node 18 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@twilio/twilio-oai",
   "devDependencies": {
-    "@stoplight/spectral-cli": "^6.1.0"
+    "@stoplight/spectral-cli": "^6.16.0",
+    "@stoplight/spectral-rulesets": "1.22.2"
   }
 }


### PR DESCRIPTION
spectral-rulesets >= 1.22.3 uses nimma 0.2.3 which crashes with "Cannot read properties of null (reading 'enum')" on Node 18+. Pinning to 1.22.2 fixes the crash on Debian Bookworm base images.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

https://github.com/stoplightio/spectral/issues/2959#issuecomment-4519633987 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
